### PR TITLE
fix(ci): restore reusable workflow compatibility

### DIFF
--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -14,5 +14,4 @@ permissions:
 
 jobs:
   check-conflicts:
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,6 @@ permissions:
 
 jobs:
   auto-merge:
-    timeout-minutes: 15
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
     with:
       max-lines: 600

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -27,8 +27,29 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-project-automation-secrets:
+    name: Check project automation secrets
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - name: Check whether GitHub App secrets exist
+        id: check
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub App secrets are missing; project automation will be skipped for this repository."
+          fi
+
   project-automation:
     name: Project automation
+    needs: check-project-automation-secrets
+    if: needs.check-project-automation-secrets.outputs.available == 'true'
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -29,7 +29,6 @@ permissions:
 jobs:
   project-automation:
     name: Project automation
-    timeout-minutes: 15
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
@@ -37,7 +36,6 @@ jobs:
 
   draft-reminder:
     name: Draft PR Reminder
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
     permissions:
       issues: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,34 +16,28 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
 
   license-compatibility:
     name: Check License Compatibility
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
 
   prettier:
     name: Formatting Check
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
 
   markdown-lint:
     name: Markdown Lint
-    timeout-minutes: 10
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
   eslint:
     name: ESLint
-    timeout-minutes: 15
     uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
     with:
       node-version: "22"
 
   astro-check:
     name: Astro TypeScript Check
-    timeout-minutes: 15
     uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
     with:
       node-version: "22"
@@ -51,7 +45,6 @@ jobs:
 
   build:
     name: Astro Build
-    timeout-minutes: 15
     uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
     with:
       node-version: "22"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full CI/CD pipeline with quality gates, PR size check, and project automation
 - Pre-commit hooks and preflight script
 - Contributing guidance now matches the Astro static-site repository instead of the generic multi-repo template
-- Workflow callers now declare job timeouts consistently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full CI/CD pipeline with quality gates, PR size check, and project automation
 - Pre-commit hooks and preflight script
 - Contributing guidance now matches the Astro static-site repository instead of the generic multi-repo template
+- Project automation now skips cleanly when repository GitHub App secrets are not configured yet
+- Tailwind Plus-derived components now declare their dual licensing explicitly for REUSE compliance

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -44,6 +44,7 @@ path = [
   "package-lock.json",
   "CODEOWNERS",
 ]
+SPDX-FileCopyrightText = "2026 SecPal"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -1,6 +1,7 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations } from "../i18n/index.ts";
 

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -1,6 +1,7 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations } from "../i18n/index.ts";
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations, getLocalizedPath } from "../i18n/index.ts";
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,6 +1,7 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 // Hero block based on Tailwind Plus UI Blocks — "Simple centered"
 // Source: https://tailwindcss.com/plus/ui-blocks/marketing/sections/heroes
 import type { Locale } from "../i18n/index.ts";

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,7 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 // Header block based on Tailwind Plus UI Blocks — "With call-to-action"
 // Source: https://tailwindcss.com/plus/ui-blocks/marketing/elements/headers
 import type { Locale } from "../i18n/index.ts";


### PR DESCRIPTION
## Summary
- remove unsupported timeout-minutes keys from reusable workflow call jobs
- keep the secpal.app GitHub Actions workflows compatible with GitHub's reusable workflow syntax
- preserve the repo initialization and protection setup while unblocking CI

## Validation
- npm run format:check
- npm run lint
- npm run check
- npm run build

## Notes
- direct pushes to main are now blocked by branch protection as intended, so this fix is delivered through a PR
