### PR TITLE
fix(site): reposition landing page as coming-soon preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - README and package metadata now match the landing page's security-operations and coming-soon positioning
-- Hero brand slogan now consistently uses the wording `SecPal – A guard’s best friend`
-- Hero now presents `SecPal – A guard’s best friend` as a compact brand slogan instead of competing with the main positioning claim
+- Hero now presents `SecPal – A guard's best friend` as a compact eyebrow tagline above the main positioning headline
 - Footer no longer claims "All rights reserved" on the public site, avoiding a misleading rights statement for the AGPL-published project
 - Landing page now leads with the SecPal product name, removes the duplicated hero view, and reframes the homepage as a focused coming-soon preview while the product is still under active construction
 - Alternate deployment builds now derive canonical and hreflang URLs from `SECPAL_SITE_URL` so `dev.secpal.app` no longer points metadata at production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- README and package metadata now match the landing page's security-operations and coming-soon positioning
+- Hero brand slogan now consistently uses the wording `SecPal – A guard’s best friend`
+- Hero now presents `SecPal – A guard’s best friend` as a compact brand slogan instead of competing with the main positioning claim
+- Footer no longer claims "All rights reserved" on the public site, avoiding a misleading rights statement for the AGPL-published project
+- Landing page now leads with the SecPal product name, removes the duplicated hero view, and reframes the homepage as a focused coming-soon preview while the product is still under active construction
 - Alternate deployment builds now derive canonical and hreflang URLs from `SECPAL_SITE_URL` so `dev.secpal.app` no longer points metadata at production
 - Dark mode toggle: added `is:inline` to ensure the script runs after DOM is ready
 - Language switcher: `getLocalizedPath` now produces trailing-slash URLs (`/de/`, `/en/`) matching Astro's canonical page paths

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ SPDX-License-Identifier: CC0-1.0
 [![PR Size](https://github.com/SecPal/secpal.app/actions/workflows/pr-size.yml/badge.svg)](https://github.com/SecPal/secpal.app/actions/workflows/pr-size.yml)
 [![License](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 
-Public landing page for [secpal.app](https://secpal.app) — the open-source platform for delivering timely security notifications to your users.
+Public landing page for [secpal.app](https://secpal.app) — the open-source security operations product being built in public for day-to-day security service work.
 
 Built with [Astro](https://astro.build), [Tailwind CSS v4](https://tailwindcss.com), and [Tailwind Plus UI Blocks](https://tailwindcss.com/plus).
 
 ## Features
 
 - **Multilingual** — English and German (`/en/`, `/de/`)
+- **Built in public** — product progress and launch positioning instead of premature app onboarding
 - **Dark mode** — class-based, persisted in `localStorage`, flash-free
-- **Static** — zero client-side JS by default (Astro island architecture)
+- **Static** — minimal client-side JS with Astro-first rendering
 - **REUSE-compliant** — all files carry SPDX headers
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@secpal/secpal.app",
   "version": "0.0.1",
-  "description": "Landing page for SecPal — the open-source security notification platform",
+  "description": "Landing page for SecPal — the open-source security operations platform built in public",
   "private": true,
   "type": "module",
   "author": "SecPal",
@@ -20,7 +20,8 @@
     "astro",
     "tailwindcss",
     "security",
-    "notifications"
+    "security-operations",
+    "built-in-public"
   ],
   "scripts": {
     "dev": "astro dev",

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -13,49 +13,61 @@ const { locale } = Astro.props;
 const t = useTranslations(locale);
 ---
 
-<div class="relative isolate overflow-hidden bg-white dark:bg-gray-900">
-  <div class="px-6 py-24 sm:py-32 lg:px-8">
-    <div class="mx-auto max-w-2xl text-center">
-      <h2
-        class="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl dark:text-white"
-      >
-        {t.cta.headline}
-      </h2>
-      <p
-        class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-gray-600 dark:text-gray-300"
-      >
-        {t.cta.subline}
-      </p>
-      <div class="mt-10 flex items-center justify-center gap-x-6">
-        <a
-          href="https://app.secpal.app/register"
-          class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-          >{t.cta.button}</a
+<div id="updates" class="bg-white py-16 sm:py-24 dark:bg-gray-900">
+  <div class="mx-auto max-w-7xl px-6 sm:px-6 lg:px-8">
+    <div
+      class="relative isolate overflow-hidden bg-gray-900 px-6 py-20 shadow-2xl sm:rounded-3xl sm:px-12 xl:px-24 dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-0 dark:after:inset-ring dark:after:inset-ring-white/15 dark:after:sm:rounded-3xl"
+    >
+      <div class="mx-auto max-w-3xl text-center">
+        <h2
+          class="text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl"
         >
-        <a
-          href="mailto:hello@secpal.app"
-          class="text-sm/6 font-semibold text-gray-900 hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
-          >{t.cta.buttonSecondary} <span aria-hidden="true">→</span></a
-        >
+          {t.cta.headline}
+        </h2>
+        <p class="mx-auto mt-6 max-w-2xl text-lg/8 text-pretty text-gray-300">
+          {t.cta.subline}
+        </p>
+        <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
+          <a
+            href="https://github.com/SecPal"
+            class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-xs hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:shadow-none"
+            >{t.cta.button}</a
+          >
+          <a
+            href="mailto:hello@secpal.app"
+            class="text-sm/6 font-semibold text-white hover:text-gray-200"
+            >{t.cta.buttonSecondary} <span aria-hidden="true">→</span></a
+          >
+        </div>
+        <p class="mx-auto mt-6 max-w-xl text-sm/6 text-gray-400">
+          {t.cta.note}
+        </p>
       </div>
+      <svg
+        viewBox="0 0 1024 1024"
+        aria-hidden="true"
+        class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2"
+      >
+        <circle
+          r="512"
+          cx="512"
+          cy="512"
+          fill="url(#secpal-cta-gradient)"
+          fill-opacity="0.7"></circle>
+        <defs>
+          <radialGradient
+            id="secpal-cta-gradient"
+            r="1"
+            cx="0"
+            cy="0"
+            gradientUnits="userSpaceOnUse"
+            gradientTransform="translate(512 512) rotate(90) scale(512)"
+          >
+            <stop stop-color="#7775D6"></stop>
+            <stop offset="1" stop-color="#E935C1" stop-opacity="0"></stop>
+          </radialGradient>
+        </defs>
+      </svg>
     </div>
   </div>
-  <svg
-    viewBox="0 0 1024 1024"
-    aria-hidden="true"
-    class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2 mask-[radial-gradient(closest-side,white,transparent)]"
-  >
-    <circle
-      r="512"
-      cx="512"
-      cy="512"
-      fill="url(#secpal-cta-gradient)"
-      fill-opacity="0.7"></circle>
-    <defs>
-      <radialGradient id="secpal-cta-gradient">
-        <stop stop-color="#818cf8"></stop>
-        <stop offset="1" stop-color="#6366f1"></stop>
-      </radialGradient>
-    </defs>
-  </svg>
 </div>

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -12,26 +12,16 @@ interface Props {
 const { locale } = Astro.props;
 const t = useTranslations(locale);
 
-// Heroicons outline paths — one per feature item
 const iconPaths = [
-  // Bell (notifications)
   "M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0",
-  // Shield check (GDPR)
   "M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z",
-  // Code bracket (open source)
   "M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5",
-  // Circle stack (CVE database)
-  "M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 5.625c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125",
-  // Users (roles)
-  "M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z",
-  // Clipboard check (audit)
-  "M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75",
 ];
 ---
 
-<div id="features" class="bg-white py-24 sm:py-32 dark:bg-gray-900">
+<div id="progress" class="bg-white py-24 sm:py-32 dark:bg-gray-900">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
-    <div class="mx-auto max-w-2xl lg:mx-0">
+    <div class="mx-auto max-w-2xl text-center lg:mx-auto">
       <h2
         class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
       >
@@ -42,12 +32,10 @@ const iconPaths = [
       </p>
     </div>
     <div class="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
-      <dl
-        class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3"
-      >
+      <dl class="grid max-w-xl grid-cols-1 gap-8 lg:max-w-none lg:grid-cols-3">
         {
           t.features.items.map((feature, i) => (
-            <div class="flex flex-col">
+            <div class="rounded-3xl border border-gray-200/80 bg-gray-50 p-8 dark:border-white/10 dark:bg-white/5">
               <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
                 <div class="mb-6 flex size-10 items-center justify-center rounded-lg bg-indigo-600 dark:bg-indigo-500">
                   <svg
@@ -68,7 +56,7 @@ const iconPaths = [
                 </div>
                 {feature.name}
               </dt>
-              <dd class="mt-1 flex flex-auto flex-col text-base/7 text-gray-600 dark:text-gray-400">
+              <dd class="mt-3 flex flex-auto flex-col text-base/7 text-gray-600 dark:text-gray-400">
                 <p class="flex-auto">{feature.description}</p>
               </dd>
             </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -58,7 +58,7 @@ const year = new Date().getFullYear();
     <p
       class="mt-8 text-center text-sm/6 text-gray-600 md:order-1 md:mt-0 dark:text-gray-400"
     >
-      &copy; {year} SecPal. {t.footer.rights}
+      &copy; {year} SecPal{t.footer.rights ? `. ${t.footer.rights}` : ""}
     </p>
   </div>
 </footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -16,7 +16,7 @@ const t = useTranslations(locale);
 ---
 
 <div class="bg-white dark:bg-gray-900">
-  <div class="relative isolate px-6 pt-14 lg:px-8">
+  <div class="relative isolate px-6 pt-0 lg:px-8">
     <div
       aria-hidden="true"
       class="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
@@ -28,9 +28,11 @@ const t = useTranslations(locale);
       </div>
     </div>
 
-    <div class="mx-auto max-w-2xl py-32 sm:py-48 lg:py-56">
+    <div
+      class="mx-auto max-w-3xl pb-16 pt-8 sm:pb-24 sm:pt-12 lg:pb-28 lg:pt-14"
+    >
       <!-- Badge -->
-      <div class="hidden sm:mb-8 sm:flex sm:justify-center">
+      <div class="mb-6 flex justify-center">
         <div
           class="relative rounded-full px-3 py-1 text-sm/6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20 dark:text-gray-400 dark:ring-white/10 dark:hover:ring-white/20"
         >
@@ -47,31 +49,55 @@ const t = useTranslations(locale);
 
       <!-- Headline + subline + CTAs -->
       <div class="text-center">
+        <p
+          class="text-sm/6 font-semibold tracking-[0.18em] text-gray-500 uppercase dark:text-gray-400"
+        >
+          {t.hero.tagline}
+        </p>
         <h1
-          class="text-5xl font-semibold tracking-tight text-balance text-gray-900 sm:text-7xl dark:text-white"
+          class="mt-4 text-5xl font-semibold tracking-tight text-balance text-gray-900 sm:text-7xl dark:text-white"
         >
           {t.hero.headline}
         </h1>
         <p
-          class="mt-8 text-lg font-medium text-pretty text-gray-500 sm:text-xl/8 dark:text-gray-400"
+          class="mx-auto mt-6 max-w-2xl text-lg font-medium text-pretty text-gray-500 sm:text-xl/8 dark:text-gray-400"
         >
           {t.hero.subline}
         </p>
+        <p
+          class="mx-auto mt-4 max-w-2xl text-base/7 text-pretty text-gray-600 dark:text-gray-300"
+        >
+          {t.hero.explanation}
+        </p>
+        <ul
+          class="mx-auto mt-10 grid max-w-2xl grid-cols-1 gap-3 text-left text-sm/6 text-gray-600 sm:grid-cols-3 dark:text-gray-300"
+        >
+          {
+            t.hero.highlights.map((highlight) => (
+              <li class="rounded-2xl border border-gray-200/80 bg-gray-50/80 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+                {highlight}
+              </li>
+            ))
+          }
+        </ul>
         <div class="mt-10 flex items-center justify-center gap-x-6">
           <a
-            href="https://app.secpal.app/register"
+            href="https://github.com/SecPal"
             class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
           >
             {t.hero.cta}
           </a>
           <a
-            href="https://github.com/SecPal"
+            href="#progress"
             class="text-sm/6 font-semibold text-gray-900 dark:text-white"
           >
             {t.hero.ctaSecondary}
             <span aria-hidden="true">→</span>
           </a>
         </div>
+        <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400">
+          {t.hero.note}
+        </p>
       </div>
     </div>
 
@@ -87,68 +113,3 @@ const t = useTranslations(locale);
     </div>
   </div>
 </div>
-
----
-
-<section class="relative isolate px-6 pt-14 lg:px-8 overflow-hidden">
-  <!-- Gradient blur top-left -->
-  <div
-    class="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
-    aria-hidden="true"
-  >
-    <div
-      class="relative left-[calc(50%-11rem)] aspect-1155/678 w-[36.125rem] -translate-x-1/2 rotate-30 bg-linear-to-tr from-indigo-500 to-indigo-200 opacity-20 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
-    >
-    </div>
-  </div>
-
-  <div class="mx-auto max-w-2xl py-24 sm:py-32 lg:py-40 text-center">
-    <!-- Badge -->
-    <div class="mb-8 flex justify-center">
-      <div
-        class="rounded-full px-3 py-1 text-sm font-semibold leading-6 text-indigo-600 ring-1 ring-indigo-900/10 hover:ring-indigo-900/20 dark:text-indigo-400 dark:ring-indigo-400/20"
-      >
-        {t.hero.badge}
-      </div>
-    </div>
-
-    <h1
-      class="text-4xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-6xl whitespace-pre-line"
-    >
-      {t.hero.headline}
-    </h1>
-
-    <p class="mt-6 text-lg leading-8 text-slate-600 dark:text-slate-300">
-      {t.hero.subline}
-    </p>
-
-    <div
-      class="mt-10 flex items-center justify-center gap-x-6 flex-wrap gap-y-3"
-    >
-      <a
-        href="https://app.secpal.app/register"
-        class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-      >
-        {t.hero.cta}
-      </a>
-      <a
-        href="https://github.com/SecPal"
-        class="text-sm font-semibold leading-6 text-slate-900 dark:text-white hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
-      >
-        {t.hero.ctaSecondary}
-        <span aria-hidden="true">→</span>
-      </a>
-    </div>
-  </div>
-
-  <!-- Gradient blur bottom-right -->
-  <div
-    class="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-30rem)]"
-    aria-hidden="true"
-  >
-    <div
-      class="relative left-[calc(50%+3rem)] aspect-1155/678 w-[36.125rem] -translate-x-1/2 bg-linear-to-tr from-indigo-500 to-indigo-200 opacity-20 sm:left-[calc(50%+36rem)] sm:w-[72.1875rem]"
-    >
-    </div>
-  </div>
-</section>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -23,7 +23,7 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
 <header class="bg-white dark:bg-gray-900">
   <nav
     aria-label="Global"
-    class="mx-auto flex max-w-7xl items-center justify-between gap-x-6 p-6 lg:px-8"
+    class="mx-auto flex max-w-7xl items-center justify-between gap-x-6 px-6 py-4 lg:px-8 lg:py-5"
   >
     <!-- Logo -->
     <div class="flex lg:flex-1">
@@ -46,19 +46,19 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
     <!-- Desktop nav links -->
     <div class="hidden lg:flex lg:gap-x-12">
       <a
-        href="#features"
+        href="#progress"
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.features}</a
+        >{t.nav.progress}</a
       >
       <a
-        href="#pricing"
+        href="#updates"
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.pricing}</a
+        >{t.nav.updates}</a
       >
       <a
-        href="https://docs.secpal.app"
+        href="https://github.com/SecPal"
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.docs}</a
+        >{t.nav.github}</a
       >
     </div>
 
@@ -115,14 +115,9 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
       </button>
 
       <a
-        href="https://app.secpal.app/login"
-        class="hidden text-sm/6 font-semibold text-gray-900 lg:block dark:text-white"
-        >{t.nav.signIn}</a
-      >
-      <a
-        href="https://app.secpal.app/register"
+        href="https://github.com/SecPal"
         class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
-        >{t.nav.getStarted}</a
+        >{t.nav.followProgress}</a
       >
     </div>
 
@@ -179,9 +174,9 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
           />
         </a>
         <a
-          href="https://app.secpal.app/register"
+          href="https://github.com/SecPal"
           class="ml-auto rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-          >{t.nav.getStarted}</a
+          >{t.nav.followProgress}</a
         >
         <button
           type="button"
@@ -209,19 +204,24 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
         <div class="-my-6 divide-y divide-gray-500/10 dark:divide-white/10">
           <div class="space-y-2 py-6">
             <a
-              href="#features"
+              href="#progress"
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.features}</a
+              >{t.nav.progress}</a
             >
             <a
-              href="#pricing"
+              href="#updates"
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.pricing}</a
+              >{t.nav.updates}</a
             >
             <a
-              href="https://docs.secpal.app"
+              href="https://github.com/SecPal"
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.docs}</a
+              >{t.nav.github}</a
+            >
+            <a
+              href="mailto:hello@secpal.app"
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+              >{t.nav.contact}</a
             >
             <!-- Language switcher in mobile menu -->
             <a
@@ -230,13 +230,6 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
             >
               {otherLocale === "de" ? "Deutsch" : "English"}
             </a>
-          </div>
-          <div class="py-6">
-            <a
-              href="https://app.secpal.app/login"
-              class="-mx-3 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.signIn}</a
-            >
           </div>
         </div>
       </div>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -5,65 +5,60 @@ import type { Translations } from "./en.ts";
 
 export const de: Translations = {
   nav: {
-    features: "Funktionen",
-    pricing: "Preise",
-    docs: "Dokumentation",
-    signIn: "Anmelden",
-    getStarted: "Loslegen",
+    progress: "Fortschritt",
+    updates: "Launch",
+    github: "GitHub",
+    contact: "Kontakt",
+    followProgress: "Fortschritt verfolgen",
   },
   hero: {
-    badge: "Open Source · AGPL-3.0 · On-Premise oder SaaS",
-    headline: "Der beste Freund\ndes Wachmanns.",
-    subline:
-      "SecPal digitalisiert das Büro Ihres Sicherheitsdienstes — Wachbuch, Wächterkontrolle, Dienstplanung und Mitarbeiterverwaltung in einer Plattform. Kein Papier mehr, kein Aktenchaos.",
-    cta: "Kostenlos starten",
-    ctaSecondary: "Auf GitHub ansehen",
+    badge: "Work in progress · Open Source · Öffentlich entwickelt",
+    tagline: "SecPal – A guard’s best friend",
+    headline: "Schluss mit der Zettelwirtschaft im Sicherheitsdienst.",
+    subline: "Digital von der Dienstplanung bis zur Schichtübergabe.",
+    explanation:
+      "SecPal wird für die operative Arbeit im Sicherheitsdienst entwickelt und soll Mitarbeitende wie Führungskräfte im Alltag spürbar entlasten.",
+    highlights: [
+      "Dienstplanung, Kontrollgänge und Dokumentation greifen endlich sauber ineinander.",
+      "Meldungen und Übergaben bleiben nachvollziehbar statt in Zetteln und Chats zu verschwinden.",
+      "SecPal ist noch im Aufbau und wird Schritt für Schritt öffentlich weiterentwickelt.",
+    ],
+    cta: "Build auf GitHub verfolgen",
+    ctaSecondary: "Ansehen, was gerade entsteht",
+    note: "Noch kein öffentliches Signup. SecPal befindet sich weiterhin im Aufbau und wird zunächst als fokussierte Coming-Soon-Seite vorgestellt.",
   },
   features: {
-    headline: "Alles, was ein moderner Sicherheitsdienst braucht.",
+    headline: "Für den Arbeitsalltag im Sicherheitsdienst gedacht.",
     subline:
-      "Von der ersten Streife bis zur Schichtabrechnung — SecPal ersetzt Klemmbrett, Excel und Aktenschrank.",
+      "SecPal wird für die operative Arbeit gebaut und mit Fokus auf klare Abläufe, bessere Übersicht und spürbare Entlastung im Alltag entwickelt.",
     items: [
       {
-        name: "Digitales Wachbuch",
+        name: "Von der Planung bis zur Übergabe",
         description:
-          "Ereignisse, Vorkommnisse und Meldungen revisionssicher protokollieren. Papierlos, jederzeit nachvollziehbar — auf Smartphone, Tablet oder Desktop.",
+          "SecPal spannt den Bogen über den gesamten operativen Ablauf: von der Dienstplanung über Kontrollgänge und Meldungen bis zur sauberen Schichtübergabe.",
       },
       {
-        name: "Wächterkontrolle",
+        name: "Operative Verwaltung aus einem Guss",
         description:
-          "NFC- und GPS-gestützte Kontrollpunkterfassung. Touren werden lückenlos dokumentiert, Abweichungen sofort sichtbar.",
+          "Neben Dokumentation und Einsatzabläufen soll SecPal Schritt für Schritt weitere operative Verwaltungsaufgaben sinnvoll in einem System zusammenführen.",
       },
       {
-        name: "Dienstplanung",
+        name: "Entlastung für Teams und Führungskräfte",
         description:
-          "Schichtpläne erstellen, Verfügbarkeiten verwalten, Dienste zuweisen. Änderungen erreichen Ihr Team sofort — kein Zettelchaos mehr.",
-      },
-      {
-        name: "Mitarbeiterverwaltung",
-        description:
-          "Qualifikationen, Zertifikate und Unterlagen an einem Ort. Ablaufende Nachweise werden automatisch erkannt.",
-      },
-      {
-        name: "On-Premise oder SaaS",
-        description:
-          "Volle Datensouveränität: Betreiben Sie SecPal auf Ihrem eigenen Server — oder nutzen Sie unser Hosting. Ihre Wahl, kein blindes Vertrauen nötig.",
-      },
-      {
-        name: "DSGVO-konform",
-        description:
-          "Alle personenbezogenen Daten verschlüsselt gespeichert. Revisionssichere Protokolle für Behördenprüfungen und Aufsichtsbehörden.",
+          "Der Fokus liegt auf klaren Abläufen, weniger Reibung im Alltag und einer spürbaren Entlastung für Mitarbeitende, Objektleitungen und Disposition.",
       },
     ],
   },
   cta: {
-    headline: "Bereit für das papierlose Büro?",
-    subline: "Kostenlos starten oder selbst hosten — ganz ohne Kreditkarte.",
-    button: "Jetzt starten",
+    headline: "Lieber Launch-Updates statt Marketing-Lärm?",
+    subline:
+      "Verfolgen Sie die Entwicklung auf GitHub, schreiben Sie uns direkt und schauen Sie wieder vorbei, wenn der erste Release-Meilenstein näher rückt.",
+    button: "Auf GitHub folgen",
     buttonSecondary: "Kontakt aufnehmen",
+    note: "SecPal ist noch im intensiven Aufbau. Öffentliches Onboarding startet erst, wenn der erste Launch-Meilenstein steht.",
   },
   footer: {
-    rights: "Alle Rechte vorbehalten.",
+    rights: "",
     links: {
       privacy: "Datenschutz",
       terms: "AGB",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -3,65 +3,60 @@
 
 export const en = {
   nav: {
-    features: "Features",
-    pricing: "Pricing",
-    docs: "Documentation",
-    signIn: "Sign in",
-    getStarted: "Get started",
+    progress: "Progress",
+    updates: "Launch",
+    github: "GitHub",
+    contact: "Contact",
+    followProgress: "Follow progress",
   },
   hero: {
-    badge: "Open Source · AGPL-3.0 · On-Premise or SaaS",
-    headline: "A guard's best friend.",
-    subline:
-      "SecPal digitalises the back office of your security service — guard log, patrol control, shift planning, and staff management in one platform. No more paper, no more chaos.",
-    cta: "Get started for free",
-    ctaSecondary: "View on GitHub",
+    badge: "Work in progress · Open source · Built in public",
+    tagline: "SecPal – A guard’s best friend",
+    headline: "Less paperwork for security operations.",
+    subline: "Digital from shift planning to handover.",
+    explanation:
+      "SecPal is being developed for operational security service work and is intended to reduce day-to-day load for both staff and managers.",
+    highlights: [
+      "Shift planning, patrol rounds, and documentation belong in one coherent workflow.",
+      "Reports and handovers stay traceable instead of getting lost across paper notes and chats.",
+      "SecPal is still work in progress and is being built in public step by step.",
+    ],
+    cta: "Follow the build on GitHub",
+    ctaSecondary: "See what is taking shape",
+    note: "No public signup yet. SecPal is still under active construction and is currently presented as a focused coming-soon page.",
   },
   features: {
-    headline: "Everything a modern security service needs.",
+    headline: "Built for day-to-day security service work.",
     subline:
-      "From the first patrol to payroll — SecPal replaces the clipboard, the spreadsheet, and the filing cabinet.",
+      "SecPal is being built around operational work first, with a focus on clearer workflows, better oversight, and meaningful day-to-day relief.",
     items: [
       {
-        name: "Digital Guard Log",
+        name: "From planning to handover",
         description:
-          "Log incidents, events, and reports in a tamper-evident, paperless record — accessible from smartphone, tablet, or desktop.",
+          "SecPal is meant to cover the full operational arc: from shift planning through patrol rounds and reporting to a clean handover between teams.",
       },
       {
-        name: "Patrol Control",
+        name: "One operational system instead of scattered admin",
         description:
-          "NFC- and GPS-based checkpoint tracking. Every tour documented in full, deviations flagged instantly.",
+          "Beyond documentation and patrol workflows, SecPal is intended to bring additional operational admin tasks together in one coherent system over time.",
       },
       {
-        name: "Shift Planning",
+        name: "Relief for staff and leadership",
         description:
-          "Build schedules, manage availability, assign shifts. Changes reach your team immediately — no more printed rosters.",
-      },
-      {
-        name: "Staff Management",
-        description:
-          "Qualifications, certificates, and documents in one place. Expiring credentials flagged automatically.",
-      },
-      {
-        name: "On-Premise or SaaS",
-        description:
-          "Full data sovereignty: run SecPal on your own server, or use our hosted service. Your choice — no blind trust required.",
-      },
-      {
-        name: "GDPR-compliant",
-        description:
-          "All personal data encrypted at rest. Tamper-evident audit logs ready for regulatory inspections.",
+          "The focus is on clearer workflows, less operational friction, and meaningful relief for guards, supervisors, operations leads, and dispatch.",
       },
     ],
   },
   cta: {
-    headline: "Ready to go paperless?",
-    subline: "Start for free or self-host — no credit card required.",
-    button: "Get started",
-    buttonSecondary: "Get in touch",
+    headline: "Want launch updates instead of marketing noise?",
+    subline:
+      "Follow development on GitHub, reach out directly, and check back as the first release milestone gets closer.",
+    button: "Follow on GitHub",
+    buttonSecondary: "Write to us",
+    note: "SecPal is still under heavy construction. Public onboarding will open once the first launch milestone is ready.",
   },
   footer: {
-    rights: "All rights reserved.",
+    rights: "",
     links: {
       privacy: "Privacy",
       terms: "Terms",
@@ -71,12 +66,11 @@ export const en = {
   },
 } as const;
 
-type DeepLoosen<T> = {
-  [K in keyof T]: T[K] extends Record<string, unknown>
-    ? DeepLoosen<T[K]>
-    : T[K] extends ReadonlyArray<infer U>
-      ? DeepLoosen<U>[]
+type DeepLoosen<T> =
+  T extends ReadonlyArray<infer U>
+    ? DeepLoosen<U>[]
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: DeepLoosen<T[K]> }
       : string;
-};
 
 export type Translations = DeepLoosen<typeof en>;

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -10,7 +10,7 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="SecPal — Coming Soon"
+  title="SecPal – Bald verfügbar"
   description="SecPal wird für die operative Arbeit im Sicherheitsdienst entwickelt und soll Mitarbeitende wie Führungskräfte im Alltag spürbar entlasten."
   lang="de"
   canonicalPath="/de/"

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -10,8 +10,8 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="SecPal — Security-Benachrichtigungen, wie sie sein sollten"
-  description="SecPal ist die Open-Source-Plattform für zeitnahe Security-Benachrichtigungen an Ihre Nutzer — schnell, zuverlässig und DSGVO-konform."
+  title="SecPal — Coming Soon"
+  description="SecPal wird für die operative Arbeit im Sicherheitsdienst entwickelt und soll Mitarbeitende wie Führungskräfte im Alltag spürbar entlasten."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -10,8 +10,8 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="SecPal — Security Notifications, Done Right"
-  description="SecPal is the open-source platform for delivering timely security notifications to your users — fast, reliable, and GDPR-compliant."
+  title="SecPal — Coming Soon"
+  description="SecPal is being developed for operational security service work and is intended to reduce day-to-day load for staff and managers."
   lang="en"
   canonicalPath="/en/"
 >


### PR DESCRIPTION
## Summary
- reposition the landing page as a focused coming-soon product preview for security operations
- replace premature app onboarding links with build-in-public and contact calls to action
- align README, metadata, translations, SEO copy, and changelog with the new positioning

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Content or documentation update
- [ ] CI, workflow, or governance change

## Validation
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `./scripts/preflight.sh` (when git metadata is available)

## Checklist
- [x] My change follows the repository conventions and domain policy (`secpal.app` / `secpal.dev` only)
- [x] I performed a self-review of the affected content, code, and workflows
- [x] I updated documentation and `CHANGELOG.md` when required
- [x] My change introduces no new warnings in the validations above
