### PR TITLE
chore(ci): add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,13 +15,17 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze Code
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+name: CodeQL Advanced Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Code
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  codeql-summary:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Check CodeQL status
+        run: |
+          if [ "${{ needs.analyze.result }}" = "success" ] || [ "${{ needs.analyze.result }}" = "skipped" ]; then
+            echo "CodeQL check passed"
+            exit 0
+          fi
+
+          echo "CodeQL analysis failed"
+          exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           category: /language:${{ matrix.language }}
 
   codeql-summary:
-    name: CodeQL
+    name: CodeQL Summary
     runs-on: ubuntu-latest
     needs: [analyze]
     if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CodeQL analysis for the landing-page repository and corresponding branch protection hardening
 - Initial landing page with Astro 5, Tailwind CSS v4, and Tailwind Plus UI Blocks
 - Multilingual routing (`/en/`, `/de/`) with full English and German translations
 - Dark mode support (class-based, `localStorage`-persisted, flash-free)


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for the landing-page repository
- publish a stable `CodeQL Summary` check for branch-protection configuration without colliding with GitHub's native CodeQL status
- keep the workflow PR stacked on top of the landing-page repositioning so it stays reviewable and mergeable in order

## Context
This PR is intentionally based on `fix/site-coming-soon-preview` and should be merged after PR #10 while both remain draft until you decide otherwise.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Content or documentation update
- [x] CI, workflow, or governance change

## Validation
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `./scripts/preflight.sh`

## Checklist
- [x] My change follows the repository conventions and domain policy (`secpal.app` / `secpal.dev` only)
- [x] I performed a self-review of the affected content, code, and workflows
- [x] I updated documentation and `CHANGELOG.md` when required
- [x] My change introduces no new warnings in the validations above
