### PR TITLE
chore(ci): add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,13 +15,17 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze Code
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,16 +37,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           category: /language:${{ matrix.language }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+---
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+name: CodeQL Advanced Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Code
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  codeql-summary:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Check CodeQL status
+        run: |
+          if [ "${{ needs.analyze.result }}" = "success" ] || [ "${{ needs.analyze.result }}" = "skipped" ]; then
+            echo "CodeQL check passed"
+            exit 0
+          fi
+
+          echo "CodeQL analysis failed"
+          exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           category: /language:${{ matrix.language }}
 
   codeql-summary:
-    name: CodeQL
+    name: CodeQL Summary
     runs-on: ubuntu-latest
     needs: [analyze]
     if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CodeQL analysis for the landing-page repository and corresponding branch protection hardening
 - Initial landing page with Astro 5, Tailwind CSS v4, and Tailwind Plus UI Blocks
 - Multilingual routing (`/en/`, `/de/`) with full English and German translations
 - Dark mode support (class-based, `localStorage`-persisted, flash-free)


### PR DESCRIPTION
## Summary
- add a dedicated CodeQL workflow for the landing-page repository
- publish a stable `CodeQL Summary` check for branch-protection configuration
- scope `security-events: write` permission to the `analyze` job only (least-privilege)
- skip analysis on forked PRs to avoid CI failures due to missing write permission
- pin `github/codeql-action` to verified SHA `38697555549f1db7851b81482ff19f1fa5c4fedc` (v4.34.1)

## Context
Replaces PR #11 which was auto-closed when its stacked base branch was deleted after PR #10 merged.

The workflow mirrors the org-wide template from the `.github` repo — there is no local `.github/codeql.yml` config file in this repository; the org template was the reference for structure and conventions.

## Type of change
- [x] CI, workflow, or governance change

## Validation
- [x] `actions/checkout@v6` — org standard
- [x] `github/codeql-action` pinned to verified SHA v4.34.1
- [x] `security-events: write` scoped to `analyze` job only
- [x] Fork guard on `analyze` job
- [x] `timeout-minutes` set on all jobs

## Checklist
- [x] Follows repository conventions and domain policy
- [x] Self-review performed
- [x] CHANGELOG.md updated
- [x] No new warnings