### PR TITLE
feat(site): add legal and discovery pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alternate deployment builds now derive canonical and hreflang URLs from `SECPAL_SITE_URL` so `dev.secpal.app` no longer points metadata at production
 - Dark mode toggle: added `is:inline` to ensure the script runs after DOM is ready
 - Language switcher: `getLocalizedPath` now produces trailing-slash URLs (`/de/`, `/en/`) matching Astro's canonical page paths
+- Footer links and Nav language switcher now always produce canonical trailing-slash URLs for non-root paths (e.g. `/en/privacy/` instead of `/en/privacy`) — `getLocalizedPath` normalized to always append trailing slash for non-root routes, so no unnecessary redirects occur
+- `sitemap.xml` `lastmod` date now derives from build time (via `import.meta.env.BUILD_LAST_MODIFIED` or `new Date()` fallback) instead of a hard-coded value, so the sitemap stays accurate without manual edits
+- Preflight hook now verifies all commits between `origin/main` and `HEAD` are signed, preventing unsigned commits from being pushed
 - Navbar logo: replaced placeholder lock icon with real SecPal `logo-light.svg` / `logo-dark.svg`
 - Logo: switched from broken SVG assets to working 48px PNGs (`logo-light-48.png` / `logo-dark-48.png`)
 - Favicon: switched from placeholder lock SVG to `logo-light-32.png`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Navbar logo: replaced placeholder lock icon with real SecPal `logo-light.svg` / `logo-dark.svg`
 - Logo: switched from broken SVG assets to working 48px PNGs (`logo-light-48.png` / `logo-dark-48.png`)
 - Favicon: switched from placeholder lock SVG to `logo-light-32.png`
+- `LegalPageShell`: `x-default` hreflang for DE pages now correctly resolves to the English URL instead of the German URL, consistent with the sitemap declarations
+- `security-txt.ts`: ISO date formatting now uses a regex replace to prevent potential silent mismatches
 - REUSE-compliant licensing across all files
 - Full CI/CD pipeline with quality gates, PR size check, and project automation
 - Pre-commit hooks and preflight script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dark mode support (class-based, `localStorage`-persisted, flash-free)
 - Nav, Hero, Features, CTA, and Footer components adapted from Tailwind Plus HTML blocks
 - Repo-local GitHub instructions, workflow rules, and PR template aligned with the other SecPal repositories
+- Public legal pages for privacy, legal notice, and security in German and English, built from Tailwind Plus-inspired content and FAQ layouts
+- Discovery files for crawlers and security researchers via a minimal `robots.txt` and RFC 9116-compliant `security.txt` endpoints
+- An environment-aware `sitemap.xml` and `robots.txt` endpoint for the public site, so crawler discovery stays correct on both `secpal.app` and `secpal.dev`
+- Environment-aware `security.txt` endpoints for both `/.well-known/security.txt` and `/security.txt`, so disclosure metadata matches the active deployment domain
+- A neutral `/security/` policy URL plus hreflang alternates in `sitemap.xml`, so discovery and multilingual indexing stay aligned
 
 ### Fixed
 
@@ -39,3 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guidance now matches the Astro static-site repository instead of the generic multi-repo template
 - Project automation now skips cleanly when repository GitHub App secrets are not configured yet
 - Tailwind Plus-derived components now declare their dual licensing explicitly for REUSE compliance
+- Footer legal navigation now points to `Impressum` / `Legal Notice` instead of incorrectly advertising terms and conditions that do not yet exist
+- Privacy pages were reduced to a lean landing-page notice that reflects the current site instead of implying broader business processes
+- English privacy copy now uses plainer wording so it matches the concise tone of the German landing-page notice more closely
+- Privacy pages now include a short storage-duration disclosure for server logs and email communication
+- Header links for `Fortschritt` / `Progress` and `Launch` now jump back to the locale-specific homepage sections instead of breaking on legal subpages
+- Public security pages now focus more tightly on vulnerability reporting, current public status, and a small set of verifiable statements
+- Legal and security pages now emit page-specific `hreflang` alternates instead of always pointing search engines back to the localized homepages
+- Security pages now expose `/security/` consistently as the neutral `x-default` target in both page metadata and the sitemap

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -114,7 +114,31 @@ if [ -f package.json ] && command -v npm >/dev/null 2>&1; then
   }
 fi
 
-# 2) PR Size Check
+# 2) Commit Signature Check
+echo "Checking commit signatures..."
+UNSIGNED=0
+while IFS= read -r commit; do
+  # %G?: G=good, B=bad/revoked, U=good/unknown-trust, X=expired, Y=expired-key, E=key-not-found, N=not-signed
+  sig=$(git log --format="%G?" -1 "$commit" 2>/dev/null || echo "N")
+  if [[ "$sig" == "N" || "$sig" == "B" ]]; then
+    echo "  ❌ $(git log --format="%h %s" -1 "$commit") — not signed (status: $sig)" >&2
+    UNSIGNED=$((UNSIGNED + 1))
+  fi
+done < <(git rev-list "origin/$BASE"..HEAD 2>/dev/null || true)
+
+if [ "$UNSIGNED" -gt 0 ]; then
+  echo "" >&2
+  echo "❌ $UNSIGNED unsigned commit(s) found." >&2
+  echo "All commits must be signed (commit.gpgsign=true is required)." >&2
+  echo "" >&2
+  echo "To re-sign all commits on this branch:" >&2
+  echo "  git rebase --exec 'git commit --amend --no-edit -S' origin/$BASE" >&2
+  echo "" >&2
+  exit 1
+fi
+echo "✅ All commits are signed"
+
+# 3) PR Size Check
 DIFF_STAT=$(git diff --shortstat origin/"$BASE"...HEAD 2>/dev/null || echo "")
 if [ -n "$DIFF_STAT" ]; then
   LINES_CHANGED=$(git diff --stat origin/"$BASE"...HEAD 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,10 +26,10 @@ const year = new Date().getFullYear();
         {t.footer.links.privacy}
       </a>
       <a
-        href={getLocalizedPath("/terms", locale)}
+        href={getLocalizedPath("/imprint", locale)}
         class="text-sm/6 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white"
       >
-        {t.footer.links.terms}
+        {t.footer.links.imprint}
       </a>
       <a
         href={getLocalizedPath("/security", locale)}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -5,7 +5,7 @@
 // Hero block based on Tailwind Plus UI Blocks — "Simple centered"
 // Source: https://tailwindcss.com/plus/ui-blocks/marketing/sections/heroes
 import type { Locale } from "../i18n/index.ts";
-import { useTranslations } from "../i18n/index.ts";
+import { useTranslations, getLocalizedPath } from "../i18n/index.ts";
 
 interface Props {
   locale: Locale;
@@ -13,6 +13,7 @@ interface Props {
 
 const { locale } = Astro.props;
 const t = useTranslations(locale);
+const progressPath = `${getLocalizedPath("/", locale)}#progress`;
 ---
 
 <div class="bg-white dark:bg-gray-900">
@@ -88,7 +89,7 @@ const t = useTranslations(locale);
             {t.hero.cta}
           </a>
           <a
-            href="#progress"
+            href={progressPath}
             class="text-sm/6 font-semibold text-gray-900 dark:text-white"
           >
             {t.hero.ctaSecondary}

--- a/src/components/LegalPageShell.astro
+++ b/src/components/LegalPageShell.astro
@@ -1,0 +1,81 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
+// Layout adapted from Tailwind Plus content sections and FAQ sections
+import Base from "../layouts/Base.astro";
+import Nav from "./Nav.astro";
+import Footer from "./Footer.astro";
+import type { Locale } from "../i18n/index.ts";
+
+interface Props {
+  locale: Locale;
+  title: string;
+  description: string;
+  canonicalPath: string;
+  currentPath: string;
+  eyebrow: string;
+  headline: string;
+  intro: string;
+  updatedLabel: string;
+  updatedAt: string;
+  xDefaultPath?: string;
+}
+
+const {
+  locale,
+  title,
+  description,
+  canonicalPath,
+  currentPath,
+  eyebrow,
+  headline,
+  intro,
+  updatedLabel,
+  updatedAt,
+  xDefaultPath,
+} = Astro.props;
+const alternateEnPath = `/en${currentPath}/`;
+const alternateDePath = `/de${currentPath}/`;
+const resolvedXDefaultPath =
+  xDefaultPath ?? (locale === "en" ? alternateEnPath : alternateDePath);
+---
+
+<Base
+  title={title}
+  description={description}
+  lang={locale}
+  canonicalPath={canonicalPath}
+  alternateEnPath={alternateEnPath}
+  alternateDePath={alternateDePath}
+  xDefaultPath={resolvedXDefaultPath}
+>
+  <Nav locale={locale} currentPath={currentPath} />
+  <main class="bg-white dark:bg-gray-900">
+    <section class="px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
+      <div
+        class="mx-auto max-w-3xl text-base/7 text-gray-700 dark:text-gray-300"
+      >
+        <p
+          class="text-base/7 font-semibold text-indigo-600 dark:text-indigo-400"
+        >
+          {eyebrow}
+        </p>
+        <h1
+          class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
+        >
+          {headline}
+        </h1>
+        <p class="mt-6 text-xl/8 text-gray-600 dark:text-gray-400">{intro}</p>
+        <p class="mt-4 text-sm/6 text-gray-500 dark:text-gray-500">
+          {updatedLabel}: {updatedAt}
+        </p>
+        <div class="mt-10 max-w-2xl text-gray-600 dark:text-gray-400">
+          <slot />
+        </div>
+      </div>
+    </section>
+    <slot name="afterContent" />
+  </main>
+  <Footer locale={locale} />
+</Base>

--- a/src/components/LegalPageShell.astro
+++ b/src/components/LegalPageShell.astro
@@ -37,8 +37,7 @@ const {
 } = Astro.props;
 const alternateEnPath = `/en${currentPath}/`;
 const alternateDePath = `/de${currentPath}/`;
-const resolvedXDefaultPath =
-  xDefaultPath ?? (locale === "en" ? alternateEnPath : alternateDePath);
+const resolvedXDefaultPath = xDefaultPath ?? alternateEnPath;
 ---
 
 <Base

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -17,6 +17,8 @@ const t = useTranslations(locale);
 
 const otherLocale: Locale = locale === "en" ? "de" : "en";
 const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
+const progressPath = `${getLocalizedPath("/", locale)}#progress`;
+const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
 ---
 
 <!-- @tailwindplus/elements is loaded in Base.astro via script tag -->
@@ -46,12 +48,12 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
     <!-- Desktop nav links -->
     <div class="hidden lg:flex lg:gap-x-12">
       <a
-        href="#progress"
+        href={progressPath}
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
         >{t.nav.progress}</a
       >
       <a
-        href="#updates"
+        href={updatesPath}
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
         >{t.nav.updates}</a
       >
@@ -204,12 +206,12 @@ const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
         <div class="-my-6 divide-y divide-gray-500/10 dark:divide-white/10">
           <div class="space-y-2 py-6">
             <a
-              href="#progress"
+              href={progressPath}
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >{t.nav.progress}</a
             >
             <a
-              href="#updates"
+              href={updatesPath}
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >{t.nav.updates}</a
             >

--- a/src/components/SecurityFaq.astro
+++ b/src/components/SecurityFaq.astro
@@ -1,0 +1,63 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
+// FAQ block adapted from Tailwind Plus FAQ sections — two-columns-with-centered-introduction
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  title: string;
+  intro: string;
+  contactLabel: string;
+  contactHref: string;
+  contactText: string;
+  items: FaqItem[];
+}
+
+const { title, intro, contactLabel, contactHref, contactText, items } =
+  Astro.props;
+---
+
+<section class="bg-white dark:bg-gray-900">
+  <div class="mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8">
+    <div class="mx-auto max-w-2xl text-center">
+      <h2
+        class="text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl dark:text-white"
+      >
+        {title}
+      </h2>
+      <p class="mt-6 text-base/7 text-gray-600 dark:text-gray-400">
+        {intro}
+        <a
+          href={contactHref}
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          {contactLabel}
+        </a>
+        {contactText}
+      </p>
+    </div>
+    <div class="mt-20">
+      <dl
+        class="space-y-16 sm:grid sm:grid-cols-2 sm:space-y-0 sm:gap-x-6 sm:gap-y-16 lg:gap-x-10"
+      >
+        {
+          items.map((item) => (
+            <div>
+              <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                {item.question}
+              </dt>
+              <dd class="mt-2 text-base/7 text-gray-600 dark:text-gray-400">
+                {item.answer}
+              </dd>
+            </div>
+          ))
+        }
+      </dl>
+    </div>
+  </div>
+</section>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -61,7 +61,7 @@ export const de: Translations = {
     rights: "",
     links: {
       privacy: "Datenschutz",
-      terms: "AGB",
+      imprint: "Impressum",
       security: "Sicherheit",
       github: "GitHub",
     },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -59,7 +59,7 @@ export const en = {
     rights: "",
     links: {
       privacy: "Privacy",
-      terms: "Terms",
+      imprint: "Legal Notice",
       security: "Security",
       github: "GitHub",
     },

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,5 +14,6 @@ export function useTranslations(locale: Locale) {
 }
 
 export function getLocalizedPath(path: string, locale: Locale): string {
-  return `/${locale}${path === "/" ? "/" : path}`;
+  const normalized = path === "/" ? "/" : path.replace(/\/?$/, "/");
+  return `/${locale}${normalized}`;
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,15 +8,30 @@ interface Props {
   description: string;
   lang: string;
   canonicalPath?: string;
+  alternateEnPath?: string;
+  alternateDePath?: string;
+  xDefaultPath?: string;
 }
 
-const { title, description, lang, canonicalPath } = Astro.props;
+const {
+  title,
+  description,
+  lang,
+  canonicalPath,
+  alternateEnPath = "/en/",
+  alternateDePath = "/de/",
+  xDefaultPath,
+} = Astro.props;
 const siteUrl = Astro.site ?? new URL("https://secpal.app");
 const canonicalUrl = canonicalPath
   ? new URL(canonicalPath, siteUrl).toString()
   : undefined;
-const alternateEnUrl = new URL("/en/", siteUrl).toString();
-const alternateDeUrl = new URL("/de/", siteUrl).toString();
+const alternateEnUrl = new URL(alternateEnPath, siteUrl).toString();
+const alternateDeUrl = new URL(alternateDePath, siteUrl).toString();
+const xDefaultUrl = new URL(
+  xDefaultPath ?? alternateEnPath,
+  siteUrl
+).toString();
 ---
 
 <!doctype html>
@@ -41,7 +56,7 @@ const alternateDeUrl = new URL("/de/", siteUrl).toString();
     />
     <link rel="alternate" hreflang="en" href={alternateEnUrl} />
     <link rel="alternate" hreflang="de" href={alternateDeUrl} />
-    <link rel="alternate" hreflang="x-default" href={alternateEnUrl} />
+    <link rel="alternate" hreflang="x-default" href={xDefaultUrl} />
     <!-- Dark mode: runs before first paint to prevent flash -->
     <script is:inline>
       (function () {

--- a/src/lib/security-txt.ts
+++ b/src/lib/security-txt.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export function buildSecurityTxt(siteUrl: URL, headerComment: string): string {
+  const expiresDate = new Date();
+  expiresDate.setUTCHours(0, 0, 0, 0);
+  expiresDate.setUTCDate(expiresDate.getUTCDate() + 180);
+  const expiresAt = expiresDate.toISOString().replace(".000Z", "Z");
+  const canonicalWellKnownUrl = new URL(
+    "/.well-known/security.txt",
+    siteUrl
+  ).toString();
+  const canonicalRootUrl = new URL("/security.txt", siteUrl).toString();
+  const policyUrl = new URL("/security/", siteUrl).toString();
+
+  return [
+    headerComment,
+    "Contact: mailto:security@secpal.app",
+    `Contact: ${policyUrl}`,
+    `Expires: ${expiresAt}`,
+    "Preferred-Languages: en, de",
+    `Canonical: ${canonicalWellKnownUrl}`,
+    `Canonical: ${canonicalRootUrl}`,
+    `Policy: ${policyUrl}`,
+    "",
+  ].join("\n");
+}

--- a/src/lib/security-txt.ts
+++ b/src/lib/security-txt.ts
@@ -5,7 +5,7 @@ export function buildSecurityTxt(siteUrl: URL, headerComment: string): string {
   const expiresDate = new Date();
   expiresDate.setUTCHours(0, 0, 0, 0);
   expiresDate.setUTCDate(expiresDate.getUTCDate() + 180);
-  const expiresAt = expiresDate.toISOString().replace(".000Z", "Z");
+  const expiresAt = expiresDate.toISOString().replace(/\.000Z$/, "Z");
   const canonicalWellKnownUrl = new URL(
     "/.well-known/security.txt",
     siteUrl

--- a/src/pages/.well-known/security.txt.ts
+++ b/src/pages/.well-known/security.txt.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { APIRoute } from "astro";
+import { buildSecurityTxt } from "../../lib/security-txt.ts";
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return new Response(
+    buildSecurityTxt(siteUrl, "# SecPal vulnerability disclosure contact"),
+    {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    }
+  );
+};

--- a/src/pages/de/imprint.astro
+++ b/src/pages/de/imprint.astro
@@ -1,0 +1,58 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+---
+
+<LegalPageShell
+  locale="de"
+  title="Impressum | SecPal"
+  description="Anbieterkennzeichnung und Kontaktangaben für secpal.app."
+  canonicalPath="/de/imprint/"
+  currentPath="/imprint"
+  eyebrow="Rechtliches"
+  headline="Impressum"
+  intro="Angaben gemäß § 5 DDG sowie ergänzende Kontaktinformationen für das Angebot unter secpal.app."
+  updatedLabel="Stand"
+  updatedAt="20. März 2026"
+>
+  <section class="space-y-10">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Diensteanbieter
+      </h2>
+      <div
+        class="mt-6 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
+      >
+        <p class="font-semibold text-gray-900 dark:text-white">SecPal</p>
+        <p class="mt-2">Holger Schmermbeck</p>
+        <p class="mt-2">Enno-Arends-Str. 4</p>
+        <p class="mt-2">26571 Juist</p>
+      </div>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Kontakt
+      </h2>
+      <p class="mt-6">
+        E-Mail: <a
+          href="mailto:hello@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >hello@secpal.app</a
+        >
+      </p>
+      <p class="mt-4">
+        Für Hinweise zu Sicherheitslücken: <a
+          href="mailto:security@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >security@secpal.app</a
+        >
+      </p>
+    </div>
+  </section>
+</LegalPageShell>

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -1,0 +1,177 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+---
+
+<LegalPageShell
+  locale="de"
+  title="Datenschutzerklärung | SecPal"
+  description="Datenschutzhinweise für den Besuch von secpal.app und die Kontaktaufnahme mit SecPal."
+  canonicalPath="/de/privacy/"
+  currentPath="/privacy"
+  eyebrow="Rechtliches"
+  headline="Datenschutzerklärung"
+  intro="Diese Datenschutzerklärung informiert darüber, welche personenbezogenen Daten beim Besuch dieser Website verarbeitet werden und zu welchen Zwecken dies geschieht."
+  updatedLabel="Stand"
+  updatedAt="20. März 2026"
+>
+  <section class="space-y-8">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        1. Verantwortlicher
+      </h2>
+      <p class="mt-6">
+        Verantwortlich für die Datenverarbeitung auf dieser Website ist:
+      </p>
+      <div
+        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
+      >
+        <p class="font-semibold text-gray-900 dark:text-white">SecPal</p>
+        <p class="mt-2">Holger Schmermbeck</p>
+        <p class="mt-2">Enno-Arends-Str. 4</p>
+        <p class="mt-2">26571 Juist</p>
+      </div>
+      <p class="mt-4">
+        Kontakt per E-Mail: <a
+          href="mailto:hello@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >hello@secpal.app</a
+        >
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        2. Zugriffsdaten und Hosting
+      </h2>
+      <p class="mt-6">
+        Beim Aufruf dieser Website werden technisch erforderliche Daten
+        verarbeitet, damit die Seite ausgeliefert und sicher betrieben werden
+        kann.
+      </p>
+      <ul
+        role="list"
+        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
+      >
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Verarbeitete Daten:</strong
+            > IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte URL, Referrer,
+            Browsertyp und Betriebssystem.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Zweck:</strong
+            > Bereitstellung der Website, Fehleranalyse, Missbrauchserkennung und
+            Absicherung des technischen Betriebs.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Rechtsgrundlage:</strong
+            > Art. 6 Abs. 1 lit. f DSGVO auf Basis des berechtigten Interesses an
+            einem sicheren und funktionsfähigen Webauftritt.</span
+          >
+        </li>
+      </ul>
+      <p class="mt-8">Das Hosting dieser Website erfolgt bei Hetzner.</p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        3. Kontaktaufnahme per E-Mail
+      </h2>
+      <p class="mt-6">
+        Wenn Sie per E-Mail Kontakt aufnehmen, verarbeiten wir die von Ihnen
+        übermittelten Angaben, um Ihre Anfrage zu beantworten und die weitere
+        Kommunikation zu dokumentieren.
+      </p>
+      <p class="mt-4">
+        Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO, soweit es um
+        vorvertragliche Maßnahmen oder die Bearbeitung einer konkreten Anfrage
+        geht, andernfalls Art. 6 Abs. 1 lit. f DSGVO.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        4. Keine Cookies und kein Tracking
+      </h2>
+      <p class="mt-6">
+        Auf dieser Website werden derzeit keine Analyse-, Tracking- oder
+        Marketing-Cookies eingesetzt. Es wird auch kein Cookie-Banner für
+        optionale Tracking-Zwecke verwendet.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        5. Speicherdauer
+      </h2>
+      <p class="mt-6">
+        Server-Logdaten werden nur so lange gespeichert, wie dies zur
+        technischen Bereitstellung, Fehleranalyse und Sicherheitsüberwachung
+        erforderlich ist.
+      </p>
+      <p class="mt-4">
+        Daten aus E-Mails werden gelöscht, sobald die jeweilige Anfrage
+        abgeschlossen ist, sofern keine gesetzlichen Aufbewahrungspflichten
+        entgegenstehen.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        6. Rechte der betroffenen Personen
+      </h2>
+      <p class="mt-6">
+        Ihnen stehen nach Maßgabe der DSGVO insbesondere Rechte auf Auskunft,
+        Berichtigung, Löschung, Einschränkung der Verarbeitung,
+        Datenübertragbarkeit sowie Widerspruch gegen die Verarbeitung zu.
+      </p>
+      <p class="mt-4">
+        Außerdem haben Sie das Recht, sich bei einer Datenschutzaufsichtsbehörde
+        zu beschweren.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        7. Änderungen dieser Datenschutzerklärung
+      </h2>
+      <p class="mt-6">
+        Wir passen diese Datenschutzerklärung an, wenn sich die Website, die
+        tatsächlichen Datenverarbeitungen oder die rechtlichen Anforderungen
+        ändern.
+      </p>
+    </div>
+  </section>
+</LegalPageShell>

--- a/src/pages/de/security.astro
+++ b/src/pages/de/security.astro
@@ -1,0 +1,132 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+import SecurityFaq from "../../components/SecurityFaq.astro";
+
+const faqItems = [
+  {
+    question: "Wie meldet man eine Sicherheitslücke?",
+    answer:
+      "Bitte keine öffentliche Issue anlegen. Sicherheitsmeldungen gehen an security@secpal.app oder über GitHub Security Advisories, damit koordinierte Offenlegung möglich bleibt.",
+  },
+  {
+    question: "Wie wird mit gemeldeten Schwachstellen umgegangen?",
+    answer:
+      "Eingehende Meldungen werden vertraulich geprüft, priorisiert und nach Möglichkeit koordiniert behoben. Falls sinnvoll, wird eine Korrektur später auch öffentlich dokumentiert.",
+  },
+  {
+    question: "Ist SecPal schon produktiv verfügbar?",
+    answer:
+      "Nein. SecPal befindet sich noch im Aufbau. Diese Seite beschreibt den Meldeweg und den aktuellen öffentlichen Stand, nicht den vollständigen Sicherheitsumfang einer produktiven Plattform.",
+  },
+  {
+    question: "Werden bereits Tracking- oder Werbedienste eingesetzt?",
+    answer:
+      "Aktuell nicht. Die öffentliche Landingpage bleibt bewusst schlank und verzichtet derzeit auf Marketing-Tracker oder Werbenetzwerke.",
+  },
+];
+---
+
+<LegalPageShell
+  locale="de"
+  title="Sicherheit | SecPal"
+  description="Öffentliche Sicherheitsinformationen und Kontaktweg für Sicherheitsmeldungen bei SecPal."
+  canonicalPath="/de/security/"
+  currentPath="/security"
+  xDefaultPath="/security/"
+  eyebrow="Vertrauen & Sicherheit"
+  headline="Sicherheit"
+  intro="Dieser Bereich nennt den Meldeweg für Sicherheitslücken und fasst knapp zusammen, was für die öffentliche Website heute bereits gilt."
+  updatedLabel="Stand"
+  updatedAt="21. März 2026"
+>
+  <section class="space-y-8">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Sicherheitsmeldungen
+      </h2>
+      <p class="mt-6">
+        Wenn Sie eine Schwachstelle entdecken, melden Sie diese bitte
+        vertraulich an
+        <a
+          href="mailto:security@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >security@secpal.app</a
+        >. Öffentliche Bugreports für Sicherheitslücken sollen vermieden werden,
+        damit keine unnötigen Risiken für Dritte entstehen.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Aktueller Stand
+      </h2>
+      <p class="mt-6">
+        SecPal ist noch keine produktive Plattform. Die öffentliche Website ist
+        eine schlanke Coming-Soon-Präsenz mit Kontakt- und Rechtsinformationen.
+        Diese Seite beschreibt deshalb bewusst nur den Meldeweg für
+        Sicherheitslücken und den aktuell sichtbaren öffentlichen Zustand.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Aktuelle Grundsätze
+      </h2>
+      <ul
+        role="list"
+        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
+      >
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Responsible Disclosure:</strong
+            > Sicherheitslücken sollen vertraulich und koordiniert gemeldet werden.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Datensparsamkeit:</strong
+            > Die Landingpage verzichtet aktuell auf unnötige Tracking- und Marketingdienste.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Realistische Kommunikation:</strong
+            > Es werden keine unbelegten Sicherheitsversprechen für Funktionen gemacht,
+            die noch nicht live sind.</span
+          >
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <Fragment slot="afterContent">
+    <SecurityFaq
+      title="Häufige Fragen zur Sicherheit"
+      intro="Wenn Ihre Frage hier nicht beantwortet wird, können Sie sich direkt per "
+      contactLabel="E-Mail"
+      contactHref="mailto:security@secpal.app"
+      contactText=" melden."
+      items={faqItems}
+    />
+  </Fragment>
+</LegalPageShell>

--- a/src/pages/en/imprint.astro
+++ b/src/pages/en/imprint.astro
@@ -1,0 +1,59 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+---
+
+<LegalPageShell
+  locale="en"
+  title="Legal Notice | SecPal"
+  description="Provider identification and contact details for secpal.app."
+  canonicalPath="/en/imprint/"
+  currentPath="/imprint"
+  eyebrow="Legal"
+  headline="Legal Notice"
+  intro="Provider identification and contact information for the website at secpal.app."
+  updatedLabel="Last updated"
+  updatedAt="March 20, 2026"
+>
+  <section class="space-y-10">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Provider
+      </h2>
+      <div
+        class="mt-6 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
+      >
+        <p class="font-semibold text-gray-900 dark:text-white">SecPal</p>
+        <p class="mt-2">Holger Schmermbeck</p>
+        <p class="mt-2">Enno-Arends-Str. 4</p>
+        <p class="mt-2">26571 Juist</p>
+        <p class="mt-2">Germany</p>
+      </div>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Contact
+      </h2>
+      <p class="mt-6">
+        Email: <a
+          href="mailto:hello@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >hello@secpal.app</a
+        >
+      </p>
+      <p class="mt-4">
+        Security reports: <a
+          href="mailto:security@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >security@secpal.app</a
+        >
+      </p>
+    </div>
+  </section>
+</LegalPageShell>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,0 +1,173 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+---
+
+<LegalPageShell
+  locale="en"
+  title="Privacy | SecPal"
+  description="Privacy notice for visitors of secpal.app and for direct contact with SecPal."
+  canonicalPath="/en/privacy/"
+  currentPath="/privacy"
+  eyebrow="Legal"
+  headline="Privacy Notice"
+  intro="This privacy notice explains which personal data may be processed when you visit this website and why that happens."
+  updatedLabel="Last updated"
+  updatedAt="March 20, 2026"
+>
+  <section class="space-y-8">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        1. Controller
+      </h2>
+      <p class="mt-6">
+        The controller responsible for data processing on this website is:
+      </p>
+      <div
+        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
+      >
+        <p class="font-semibold text-gray-900 dark:text-white">SecPal</p>
+        <p class="mt-2">Holger Schmermbeck</p>
+        <p class="mt-2">Enno-Arends-Str. 4</p>
+        <p class="mt-2">26571 Juist</p>
+        <p class="mt-2">Germany</p>
+      </div>
+      <p class="mt-4">
+        Contact by email: <a
+          href="mailto:hello@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >hello@secpal.app</a
+        >
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        2. Access data and hosting
+      </h2>
+      <p class="mt-6">
+        When you visit this website, technically necessary data is processed so
+        the site can be delivered and operated securely.
+      </p>
+      <ul
+        role="list"
+        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
+      >
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Processed data:</strong
+            > IP address, date and time of access, requested URL, referrer, browser
+            type, and operating system.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Purpose:</strong
+            > delivery of the website, error analysis, abuse detection, and safeguarding
+            technical operations.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Legal basis:</strong
+            > Art. 6(1)(f) GDPR based on the legitimate interest in operating a secure
+            and functional website.</span
+          >
+        </li>
+      </ul>
+      <p class="mt-8">This website is hosted by Hetzner.</p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        3. Contact by email
+      </h2>
+      <p class="mt-6">
+        If you contact us by email, we process the information you send so we
+        can answer your request and document the related communication.
+      </p>
+      <p class="mt-4">
+        The legal basis is Art. 6(1)(b) GDPR where your request relates to
+        pre-contractual steps or a specific inquiry, otherwise Art. 6(1)(f)
+        GDPR.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        4. No cookies and no tracking
+      </h2>
+      <p class="mt-6">
+        This website currently does not use analytics, tracking, or marketing
+        cookies. There is also no consent banner for optional tracking at this
+        time.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        5. Storage duration
+      </h2>
+      <p class="mt-6">
+        Server log data is stored only for as long as necessary for technical
+        delivery, error analysis, and security monitoring.
+      </p>
+      <p class="mt-4">
+        Data from emails is deleted once the relevant request has been
+        completed, unless statutory retention obligations require otherwise.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        6. Data subject rights
+      </h2>
+      <p class="mt-6">
+        Under the GDPR, you may have rights of access, rectification, erasure,
+        restriction of processing, data portability, and objection to
+        processing.
+      </p>
+      <p class="mt-4">
+        You also have the right to lodge a complaint with a supervisory
+        authority.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        7. Changes to this notice
+      </h2>
+      <p class="mt-6">
+        We update this privacy notice whenever the website, the actual data
+        processing activities, or the legal requirements change.
+      </p>
+    </div>
+  </section>
+</LegalPageShell>

--- a/src/pages/en/security.astro
+++ b/src/pages/en/security.astro
@@ -1,0 +1,133 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import LegalPageShell from "../../components/LegalPageShell.astro";
+import SecurityFaq from "../../components/SecurityFaq.astro";
+
+const faqItems = [
+  {
+    question: "How should a vulnerability be reported?",
+    answer:
+      "Please do not open a public issue for security vulnerabilities. Send reports to security@secpal.app or use GitHub Security Advisories so coordinated disclosure remains possible.",
+  },
+  {
+    question: "What happens after a vulnerability is reported?",
+    answer:
+      "Incoming reports are reviewed confidentially, prioritized, and fixed where possible through a coordinated process. Where appropriate, a later public note may describe the correction.",
+  },
+  {
+    question: "Is SecPal already a production service?",
+    answer:
+      "No. SecPal is still under construction. This page describes the reporting path and the current public state, not the full assurance level of a live production platform.",
+  },
+  {
+    question: "Are tracking or advertising services already in use?",
+    answer:
+      "Not at the moment. The public landing page intentionally stays lean and currently avoids marketing trackers or ad networks.",
+  },
+];
+---
+
+<LegalPageShell
+  locale="en"
+  title="Security | SecPal"
+  description="Public security information and vulnerability reporting path for SecPal."
+  canonicalPath="/en/security/"
+  currentPath="/security"
+  xDefaultPath="/security/"
+  eyebrow="Trust & Security"
+  headline="Security"
+  intro="This page gives the reporting path for security issues and briefly states what already applies to the public website today."
+  updatedLabel="Last updated"
+  updatedAt="March 21, 2026"
+>
+  <section class="space-y-8">
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Vulnerability reporting
+      </h2>
+      <p class="mt-6">
+        If you discover a vulnerability, please report it confidentially to
+        <a
+          href="mailto:security@secpal.app"
+          class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >security@secpal.app</a
+        >. Public bug reports for security issues should be avoided so
+        unnecessary risk is not created for others.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Current status
+      </h2>
+      <p class="mt-6">
+        SecPal is not yet a live production platform. The public website is a
+        lean coming-soon presence with contact and legal information. This page
+        therefore focuses only on vulnerability reporting and the currently
+        visible public state.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        Current principles
+      </h2>
+      <ul
+        role="list"
+        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
+      >
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Responsible disclosure:</strong
+            > vulnerabilities should be reported confidentially and handled in a coordinated
+            way.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >Data minimization:</strong
+            > the landing page currently avoids unnecessary tracking and marketing
+            services.</span
+          >
+        </li>
+        <li class="flex gap-x-3">
+          <span
+            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
+          ></span>
+          <span
+            ><strong class="font-semibold text-gray-900 dark:text-white"
+              >No inflated claims:</strong
+            > this page does not promise production-grade controls for features that
+            are not yet live.</span
+          >
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  <Fragment slot="afterContent">
+    <SecurityFaq
+      title="Security FAQ"
+      intro="If your question is not covered here, reach out by "
+      contactLabel="email"
+      contactHref="mailto:security@secpal.app"
+      contactText="."
+      items={faqItems}
+    />
+  </Fragment>
+</LegalPageShell>

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL("https://secpal.app");
+  const sitemapUrl = new URL("/sitemap.xml", siteUrl).toString();
+  const body = ["User-agent: *", "Allow: /", `Sitemap: ${sitemapUrl}`, ""].join(
+    "\n"
+  );
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/security.txt.ts
+++ b/src/pages/security.txt.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { APIRoute } from "astro";
+import { buildSecurityTxt } from "../lib/security-txt.ts";
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return new Response(
+    buildSecurityTxt(
+      siteUrl,
+      "# Legacy fallback for clients that do not use /.well-known/"
+    ),
+    {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    }
+  );
+};

--- a/src/pages/security/index.astro
+++ b/src/pages/security/index.astro
@@ -1,0 +1,64 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import Base from "../../layouts/Base.astro";
+import Nav from "../../components/Nav.astro";
+import Footer from "../../components/Footer.astro";
+---
+
+<Base
+  title="Security | SecPal"
+  description="Language-neutral security entry point for SecPal with links to the English and German security pages."
+  lang="en"
+  canonicalPath="/security/"
+  alternateEnPath="/en/security/"
+  alternateDePath="/de/security/"
+  xDefaultPath="/security/"
+>
+  <Nav locale="en" currentPath="/security" />
+  <main class="bg-white dark:bg-gray-900">
+    <section class="px-6 py-16 sm:py-24 lg:px-8 lg:py-32">
+      <div
+        class="mx-auto max-w-3xl text-center text-base/7 text-gray-700 dark:text-gray-300"
+      >
+        <p
+          class="text-base/7 font-semibold text-indigo-600 dark:text-indigo-400"
+        >
+          Security
+        </p>
+        <h1
+          class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
+        >
+          Security Reporting
+        </h1>
+        <p class="mt-6 text-xl/8 text-gray-600 dark:text-gray-400">
+          This language-neutral entry point links to the public security
+          information for SecPal.
+        </p>
+        <p class="mt-4 text-base/7 text-gray-600 dark:text-gray-400">
+          For vulnerability reports, contact
+          <a
+            href="mailto:security@secpal.app"
+            class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+            >security@secpal.app</a
+          >.
+        </p>
+        <div
+          class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row"
+        >
+          <a
+            href="/en/security/"
+            class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+            >English security page</a
+          >
+          <a
+            href="/de/security/"
+            class="rounded-md border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:border-white/15 dark:text-white dark:hover:bg-white/5"
+            >Deutsche Sicherheitsseite</a
+          >
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer locale="en" />
+</Base>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -77,7 +77,16 @@ const pages = [
   },
 ];
 
-const lastModified = "2026-03-21";
+const getLastModified = (): string => {
+  const fromEnv = import.meta.env.BUILD_LAST_MODIFIED as string | undefined;
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  return new Date().toISOString().slice(0, 10);
+};
+
+const lastModified = getLastModified();
 
 export const GET: APIRoute = ({ site }) => {
   const siteUrl = site ?? new URL("https://secpal.app");

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { APIRoute } from "astro";
+
+const pages = [
+  {
+    path: "/en/",
+    alternates: {
+      en: "/en/",
+      de: "/de/",
+      "x-default": "/en/",
+    },
+  },
+  {
+    path: "/de/",
+    alternates: {
+      en: "/en/",
+      de: "/de/",
+      "x-default": "/en/",
+    },
+  },
+  {
+    path: "/en/privacy/",
+    alternates: {
+      en: "/en/privacy/",
+      de: "/de/privacy/",
+      "x-default": "/en/privacy/",
+    },
+  },
+  {
+    path: "/de/privacy/",
+    alternates: {
+      en: "/en/privacy/",
+      de: "/de/privacy/",
+      "x-default": "/en/privacy/",
+    },
+  },
+  {
+    path: "/en/imprint/",
+    alternates: {
+      en: "/en/imprint/",
+      de: "/de/imprint/",
+      "x-default": "/en/imprint/",
+    },
+  },
+  {
+    path: "/de/imprint/",
+    alternates: {
+      en: "/en/imprint/",
+      de: "/de/imprint/",
+      "x-default": "/en/imprint/",
+    },
+  },
+  {
+    path: "/security/",
+    alternates: {
+      en: "/en/security/",
+      de: "/de/security/",
+      "x-default": "/security/",
+    },
+  },
+  {
+    path: "/en/security/",
+    alternates: {
+      en: "/en/security/",
+      de: "/de/security/",
+      "x-default": "/security/",
+    },
+  },
+  {
+    path: "/de/security/",
+    alternates: {
+      en: "/en/security/",
+      de: "/de/security/",
+      "x-default": "/security/",
+    },
+  },
+];
+
+const lastModified = "2026-03-21";
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL("https://secpal.app");
+  const urls = pages
+    .map((page) => {
+      const location = new URL(page.path, siteUrl).toString();
+      const alternates = Object.entries(page.alternates)
+        .map(([hreflang, href]) => {
+          const alternateUrl = new URL(href, siteUrl).toString();
+
+          return `    <xhtml:link rel="alternate" hreflang="${hreflang}" href="${alternateUrl}" />`;
+        })
+        .join("\n");
+
+      return [
+        "  <url>",
+        `    <loc>${location}</loc>`,
+        alternates,
+        `    <lastmod>${lastModified}</lastmod>`,
+        "  </url>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+    urls,
+    "</urlset>",
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- add public privacy, legal notice, and security pages in German and English
- replace the nonexistent terms link with a real legal notice link and fix homepage section navigation from legal subpages
- add environment-aware discovery endpoints for `robots.txt`, `sitemap.xml`, and `security.txt`, including a neutral `/security/` policy URL and hreflang-aware metadata

## Why

The landing site now exposes the minimum public legal and discovery surface expected for a real public-facing site while keeping the copy and metadata aligned with the current coming-soon scope.

## Self-review

- No code findings from self-review
- Residual note: the Astro/Vite warning about unused imports in `node_modules` is upstream and unchanged by this PR

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Checklist

- [x] Formatting, lint, typecheck, and build passed
- [x] `CHANGELOG.md` updated in the same change set
- [x] No bypass used
- [x] No out-of-scope findings requiring a GitHub issue were identified

## Scope Note

This draft is larger than the preferred PR size guideline because it combines bilingual legal pages with the related discovery and metadata work needed to ship them coherently. It still remains a single topic: public legal and discovery readiness for the landing site.