### PR TITLE
fix: polish secpal.app public release website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Landing page and legal pages now use tighter, aligned English and German copy, a release-ready claim, and more precise metadata for `title`, description, canonical, and `hreflang`
+- Landing page wording now emphasizes less paperwork, fewer media breaks, and clearer handovers while reducing repeated phrasing across hero, features, CTA, and legal metadata
 
 - README and package metadata now match the landing page's security-operations and coming-soon positioning
 - Hero now presents `SecPal – A guard’s best friend` as a compact eyebrow tagline above the main positioning headline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Landing page and legal pages now use tighter, aligned English and German copy, a release-ready claim, and more precise metadata for `title`, description, canonical, and `hreflang`
+
 - README and package metadata now match the landing page's security-operations and coming-soon positioning
-- Hero now presents `SecPal – A guard's best friend` as a compact eyebrow tagline above the main positioning headline
+- Hero now presents `SecPal – A guard’s best friend` as a compact eyebrow tagline above the main positioning headline
 - Footer no longer claims "All rights reserved" on the public site, avoiding a misleading rights statement for the AGPL-published project
 - Landing page now leads with the SecPal product name, removes the duplicated hero view, and reframes the homepage as a focused coming-soon preview while the product is still under active construction
 - Alternate deployment builds now derive canonical and hreflang URLs from `SECPAL_SITE_URL` so `dev.secpal.app` no longer points metadata at production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Landing page and legal pages now use tighter, aligned English and German copy, a release-ready claim, and more precise metadata for `title`, description, canonical, and `hreflang`
+- Landing page and legal pages now use tighter, aligned English and German copy, a release-ready claim, and more precise `title` and description metadata
 - Landing page wording now emphasizes less paperwork, fewer media breaks, and clearer handovers while reducing repeated phrasing across hero, features, CTA, and legal metadata
 
 - README and package metadata now match the landing page's security-operations and coming-soon positioning

--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ SPDX-License-Identifier: CC0-1.0
 [![PR Size](https://github.com/SecPal/secpal.app/actions/workflows/pr-size.yml/badge.svg)](https://github.com/SecPal/secpal.app/actions/workflows/pr-size.yml)
 [![License](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 
-Public landing page for [secpal.app](https://secpal.app) — the open-source security operations product being built in public for day-to-day security service work.
+Public website for [secpal.app](https://secpal.app): SecPal – A guard’s best friend.
+
+The site presents the product direction, legal pages, and direct contact paths for the planned public release.
 
 Built with [Astro](https://astro.build), [Tailwind CSS v4](https://tailwindcss.com), and [Tailwind Plus UI Blocks](https://tailwindcss.com/plus).
 
 ## Features
 
 - **Multilingual** — English and German (`/en/`, `/de/`)
-- **Built in public** — product progress and launch positioning instead of premature app onboarding
+- **Built in public** — product progress and release readiness instead of premature app onboarding
 - **Dark mode** — class-based, persisted in `localStorage`, flash-free
 - **Static** — minimal client-side JS with Astro-first rendering
 - **REUSE-compliant** — all files carry SPDX headers

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@secpal/secpal.app",
   "version": "0.0.1",
-  "description": "Landing page for SecPal — the open-source security operations platform built in public",
+  "description": "Public website for SecPal – A guard’s best friend",
   "private": true,
   "type": "module",
   "author": "SecPal",

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -16,7 +16,7 @@ const t = useTranslations(locale);
 <div id="updates" class="bg-white py-16 sm:py-24 dark:bg-gray-900">
   <div class="mx-auto max-w-7xl px-6 sm:px-6 lg:px-8">
     <div
-      class="relative isolate overflow-hidden bg-gray-900 px-6 py-20 shadow-2xl sm:rounded-3xl sm:px-12 xl:px-24 dark:bg-gray-800 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-0 dark:after:inset-ring dark:after:inset-ring-white/15 dark:after:sm:rounded-3xl"
+      class="relative isolate overflow-hidden bg-slate-950 px-6 py-20 shadow-2xl sm:rounded-3xl sm:px-12 xl:px-24 dark:shadow-none dark:after:pointer-events-none dark:after:absolute dark:after:inset-0 dark:after:inset-ring dark:after:inset-ring-white/15 dark:after:sm:rounded-3xl"
     >
       <div class="mx-auto max-w-3xl text-center">
         <h2
@@ -63,8 +63,8 @@ const t = useTranslations(locale);
             gradientUnits="userSpaceOnUse"
             gradientTransform="translate(512 512) rotate(90) scale(512)"
           >
-            <stop stop-color="#7775D6"></stop>
-            <stop offset="1" stop-color="#E935C1" stop-opacity="0"></stop>
+            <stop stop-color="#2563EB"></stop>
+            <stop offset="1" stop-color="#0F766E" stop-opacity="0"></stop>
           </radialGradient>
         </defs>
       </svg>

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -39,9 +39,13 @@ const t = useTranslations(locale);
             >{t.cta.buttonSecondary} <span aria-hidden="true">→</span></a
           >
         </div>
-        <p class="mx-auto mt-6 max-w-xl text-sm/6 text-gray-400">
-          {t.cta.note}
-        </p>
+        {
+          t.cta.note && (
+            <p class="mx-auto mt-6 max-w-xl text-sm/6 text-gray-400">
+              {t.cta.note}
+            </p>
+          )
+        }
       </div>
       <svg
         viewBox="0 0 1024 1024"

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -21,7 +21,7 @@ const iconPaths = [
 
 <div id="progress" class="bg-white py-24 sm:py-32 dark:bg-gray-900">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
-    <div class="mx-auto max-w-2xl text-center lg:mx-auto">
+    <div class="mx-auto max-w-3xl text-center lg:mx-auto">
       <h2
         class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
       >
@@ -35,7 +35,7 @@ const iconPaths = [
       <dl class="grid max-w-xl grid-cols-1 gap-8 lg:max-w-none lg:grid-cols-3">
         {
           t.features.items.map((feature, i) => (
-            <div class="rounded-3xl border border-gray-200/80 bg-gray-50 p-8 dark:border-white/10 dark:bg-white/5">
+            <div class="rounded-3xl border border-gray-200/80 bg-white p-8 shadow-xs dark:border-white/10 dark:bg-white/5">
               <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
                 <div class="mb-6 flex size-10 items-center justify-center rounded-lg bg-indigo-600 dark:bg-indigo-500">
                   <svg

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -35,16 +35,9 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
       <!-- Badge -->
       <div class="mb-6 flex justify-center">
         <div
-          class="relative rounded-full px-3 py-1 text-sm/6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20 dark:text-gray-400 dark:ring-white/10 dark:hover:ring-white/20"
+          class="rounded-full px-3 py-1 text-sm/6 text-gray-600 ring-1 ring-gray-900/10 dark:text-gray-400 dark:ring-white/10"
         >
           {t.hero.badge}
-          <a
-            href="https://github.com/SecPal"
-            class="font-semibold text-indigo-600 dark:text-indigo-400"
-          >
-            <span aria-hidden="true" class="absolute inset-0"></span>
-            GitHub <span aria-hidden="true">&rarr;</span>
-          </a>
         </div>
       </div>
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -24,13 +24,13 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
     >
       <div
         style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"
-        class="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#818cf8] to-[#6366f1] opacity-20 sm:left-[calc(50%-30rem)] sm:w-288.75"
+        class="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#0f766e] to-[#2563eb] opacity-15 sm:left-[calc(50%-30rem)] sm:w-288.75"
       >
       </div>
     </div>
 
     <div
-      class="mx-auto max-w-3xl pb-16 pt-8 sm:pb-24 sm:pt-12 lg:pb-28 lg:pt-14"
+      class="mx-auto max-w-4xl pb-16 pt-8 sm:pb-24 sm:pt-12 lg:pb-28 lg:pt-14"
     >
       <!-- Badge -->
       <div class="mb-6 flex justify-center">
@@ -66,16 +66,16 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
           {t.hero.subline}
         </p>
         <p
-          class="mx-auto mt-4 max-w-2xl text-base/7 text-pretty text-gray-600 dark:text-gray-300"
+          class="mx-auto mt-4 max-w-3xl text-base/7 text-pretty text-gray-600 dark:text-gray-300"
         >
           {t.hero.explanation}
         </p>
         <ul
-          class="mx-auto mt-10 grid max-w-2xl grid-cols-1 gap-3 text-left text-sm/6 text-gray-600 sm:grid-cols-3 dark:text-gray-300"
+          class="mx-auto mt-10 grid max-w-4xl grid-cols-1 gap-3 text-left text-sm/6 text-gray-600 lg:grid-cols-3 dark:text-gray-300"
         >
           {
             t.hero.highlights.map((highlight) => (
-              <li class="rounded-2xl border border-gray-200/80 bg-gray-50/80 px-4 py-3 dark:border-white/10 dark:bg-white/5">
+              <li class="rounded-2xl border border-gray-200/80 bg-white px-4 py-4 shadow-xs dark:border-white/10 dark:bg-white/5">
                 {highlight}
               </li>
             ))
@@ -108,7 +108,7 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
     >
       <div
         style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"
-        class="relative left-[calc(50%+3rem)] aspect-1155/678 w-144.5 -translate-x-1/2 bg-linear-to-tr from-[#818cf8] to-[#6366f1] opacity-20 sm:left-[calc(50%+36rem)] sm:w-288.75"
+        class="relative left-[calc(50%+3rem)] aspect-1155/678 w-144.5 -translate-x-1/2 bg-linear-to-tr from-[#2563eb] to-[#0f766e] opacity-15 sm:left-[calc(50%+36rem)] sm:w-288.75"
       >
       </div>
     </div>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -17,7 +17,7 @@ export const de: Translations = {
     headline: "Weniger Reibung im Sicherheitsdienst.",
     subline: "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Abläufe.",
     explanation:
-      "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf führen statt sie über Papier, Chats und Insellösungen zu verteilen.",
+      "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf organisieren statt sie über Papier, Chats und Insellösungen zu verteilen.",
     highlights: [
       "Operative Abläufe gehören in ein durchgängiges System statt in einzelne Teillösungen.",
       "Informationen bleiben nachvollziehbar — nicht verstreut in Notizen, Kurznachrichten und verteilten Dateien.",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,7 +6,7 @@ import type { Translations } from "./en.ts";
 export const de: Translations = {
   nav: {
     progress: "Fortschritt",
-    updates: "Veröffentlichung",
+    updates: "Kontakt",
     github: "GitHub",
     contact: "Kontakt",
     followProgress: "Fortschritt verfolgen",
@@ -21,12 +21,12 @@ export const de: Translations = {
       "SecPal entsteht für Sicherheitsdienste, die ihre operative Arbeit in einem klaren Ablauf zusammenführen wollen, statt Informationen über Papier, Chats und Insellösungen zu verstreuen.",
     highlights: [
       "Operative Abläufe gehören in ein durchgängiges System statt in einzelne Teillösungen.",
-      "Informationen sollen nachvollziehbar bleiben statt in Zetteln, Chats und Insellösungen zu verschwinden.",
+      "Informationen sollen nachvollziehbar bleiben, nicht in Notizen, Kurznachrichten und verteilten Dateien verschwinden.",
       "SecPal entsteht öffentlich, mit klarem Fokus und nachvollziehbaren Release-Schritten.",
     ],
     cta: "Entwicklung auf GitHub verfolgen",
-    ctaSecondary: "Mehr zum aktuellen Stand",
-    note: "Die öffentliche Website zeigt Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist derzeit noch nicht geöffnet.",
+    ctaSecondary: "Zu den Features",
+    note: "Die öffentliche Website zeigt die Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist derzeit noch nicht geöffnet.",
   },
   features: {
     headline: "Für die operative Realität gebaut.",
@@ -39,14 +39,14 @@ export const de: Translations = {
           "SecPal soll operative Arbeit in einem klaren Zusammenhang abbilden statt Einzelschritte in getrennten Werkzeugen zu verteilen.",
       },
       {
-        name: "Weniger Medienbrüche im Alltag",
+        name: "Dokumentiert im Ablauf, nicht im Nachhinein",
         description:
-          "Statt Papier, Chats und Insellösungen bündelt SecPal Informationen und Abläufe in einem strukturierten System.",
+          "Formulare, Kontrollgänge und Schichtübergaben entstehen direkt im Ablauf statt nachträglich auf Papier oder in separaten Apps.",
       },
       {
         name: "Mehr Überblick im Alltag",
         description:
-          "Das schafft klarere Statusbilder, weniger Doppelarbeit und bessere Übersicht für Teams, Führung und Disposition.",
+          "Klare Statusbilder, weniger Doppelarbeit und bessere Übersicht für Teams, Führung und Disposition.",
       },
     ],
   },
@@ -56,7 +56,7 @@ export const de: Translations = {
       "Auf GitHub ist der aktuelle Stand sichtbar. Für Fragen, Hinweise oder frühen Austausch erreichen Sie SecPal direkt.",
     button: "GitHub ansehen",
     buttonSecondary: "Kontakt aufnehmen",
-    note: "Die öffentliche Website bleibt bewusst fokussiert, solange SecPal noch nicht öffentlich zugänglich ist.",
+    note: "",
   },
   footer: {
     rights: "",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,56 +6,57 @@ import type { Translations } from "./en.ts";
 export const de: Translations = {
   nav: {
     progress: "Fortschritt",
-    updates: "Launch",
+    updates: "Veröffentlichung",
     github: "GitHub",
     contact: "Kontakt",
     followProgress: "Fortschritt verfolgen",
   },
   hero: {
-    badge: "Work in progress · Open Source · Öffentlich entwickelt",
+    badge: "Öffentliche Website · Open Source · Öffentlich entwickelt",
     tagline: "SecPal – A guard’s best friend",
-    headline: "Schluss mit der Zettelwirtschaft im Sicherheitsdienst.",
-    subline: "Digital von der Dienstplanung bis zur Schichtübergabe.",
+    headline: "Weniger Reibung im Sicherheitsdienst.",
+    subline:
+      "Ein klarer operativer Ablauf von der Dienstplanung bis zur Übergabe.",
     explanation:
-      "SecPal wird für die operative Arbeit im Sicherheitsdienst entwickelt und soll Mitarbeitende wie Führungskräfte im Alltag spürbar entlasten.",
+      "SecPal wird für Sicherheitsdienste entwickelt, die Dienstplanung, Kontrollgänge, Meldungen und saubere Übergaben ohne papierlastige Umwege abbilden wollen.",
     highlights: [
-      "Dienstplanung, Kontrollgänge und Dokumentation greifen endlich sauber ineinander.",
-      "Meldungen und Übergaben bleiben nachvollziehbar statt in Zetteln und Chats zu verschwinden.",
-      "SecPal ist noch im Aufbau und wird Schritt für Schritt öffentlich weiterentwickelt.",
+      "Dienstplanung, Kontrollgänge, Meldungen und Übergaben gehören in einen durchgehenden Ablauf.",
+      "Informationen sollen nachvollziehbar bleiben statt in Zetteln, Chats und Einzellösungen zu verschwinden.",
+      "SecPal entsteht öffentlich, mit klarem Fokus und nachvollziehbaren Release-Schritten.",
     ],
-    cta: "Build auf GitHub verfolgen",
-    ctaSecondary: "Ansehen, was gerade entsteht",
-    note: "Noch kein öffentliches Signup. SecPal befindet sich weiterhin im Aufbau und wird zunächst als fokussierte Coming-Soon-Seite vorgestellt.",
+    cta: "Entwicklung auf GitHub verfolgen",
+    ctaSecondary: "Aktuellen Umfang ansehen",
+    note: "Die öffentliche Website zeigt Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist noch nicht geöffnet.",
   },
   features: {
-    headline: "Für den Arbeitsalltag im Sicherheitsdienst gedacht.",
+    headline: "Für die operative Realität gebaut.",
     subline:
-      "SecPal wird für die operative Arbeit gebaut und mit Fokus auf klare Abläufe, bessere Übersicht und spürbare Entlastung im Alltag entwickelt.",
+      "Die erste öffentliche Version entsteht ausgehend von den Abläufen, die Sicherheitsdienste täglich wirklich brauchen: planen, kontrollieren, melden, übergeben und Überblick behalten.",
     items: [
       {
-        name: "Von der Planung bis zur Übergabe",
+        name: "Von der Planung bis zur Übergabe verbunden",
         description:
-          "SecPal spannt den Bogen über den gesamten operativen Ablauf: von der Dienstplanung über Kontrollgänge und Meldungen bis zur sauberen Schichtübergabe.",
+          "SecPal wird als durchgehender operativer Faden angelegt: von der Dienstplanung und Kontrollgängen bis zu Meldungen und sauberen Übergaben.",
       },
       {
-        name: "Operative Verwaltung aus einem Guss",
+        name: "Weniger Brüche im Arbeitsalltag",
         description:
-          "Neben Dokumentation und Einsatzabläufen soll SecPal Schritt für Schritt weitere operative Verwaltungsaufgaben sinnvoll in einem System zusammenführen.",
+          "Statt getrennter Papierprotokolle, Chats und Nebenlisten bündelt SecPal die wesentlichen Abläufe in einem strukturierten System.",
       },
       {
-        name: "Entlastung für Teams und Führungskräfte",
+        name: "Nützlich für Teams und Führung",
         description:
-          "Der Fokus liegt auf klaren Abläufen, weniger Reibung im Alltag und einer spürbaren Entlastung für Mitarbeitende, Objektleitungen und Disposition.",
+          "Ziel sind klarere Statusbilder, weniger Doppelarbeit und bessere Übersicht für Sicherheitskräfte, Objektleitungen, Einsatzleitungen und Disposition.",
       },
     ],
   },
   cta: {
-    headline: "Lieber Launch-Updates statt Marketing-Lärm?",
+    headline: "Die Veröffentlichung verfolgen, nicht den Lärm.",
     subline:
-      "Verfolgen Sie die Entwicklung auf GitHub, schreiben Sie uns direkt und schauen Sie wieder vorbei, wenn der erste Release-Meilenstein näher rückt.",
-    button: "Auf GitHub folgen",
-    buttonSecondary: "Kontakt aufnehmen",
-    note: "SecPal ist noch im intensiven Aufbau. Öffentliches Onboarding startet erst, wenn der erste Launch-Meilenstein steht.",
+      "Auf GitHub ist der aktuelle Stand sichtbar, Kontakt bleibt direkt, und die öffentliche Website bleibt bewusst fokussiert, bis die erste Version bereit ist.",
+    button: "GitHub ansehen",
+    buttonSecondary: "SecPal kontaktieren",
+    note: "SecPal wird für eine erste öffentliche Veröffentlichung vorbereitet. Bis dahin bleibt diese Website bewusst schlank.",
   },
   footer: {
     rights: "",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -31,7 +31,7 @@ export const de: Translations = {
   features: {
     headline: "Für die operative Realität gebaut.",
     subline:
-      "SecPal konzentriert sich auf das, was im Sicherheitsdienst täglich funktionieren muss: klare Abläufe, verlässliche Dokumentation und bessere Übersicht.",
+      "SecPal konzentriert sich auf das, was im Sicherheitsdienst täglich funktionieren muss: klare Abläufe, verlässliche Dokumentation und Übersicht für Teams und Führung.",
     items: [
       {
         name: "Ein System statt Stückwerk",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -18,10 +18,10 @@ export const de: Translations = {
     subline:
       "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Übergaben.",
     explanation:
-      "SecPal entsteht für Sicherheitsdienste, die ihre operative Arbeit in einem klaren Ablauf zusammenführen wollen, statt Informationen über Papier, Chats und Insellösungen zu verstreuen.",
+      "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf führen statt sie über Papier, Chats und Insellösungen zu verteilen.",
     highlights: [
       "Operative Abläufe gehören in ein durchgängiges System statt in einzelne Teillösungen.",
-      "Informationen sollen nachvollziehbar bleiben, nicht in Notizen, Kurznachrichten und verteilten Dateien verschwinden.",
+      "Informationen bleiben nachvollziehbar — nicht verstreut in Notizen, Kurznachrichten und verteilten Dateien.",
       "SecPal entsteht öffentlich, mit klarem Fokus und nachvollziehbaren Release-Schritten.",
     ],
     cta: "Entwicklung auf GitHub verfolgen",
@@ -36,7 +36,7 @@ export const de: Translations = {
       {
         name: "Ein System statt Stückwerk",
         description:
-          "SecPal soll operative Arbeit in einem klaren Zusammenhang abbilden statt Einzelschritte in getrennten Werkzeugen zu verteilen.",
+          "SecPal bildet operative Arbeit in einem klaren Zusammenhang ab statt Einzelschritte auf getrennte Werkzeuge zu verteilen.",
       },
       {
         name: "Dokumentiert im Ablauf, nicht im Nachhinein",
@@ -44,7 +44,7 @@ export const de: Translations = {
           "Formulare, Kontrollgänge und Schichtübergaben entstehen direkt im Ablauf statt nachträglich auf Papier oder in separaten Apps.",
       },
       {
-        name: "Überblick für Teams und Führung",
+        name: "Kein Statusrätsel für Objektleitung und Disposition",
         description:
           "Klare Statusbilder, weniger Doppelarbeit und Überblick für Teams, Führung und Disposition.",
       },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -43,7 +43,7 @@ export const de: Translations = {
           "Formulare, Kontrollgänge und Schichtübergaben entstehen direkt im Ablauf statt nachträglich auf Papier oder in separaten Apps.",
       },
       {
-        name: "Kein Statusrätsel für Objektleitung und Disposition",
+        name: "Kein Statusrätsel für Einsatzleitung und Disposition",
         description:
           "Klare Statusbilder, weniger Doppelarbeit und Überblick für Teams, Führung und Disposition.",
       },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,7 +6,7 @@ import type { Translations } from "./en.ts";
 export const de: Translations = {
   nav: {
     progress: "Fortschritt",
-    updates: "Kontakt",
+    updates: "Folgen",
     github: "GitHub",
     contact: "Kontakt",
     followProgress: "Fortschritt verfolgen",
@@ -44,9 +44,9 @@ export const de: Translations = {
           "Formulare, Kontrollgänge und Schichtübergaben entstehen direkt im Ablauf statt nachträglich auf Papier oder in separaten Apps.",
       },
       {
-        name: "Mehr Überblick im Alltag",
+        name: "Überblick für Teams und Führung",
         description:
-          "Klare Statusbilder, weniger Doppelarbeit und bessere Übersicht für Teams, Führung und Disposition.",
+          "Klare Statusbilder, weniger Doppelarbeit und Überblick für Teams, Führung und Disposition.",
       },
     ],
   },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -12,51 +12,51 @@ export const de: Translations = {
     followProgress: "Fortschritt verfolgen",
   },
   hero: {
-    badge: "Öffentliche Website · Open Source · Öffentlich entwickelt",
+    badge: "Aus der Praxis · Open Source · Öffentlich entwickelt",
     tagline: "SecPal – A guard’s best friend",
     headline: "Weniger Reibung im Sicherheitsdienst.",
     subline:
-      "Ein klarer operativer Ablauf von der Dienstplanung bis zur Übergabe.",
+      "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Übergaben.",
     explanation:
-      "SecPal wird für Sicherheitsdienste entwickelt, die Dienstplanung, Kontrollgänge, Meldungen und saubere Übergaben ohne papierlastige Umwege abbilden wollen.",
+      "SecPal entsteht für Sicherheitsdienste, die ihre operative Arbeit in einem klaren Ablauf zusammenführen wollen, statt Informationen über Papier, Chats und Insellösungen zu verstreuen.",
     highlights: [
-      "Dienstplanung, Kontrollgänge, Meldungen und Übergaben gehören in einen durchgehenden Ablauf.",
-      "Informationen sollen nachvollziehbar bleiben statt in Zetteln, Chats und Einzellösungen zu verschwinden.",
+      "Operative Abläufe gehören in ein durchgängiges System statt in einzelne Teillösungen.",
+      "Informationen sollen nachvollziehbar bleiben statt in Zetteln, Chats und Insellösungen zu verschwinden.",
       "SecPal entsteht öffentlich, mit klarem Fokus und nachvollziehbaren Release-Schritten.",
     ],
     cta: "Entwicklung auf GitHub verfolgen",
-    ctaSecondary: "Aktuellen Umfang ansehen",
-    note: "Die öffentliche Website zeigt Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist noch nicht geöffnet.",
+    ctaSecondary: "Mehr zum aktuellen Stand",
+    note: "Die öffentliche Website zeigt Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist derzeit noch nicht geöffnet.",
   },
   features: {
     headline: "Für die operative Realität gebaut.",
     subline:
-      "Die erste öffentliche Version entsteht ausgehend von den Abläufen, die Sicherheitsdienste täglich wirklich brauchen: planen, kontrollieren, melden, übergeben und Überblick behalten.",
+      "SecPal konzentriert sich auf das, was im Sicherheitsdienst täglich funktionieren muss: klare Abläufe, verlässliche Dokumentation und bessere Übersicht.",
     items: [
       {
-        name: "Von der Planung bis zur Übergabe verbunden",
+        name: "Ein System statt Stückwerk",
         description:
-          "SecPal wird als durchgehender operativer Faden angelegt: von der Dienstplanung und Kontrollgängen bis zu Meldungen und sauberen Übergaben.",
+          "SecPal soll operative Arbeit in einem klaren Zusammenhang abbilden statt Einzelschritte in getrennten Werkzeugen zu verteilen.",
       },
       {
-        name: "Weniger Brüche im Arbeitsalltag",
+        name: "Weniger Medienbrüche im Alltag",
         description:
-          "Statt getrennter Papierprotokolle, Chats und Nebenlisten bündelt SecPal die wesentlichen Abläufe in einem strukturierten System.",
+          "Statt Papier, Chats und Insellösungen bündelt SecPal Informationen und Abläufe in einem strukturierten System.",
       },
       {
-        name: "Nützlich für Teams und Führung",
+        name: "Mehr Überblick im Alltag",
         description:
-          "Ziel sind klarere Statusbilder, weniger Doppelarbeit und bessere Übersicht für Sicherheitskräfte, Objektleitungen, Einsatzleitungen und Disposition.",
+          "Das schafft klarere Statusbilder, weniger Doppelarbeit und bessere Übersicht für Teams, Führung und Disposition.",
       },
     ],
   },
   cta: {
-    headline: "Die Veröffentlichung verfolgen, nicht den Lärm.",
+    headline: "Fortschritt statt Marketing-Lärm.",
     subline:
-      "Auf GitHub ist der aktuelle Stand sichtbar, Kontakt bleibt direkt, und die öffentliche Website bleibt bewusst fokussiert, bis die erste Version bereit ist.",
+      "Auf GitHub ist der aktuelle Stand sichtbar. Für Fragen, Hinweise oder frühen Austausch erreichen Sie SecPal direkt.",
     button: "GitHub ansehen",
-    buttonSecondary: "SecPal kontaktieren",
-    note: "SecPal wird für eine erste öffentliche Veröffentlichung vorbereitet. Bis dahin bleibt diese Website bewusst schlank.",
+    buttonSecondary: "Kontakt aufnehmen",
+    note: "Die öffentliche Website bleibt bewusst fokussiert, solange SecPal noch nicht öffentlich zugänglich ist.",
   },
   footer: {
     rights: "",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -15,8 +15,7 @@ export const de: Translations = {
     badge: "Aus der Praxis · Open Source · Öffentlich entwickelt",
     tagline: "SecPal – A guard’s best friend",
     headline: "Weniger Reibung im Sicherheitsdienst.",
-    subline:
-      "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Übergaben.",
+    subline: "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Abläufe.",
     explanation:
       "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf führen statt sie über Papier, Chats und Insellösungen zu verteilen.",
     highlights: [
@@ -34,7 +33,7 @@ export const de: Translations = {
       "SecPal konzentriert sich auf das, was im Sicherheitsdienst täglich funktionieren muss: klare Abläufe, verlässliche Dokumentation und Übersicht für Teams und Führung.",
     items: [
       {
-        name: "Ein System statt Stückwerk",
+        name: "Ein System statt verteilter Teillösungen",
         description:
           "SecPal bildet operative Arbeit in einem klaren Zusammenhang ab statt Einzelschritte auf getrennte Werkzeuge zu verteilen.",
       },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,7 +4,7 @@
 export const en = {
   nav: {
     progress: "Progress",
-    updates: "Release",
+    updates: "Contact",
     github: "GitHub",
     contact: "Contact",
     followProgress: "Follow progress",
@@ -18,11 +18,11 @@ export const en = {
       "SecPal is being built for security service operations that need day-to-day work to follow one clear operational flow instead of being scattered across paper notes, chats, and disconnected tools.",
     highlights: [
       "Operational work belongs in one connected system instead of isolated tools.",
-      "Information should remain traceable instead of being lost across notes, chats, and isolated tools.",
+      "Information should remain traceable, not disappear into notes, messages, and scattered files.",
       "SecPal is taking shape in public, with a focused scope and clear release steps.",
     ],
     cta: "Follow development on GitHub",
-    ctaSecondary: "See the current state",
+    ctaSecondary: "See the features",
     note: "The public website shows the product direction, legal information, and contact paths. Public access to the app is not open yet.",
   },
   features: {
@@ -36,14 +36,14 @@ export const en = {
           "SecPal is meant to support operational work as one connected whole instead of spreading it across separate tools and partial workflows.",
       },
       {
-        name: "Fewer fragmented tools in daily work",
+        name: "Documented in the workflow, not after the fact",
         description:
-          "Instead of paper logs, chats, and isolated tools, SecPal brings information and workflows together in one structured system.",
+          "Forms, patrol records, and shift handovers are captured in the workflow directly instead of being written up separately on paper or in disconnected apps.",
       },
       {
         name: "Better oversight day to day",
         description:
-          "That creates clearer status, less duplicate work, and better oversight for teams, leadership, and dispatch.",
+          "Clearer status, less duplicate work, and better oversight for teams, leadership, and dispatch.",
       },
     ],
   },
@@ -53,7 +53,7 @@ export const en = {
       "GitHub shows the current state. For questions, feedback, or early contact, you can reach SecPal directly.",
     button: "View GitHub",
     buttonSecondary: "Get in touch",
-    note: "The public website stays intentionally focused while SecPal is not yet publicly accessible.",
+    note: "",
   },
   footer: {
     rights: "",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,7 +15,7 @@ export const en = {
     headline: "Less friction in security operations.",
     subline: "Less paperwork, fewer fragmented tools, clearer workflows.",
     explanation:
-      "SecPal is built for security operations that run on one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
+      "SecPal is built for security operations that follow one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [
       "Operational work belongs in one connected system instead of isolated tools.",
       "Information stays traceable instead of disappearing into notes, messages, and scattered files.",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -28,7 +28,7 @@ export const en = {
   features: {
     headline: "Built around operational reality.",
     subline:
-      "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and better oversight.",
+      "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and visibility for teams and leadership.",
     items: [
       {
         name: "One system instead of patchwork",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,7 +15,7 @@ export const en = {
     headline: "Less friction in security operations.",
     subline: "Less paperwork, fewer fragmented tools, clearer workflows.",
     explanation:
-      "SecPal is built for security operations that follow one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
+      "SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [
       "Operational work belongs in one connected system instead of isolated tools.",
       "Information stays traceable instead of disappearing into notes, messages, and scattered files.",
@@ -31,7 +31,7 @@ export const en = {
       "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and visibility for teams and leadership.",
     items: [
       {
-        name: "One system instead of scattered solutions",
+        name: "One system instead of fragmented tools and partial workflows",
         description:
           "SecPal brings operational work together as one connected whole instead of spreading it across separate tools and partial workflows.",
       },
@@ -41,7 +41,7 @@ export const en = {
           "Forms, patrol records, and shift handovers are captured in the workflow directly instead of being written up separately on paper or in disconnected apps.",
       },
       {
-        name: "No guesswork for supervisors and dispatch",
+        name: "No guesswork for operations leads and dispatch",
         description:
           "Clearer status, less duplicate work, and visibility for teams, leadership, and dispatch.",
       },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,10 +15,10 @@ export const en = {
     headline: "Less friction in security operations.",
     subline: "Less paperwork, fewer fragmented tools, clearer handovers.",
     explanation:
-      "SecPal is being built for security service operations that need day-to-day work to follow one clear operational flow instead of being scattered across paper notes, chats, and disconnected tools.",
+      "SecPal is built for security operations that run on one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [
       "Operational work belongs in one connected system instead of isolated tools.",
-      "Information should remain traceable, not disappear into notes, messages, and scattered files.",
+      "Information stays traceable instead of disappearing into notes, messages, and scattered files.",
       "SecPal is taking shape in public, with a focused scope and clear release steps.",
     ],
     cta: "Follow development on GitHub",
@@ -33,7 +33,7 @@ export const en = {
       {
         name: "One system instead of patchwork",
         description:
-          "SecPal is meant to support operational work as one connected whole instead of spreading it across separate tools and partial workflows.",
+          "SecPal brings operational work together as one connected whole instead of spreading it across separate tools and partial workflows.",
       },
       {
         name: "Documented in the workflow, not after the fact",
@@ -41,7 +41,7 @@ export const en = {
           "Forms, patrol records, and shift handovers are captured in the workflow directly instead of being written up separately on paper or in disconnected apps.",
       },
       {
-        name: "Visibility for teams and leadership",
+        name: "No guesswork for supervisors and dispatch",
         description:
           "Clearer status, less duplicate work, and visibility for teams, leadership, and dispatch.",
       },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -13,7 +13,7 @@ export const en = {
     badge: "From operational practice · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
     headline: "Less friction in security operations.",
-    subline: "Less paperwork, fewer fragmented tools, clearer handovers.",
+    subline: "Less paperwork, fewer fragmented tools, clearer workflows.",
     explanation:
       "SecPal is built for security operations that run on one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [
@@ -31,7 +31,7 @@ export const en = {
       "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and visibility for teams and leadership.",
     items: [
       {
-        name: "One system instead of patchwork",
+        name: "One system instead of scattered solutions",
         description:
           "SecPal brings operational work together as one connected whole instead of spreading it across separate tools and partial workflows.",
       },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -10,50 +10,50 @@ export const en = {
     followProgress: "Follow progress",
   },
   hero: {
-    badge: "Public website · Open source · Built in public",
+    badge: "From operational practice · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
     headline: "Less friction in security operations.",
-    subline: "One clear operational flow from shift planning to handover.",
+    subline: "Less paperwork, fewer fragmented tools, clearer handovers.",
     explanation:
-      "SecPal is being developed for security service operations that need dependable planning, patrol documentation, reporting, and clean handovers without paper-heavy workarounds.",
+      "SecPal is being built for security service operations that need day-to-day work to follow one clear operational flow instead of being scattered across paper notes, chats, and disconnected tools.",
     highlights: [
-      "Shift planning, patrol rounds, reports, and handovers belong in one operational flow.",
-      "Information should stay traceable instead of being scattered across paper notes, chats, and disconnected tools.",
+      "Operational work belongs in one connected system instead of isolated tools.",
+      "Information should remain traceable instead of being lost across notes, chats, and isolated tools.",
       "SecPal is taking shape in public, with a focused scope and clear release steps.",
     ],
     cta: "Follow development on GitHub",
-    ctaSecondary: "See the current scope",
+    ctaSecondary: "See the current state",
     note: "The public website shows the product direction, legal information, and contact paths. Public access to the app is not open yet.",
   },
   features: {
     headline: "Built around operational reality.",
     subline:
-      "The first public release is being shaped around the routine work security teams actually do every day: plan, patrol, report, hand over, and keep oversight.",
+      "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and better oversight.",
     items: [
       {
-        name: "Planning to handover, kept connected",
+        name: "One system instead of patchwork",
         description:
-          "SecPal is being designed as one operational thread: from shift planning and patrol rounds to incident reporting and clean handovers.",
+          "SecPal is meant to support operational work as one connected whole instead of spreading it across separate tools and partial workflows.",
       },
       {
-        name: "Less fragmentation in daily operations",
+        name: "Fewer fragmented tools in daily work",
         description:
-          "Instead of separate paper logs, chats, and ad hoc admin, SecPal brings the essentials into one structured system.",
+          "Instead of paper logs, chats, and isolated tools, SecPal brings information and workflows together in one structured system.",
       },
       {
-        name: "Useful for teams and leadership",
+        name: "Better oversight day to day",
         description:
-          "The goal is clearer status, less duplicate work, and better oversight for guards, supervisors, operations leads, and dispatch.",
+          "That creates clearer status, less duplicate work, and better oversight for teams, leadership, and dispatch.",
       },
     ],
   },
   cta: {
-    headline: "Follow the release, not the noise.",
+    headline: "Progress, not marketing noise.",
     subline:
-      "GitHub shows the current build, contact stays direct, and the public site remains focused until the first release is ready.",
+      "GitHub shows the current state. For questions, feedback, or early contact, you can reach SecPal directly.",
     button: "View GitHub",
-    buttonSecondary: "Contact SecPal",
-    note: "SecPal is being prepared for a first public release. This site stays intentionally lean until that milestone is ready.",
+    buttonSecondary: "Get in touch",
+    note: "The public website stays intentionally focused while SecPal is not yet publicly accessible.",
   },
   footer: {
     rights: "",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,56 +4,56 @@
 export const en = {
   nav: {
     progress: "Progress",
-    updates: "Launch",
+    updates: "Release",
     github: "GitHub",
     contact: "Contact",
     followProgress: "Follow progress",
   },
   hero: {
-    badge: "Work in progress · Open source · Built in public",
+    badge: "Public website · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
-    headline: "Less paperwork for security operations.",
-    subline: "Digital from shift planning to handover.",
+    headline: "Less friction in security operations.",
+    subline: "One clear operational flow from shift planning to handover.",
     explanation:
-      "SecPal is being developed for operational security service work and is intended to reduce day-to-day load for both staff and managers.",
+      "SecPal is being developed for security service operations that need dependable planning, patrol documentation, reporting, and clean handovers without paper-heavy workarounds.",
     highlights: [
-      "Shift planning, patrol rounds, and documentation belong in one coherent workflow.",
-      "Reports and handovers stay traceable instead of getting lost across paper notes and chats.",
-      "SecPal is still work in progress and is being built in public step by step.",
+      "Shift planning, patrol rounds, reports, and handovers belong in one operational flow.",
+      "Information should stay traceable instead of being scattered across paper notes, chats, and disconnected tools.",
+      "SecPal is taking shape in public, with a focused scope and clear release steps.",
     ],
-    cta: "Follow the build on GitHub",
-    ctaSecondary: "See what is taking shape",
-    note: "No public signup yet. SecPal is still under active construction and is currently presented as a focused coming-soon page.",
+    cta: "Follow development on GitHub",
+    ctaSecondary: "See the current scope",
+    note: "The public website shows the product direction, legal information, and contact paths. Public access to the app is not open yet.",
   },
   features: {
-    headline: "Built for day-to-day security service work.",
+    headline: "Built around operational reality.",
     subline:
-      "SecPal is being built around operational work first, with a focus on clearer workflows, better oversight, and meaningful day-to-day relief.",
+      "The first public release is being shaped around the routine work security teams actually do every day: plan, patrol, report, hand over, and keep oversight.",
     items: [
       {
-        name: "From planning to handover",
+        name: "Planning to handover, kept connected",
         description:
-          "SecPal is meant to cover the full operational arc: from shift planning through patrol rounds and reporting to a clean handover between teams.",
+          "SecPal is being designed as one operational thread: from shift planning and patrol rounds to incident reporting and clean handovers.",
       },
       {
-        name: "One operational system instead of scattered admin",
+        name: "Less fragmentation in daily operations",
         description:
-          "Beyond documentation and patrol workflows, SecPal is intended to bring additional operational admin tasks together in one coherent system over time.",
+          "Instead of separate paper logs, chats, and ad hoc admin, SecPal brings the essentials into one structured system.",
       },
       {
-        name: "Relief for staff and leadership",
+        name: "Useful for teams and leadership",
         description:
-          "The focus is on clearer workflows, less operational friction, and meaningful relief for guards, supervisors, operations leads, and dispatch.",
+          "The goal is clearer status, less duplicate work, and better oversight for guards, supervisors, operations leads, and dispatch.",
       },
     ],
   },
   cta: {
-    headline: "Want launch updates instead of marketing noise?",
+    headline: "Follow the release, not the noise.",
     subline:
-      "Follow development on GitHub, reach out directly, and check back as the first release milestone gets closer.",
-    button: "Follow on GitHub",
-    buttonSecondary: "Write to us",
-    note: "SecPal is still under heavy construction. Public onboarding will open once the first launch milestone is ready.",
+      "GitHub shows the current build, contact stays direct, and the public site remains focused until the first release is ready.",
+    button: "View GitHub",
+    buttonSecondary: "Contact SecPal",
+    note: "SecPal is being prepared for a first public release. This site stays intentionally lean until that milestone is ready.",
   },
   footer: {
     rights: "",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,7 +4,7 @@
 export const en = {
   nav: {
     progress: "Progress",
-    updates: "Contact",
+    updates: "Follow",
     github: "GitHub",
     contact: "Contact",
     followProgress: "Follow progress",
@@ -41,9 +41,9 @@ export const en = {
           "Forms, patrol records, and shift handovers are captured in the workflow directly instead of being written up separately on paper or in disconnected apps.",
       },
       {
-        name: "Better oversight day to day",
+        name: "Visibility for teams and leadership",
         description:
-          "Clearer status, less duplicate work, and better oversight for teams, leadership, and dispatch.",
+          "Clearer status, less duplicate work, and visibility for teams, leadership, and dispatch.",
       },
     ],
   },

--- a/src/pages/de/imprint.astro
+++ b/src/pages/de/imprint.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Impressum | SecPal"
-  description="Anbieterkennzeichnung und direkte Kontaktangaben für secpal.app."
+  description="Anbieterangaben und direkte Kontaktwege für secpal.app."
   canonicalPath="/de/imprint/"
   currentPath="/imprint"
   eyebrow="Rechtliches"
   headline="Impressum"
-  intro="Angaben zum Diensteanbieter und direkte Kontaktwege für das Angebot unter secpal.app."
+  intro="Angaben zum Diensteanbieter und direkte Kontaktwege für secpal.app."
   updatedLabel="Stand"
   updatedAt="20. März 2026"
 >

--- a/src/pages/de/imprint.astro
+++ b/src/pages/de/imprint.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Impressum | SecPal"
-  description="Anbieterkennzeichnung und Kontaktangaben für secpal.app."
+  description="Anbieterkennzeichnung und direkte Kontaktangaben für secpal.app."
   canonicalPath="/de/imprint/"
   currentPath="/imprint"
   eyebrow="Rechtliches"
   headline="Impressum"
-  intro="Angaben gemäß § 5 DDG sowie ergänzende Kontaktinformationen für das Angebot unter secpal.app."
+  intro="Angaben zum Diensteanbieter und direkte Kontaktwege für das Angebot unter secpal.app."
   updatedLabel="Stand"
   updatedAt="20. März 2026"
 >

--- a/src/pages/de/imprint.astro
+++ b/src/pages/de/imprint.astro
@@ -14,7 +14,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   headline="Impressum"
   intro="Angaben zum Diensteanbieter und direkte Kontaktwege für secpal.app."
   updatedLabel="Stand"
-  updatedAt="20. März 2026"
+  updatedAt="21. März 2026"
 >
   <section class="space-y-10">
     <div>

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal bringt Planung, Kontrollgänge, Meldungen und Übergaben für Sicherheitsdienste in einen klaren operativen Ablauf."
+  description="SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf organisieren statt sie über Papier, Chats und Insellösungen zu verteilen."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal wird für Sicherheitsdienste entwickelt, die klarere Planung, nachvollziehbare Dokumentation, Meldungen und saubere Übergaben brauchen."
+  description="SecPal bringt Planung, Kontrollgänge, Meldungen und Übergaben für Sicherheitsdienste in einen klaren operativen Ablauf."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -10,8 +10,8 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="SecPal – Bald verfügbar"
-  description="SecPal wird für die operative Arbeit im Sicherheitsdienst entwickelt und soll Mitarbeitende wie Führungskräfte im Alltag spürbar entlasten."
+  title="SecPal – A guard’s best friend"
+  description="SecPal wird für Sicherheitsdienste entwickelt, die klarere Planung, nachvollziehbare Dokumentation, Meldungen und saubere Übergaben brauchen."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf organisieren statt sie über Papier, Chats und Insellösungen zu verteilen."
+  description="SecPal reduziert Zettelwirtschaft, Medienbrüche und Reibung im Sicherheitsdienst mit einem klaren operativen Ablauf."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -6,13 +6,13 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
 <LegalPageShell
   locale="de"
-  title="Datenschutzerklärung | SecPal"
-  description="Datenschutzhinweise für den Besuch von secpal.app und die Kontaktaufnahme mit SecPal."
+  title="Datenschutz | SecPal"
+  description="Datenschutzhinweise für secpal.app und die direkte Kontaktaufnahme mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung informiert darüber, welche personenbezogenen Daten beim Besuch dieser Website verarbeitet werden und zu welchen Zwecken dies geschieht."
+  intro="Diese Datenschutzerklärung beschreibt knapp, welche personenbezogenen Daten beim Besuch von secpal.app oder bei einer direkten Kontaktaufnahme verarbeitet werden."
   updatedLabel="Stand"
   updatedAt="20. März 2026"
 >

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Datenschutz | SecPal"
-  description="Datenschutzhinweise für secpal.app und die direkte Kontaktaufnahme mit SecPal."
+  description="Datenschutzhinweise für secpal.app und direkte E-Mail-Kontakte mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung beschreibt knapp, welche personenbezogenen Daten beim Besuch von secpal.app oder bei einer direkten Kontaktaufnahme verarbeitet werden."
+  intro="Diese Datenschutzerklärung beschreibt knapp, welche personenbezogenen Daten beim Besuch von secpal.app oder bei direktem E-Mail-Kontakt mit SecPal verarbeitet werden."
   updatedLabel="Stand"
   updatedAt="20. März 2026"
 >

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -14,7 +14,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   headline="Datenschutzerklärung"
   intro="Diese Datenschutzerklärung beschreibt knapp, welche personenbezogenen Daten beim Besuch von secpal.app oder bei direktem E-Mail-Kontakt mit SecPal verarbeitet werden."
   updatedLabel="Stand"
-  updatedAt="20. März 2026"
+  updatedAt="21. März 2026"
 >
   <section class="space-y-8">
     <div>

--- a/src/pages/de/security.astro
+++ b/src/pages/de/security.astro
@@ -31,13 +31,13 @@ const faqItems = [
 <LegalPageShell
   locale="de"
   title="Sicherheit | SecPal"
-  description="Meldeweg für Sicherheitslücken und knappe öffentliche Sicherheitsinformationen für secpal.app."
+  description="Meldeweg für Sicherheitslücken und aktueller öffentlicher Sicherheitsstand von secpal.app."
   canonicalPath="/de/security/"
   currentPath="/security"
   xDefaultPath="/security/"
   eyebrow="Vertrauen & Sicherheit"
   headline="Sicherheit"
-  intro="Dieser Bereich nennt den Meldeweg für Sicherheitslücken und beschreibt den aktuell öffentlich belegbaren Sicherheitsstand von secpal.app."
+  intro="Dieser Bereich nennt den Meldeweg für Sicherheitslücken und fasst den derzeit öffentlich belegbaren Sicherheitsstand von secpal.app zusammen."
   updatedLabel="Stand"
   updatedAt="21. März 2026"
 >
@@ -68,9 +68,9 @@ const faqItems = [
       </h2>
       <p class="mt-6">
         SecPal ist noch keine produktive Plattform. Die öffentliche Website ist
-        eine schlanke Landingpage mit Kontakt- und Rechtsinformationen. Diese
-        Seite beschreibt deshalb den Meldeweg für Sicherheitslücken und den
-        aktuell sichtbaren öffentlichen Zustand.
+        bewusst schlank gehalten und enthält vor allem Landinginhalte,
+        Rechtsinformationen und Kontaktwege. Diese Seite beschreibt deshalb den
+        Meldeweg für Sicherheitslücken und den aktuellen öffentlichen Zustand.
       </p>
     </div>
 

--- a/src/pages/de/security.astro
+++ b/src/pages/de/security.astro
@@ -31,13 +31,13 @@ const faqItems = [
 <LegalPageShell
   locale="de"
   title="Sicherheit | SecPal"
-  description="Öffentliche Sicherheitsinformationen und Kontaktweg für Sicherheitsmeldungen bei SecPal."
+  description="Meldeweg für Sicherheitslücken und knappe öffentliche Sicherheitsinformationen für secpal.app."
   canonicalPath="/de/security/"
   currentPath="/security"
   xDefaultPath="/security/"
   eyebrow="Vertrauen & Sicherheit"
   headline="Sicherheit"
-  intro="Dieser Bereich nennt den Meldeweg für Sicherheitslücken und fasst knapp zusammen, was für die öffentliche Website heute bereits gilt."
+  intro="Dieser Bereich nennt den Meldeweg für Sicherheitslücken und beschreibt den aktuell öffentlich belegbaren Sicherheitsstand von secpal.app."
   updatedLabel="Stand"
   updatedAt="21. März 2026"
 >
@@ -68,9 +68,9 @@ const faqItems = [
       </h2>
       <p class="mt-6">
         SecPal ist noch keine produktive Plattform. Die öffentliche Website ist
-        eine schlanke Coming-Soon-Präsenz mit Kontakt- und Rechtsinformationen.
-        Diese Seite beschreibt deshalb bewusst nur den Meldeweg für
-        Sicherheitslücken und den aktuell sichtbaren öffentlichen Zustand.
+        eine schlanke Landingpage mit Kontakt- und Rechtsinformationen. Diese
+        Seite beschreibt deshalb den Meldeweg für Sicherheitslücken und den
+        aktuell sichtbaren öffentlichen Zustand.
       </p>
     </div>
 
@@ -110,7 +110,7 @@ const faqItems = [
           ></span>
           <span
             ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Realistische Kommunikation:</strong
+              >Belastbare Aussagen:</strong
             > Es werden keine unbelegten Sicherheitsversprechen für Funktionen gemacht,
             die noch nicht live sind.</span
           >

--- a/src/pages/en/imprint.astro
+++ b/src/pages/en/imprint.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Legal Notice | SecPal"
-  description="Provider identification and direct contact details for secpal.app."
+  description="Provider information and direct contact routes for secpal.app."
   canonicalPath="/en/imprint/"
   currentPath="/imprint"
   eyebrow="Legal"
   headline="Legal Notice"
-  intro="Provider identification and direct contact routes for the website at secpal.app."
+  intro="Provider information and direct contact routes for secpal.app."
   updatedLabel="Last updated"
   updatedAt="March 20, 2026"
 >

--- a/src/pages/en/imprint.astro
+++ b/src/pages/en/imprint.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Legal Notice | SecPal"
-  description="Provider identification and contact details for secpal.app."
+  description="Provider identification and direct contact details for secpal.app."
   canonicalPath="/en/imprint/"
   currentPath="/imprint"
   eyebrow="Legal"
   headline="Legal Notice"
-  intro="Provider identification and contact information for the website at secpal.app."
+  intro="Provider identification and direct contact routes for the website at secpal.app."
   updatedLabel="Last updated"
   updatedAt="March 20, 2026"
 >

--- a/src/pages/en/imprint.astro
+++ b/src/pages/en/imprint.astro
@@ -14,7 +14,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   headline="Legal Notice"
   intro="Provider information and direct contact routes for secpal.app."
   updatedLabel="Last updated"
-  updatedAt="March 20, 2026"
+  updatedAt="March 21, 2026"
 >
   <section class="space-y-10">
     <div>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal brings planning, patrol documentation, reporting, and handovers into one clear operational flow for security service operations."
+  description="SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools."
   lang="en"
   canonicalPath="/en/"
 >

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal is being built for security service operations that need clearer planning, patrol documentation, reporting, and handovers."
+  description="SecPal brings planning, patrol documentation, reporting, and handovers into one clear operational flow for security service operations."
   lang="en"
   canonicalPath="/en/"
 >

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools."
+  description="SecPal reduces paperwork, fragmented tools, and operational friction in security operations with one clear workflow."
   lang="en"
   canonicalPath="/en/"
 >

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -10,8 +10,8 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="SecPal — Coming Soon"
-  description="SecPal is being developed for operational security service work and is intended to reduce day-to-day load for staff and managers."
+  title="SecPal – A guard’s best friend"
+  description="SecPal is being built for security service operations that need clearer planning, patrol documentation, reporting, and handovers."
   lang="en"
   canonicalPath="/en/"
 >

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -14,7 +14,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   headline="Privacy Notice"
   intro="This privacy notice briefly explains which personal data may be processed when you visit secpal.app or contact SecPal by email."
   updatedLabel="Last updated"
-  updatedAt="March 20, 2026"
+  updatedAt="March 21, 2026"
 >
   <section class="space-y-8">
     <div>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -6,13 +6,13 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
 <LegalPageShell
   locale="en"
-  title="Privacy | SecPal"
-  description="Privacy notice for visitors of secpal.app and for direct contact with SecPal."
+  title="Privacy Notice | SecPal"
+  description="Privacy notice for secpal.app and for direct email contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice explains which personal data may be processed when you visit this website and why that happens."
+  intro="This privacy notice briefly explains which personal data may be processed when you visit secpal.app or contact SecPal directly."
   updatedLabel="Last updated"
   updatedAt="March 20, 2026"
 >

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Privacy Notice | SecPal"
-  description="Privacy notice for secpal.app and for direct email contact with SecPal."
+  description="Privacy notice for secpal.app and direct email contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice briefly explains which personal data may be processed when you visit secpal.app or contact SecPal directly."
+  intro="This privacy notice briefly explains which personal data may be processed when you visit secpal.app or contact SecPal by email."
   updatedLabel="Last updated"
   updatedAt="March 20, 2026"
 >

--- a/src/pages/en/security.astro
+++ b/src/pages/en/security.astro
@@ -23,7 +23,7 @@ const faqItems = [
   {
     question: "Are tracking or advertising services already in use?",
     answer:
-      "Not at the moment. The public landing page intentionally stays lean and currently avoids marketing trackers or ad networks.",
+      "Not at the moment. The public website intentionally stays lean and currently avoids marketing trackers or ad networks.",
   },
 ];
 ---
@@ -31,13 +31,13 @@ const faqItems = [
 <LegalPageShell
   locale="en"
   title="Security | SecPal"
-  description="Security reporting path and concise public security information for secpal.app."
+  description="Security reporting path and current public security posture for secpal.app."
   canonicalPath="/en/security/"
   currentPath="/security"
   xDefaultPath="/security/"
   eyebrow="Trust & Security"
   headline="Security"
-  intro="This page gives the reporting path for security issues and states the currently verifiable public security posture of secpal.app."
+  intro="This page gives the reporting path for security issues and summarizes the currently verifiable public security posture of secpal.app."
   updatedLabel="Last updated"
   updatedAt="March 21, 2026"
 >
@@ -67,9 +67,9 @@ const faqItems = [
       </h2>
       <p class="mt-6">
         SecPal is not yet a live production platform. The public website is a
-        lean landing page with contact and legal information. This page
-        therefore focuses on vulnerability reporting and the currently visible
-        public state.
+        deliberately lean website focused on landing content, legal information,
+        and contact routes. This page therefore focuses on vulnerability
+        reporting and the current public state.
       </p>
     </div>
 

--- a/src/pages/en/security.astro
+++ b/src/pages/en/security.astro
@@ -31,13 +31,13 @@ const faqItems = [
 <LegalPageShell
   locale="en"
   title="Security | SecPal"
-  description="Public security information and vulnerability reporting path for SecPal."
+  description="Security reporting path and concise public security information for secpal.app."
   canonicalPath="/en/security/"
   currentPath="/security"
   xDefaultPath="/security/"
   eyebrow="Trust & Security"
   headline="Security"
-  intro="This page gives the reporting path for security issues and briefly states what already applies to the public website today."
+  intro="This page gives the reporting path for security issues and states the currently verifiable public security posture of secpal.app."
   updatedLabel="Last updated"
   updatedAt="March 21, 2026"
 >
@@ -67,9 +67,9 @@ const faqItems = [
       </h2>
       <p class="mt-6">
         SecPal is not yet a live production platform. The public website is a
-        lean coming-soon presence with contact and legal information. This page
-        therefore focuses only on vulnerability reporting and the currently
-        visible public state.
+        lean landing page with contact and legal information. This page
+        therefore focuses on vulnerability reporting and the currently visible
+        public state.
       </p>
     </div>
 

--- a/src/pages/security/index.astro
+++ b/src/pages/security/index.astro
@@ -48,11 +48,13 @@ import Footer from "../../components/Footer.astro";
         >
           <a
             href="/en/security/"
+            aria-label="Security policy in English"
             class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
             >English</a
           >
           <a
             href="/de/security/"
+            aria-label="Sicherheitsrichtlinie auf Deutsch"
             class="rounded-md border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:border-white/15 dark:text-white dark:hover:bg-white/5"
             >Deutsch</a
           >

--- a/src/pages/security/index.astro
+++ b/src/pages/security/index.astro
@@ -7,8 +7,8 @@ import Footer from "../../components/Footer.astro";
 ---
 
 <Base
-  title="Security | SecPal"
-  description="Language-neutral security entry point for SecPal with links to the English and German security pages."
+  title="Security Reporting | SecPal"
+  description="Neutral entry point for security reporting on secpal.app with links to the English and German security pages."
   lang="en"
   canonicalPath="/security/"
   alternateEnPath="/en/security/"
@@ -32,8 +32,8 @@ import Footer from "../../components/Footer.astro";
           Security Reporting
         </h1>
         <p class="mt-6 text-xl/8 text-gray-600 dark:text-gray-400">
-          This language-neutral entry point links to the public security
-          information for SecPal.
+          This neutral entry point links to the public security guidance for
+          secpal.app.
         </p>
         <p class="mt-4 text-base/7 text-gray-600 dark:text-gray-400">
           For vulnerability reports, contact
@@ -49,12 +49,12 @@ import Footer from "../../components/Footer.astro";
           <a
             href="/en/security/"
             class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-            >English security page</a
+            >English</a
           >
           <a
             href="/de/security/"
             class="rounded-md border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:border-white/15 dark:text-white dark:hover:bg-white/5"
-            >Deutsche Sicherheitsseite</a
+            >Deutsch</a
           >
         </div>
       </div>


### PR DESCRIPTION
# Description

Refines the public SecPal website for release readiness on secpal.app.

The landing page copy is sharper and better aligned across German and English, the legal pages are tone-matched to the rest of the site, and metadata was tightened for publication use.

Tailwind Plus remains the technical basis for the page structure. The Hero, feature grid, CTA panel, footer, and legal-page shells were kept on the existing Tailwind Plus-derived foundation and adjusted only where brand calm, clarity, and consistency improved.

Related issue: none

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Content or documentation update
- [ ] CI, workflow, or governance change

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `./scripts/preflight.sh` (when git metadata is available)

## Checklist

- [x] My change follows the repository conventions and domain policy (`secpal.app` / `secpal.dev` only)
- [x] I performed a self-review of the affected content, code, and workflows
- [x] I updated documentation and `CHANGELOG.md` when required
- [x] My change introduces no new warnings in the validations above

## Notes for review

- Claim unified to `SecPal – A guard’s best friend`
- German and English landing pages now carry the same core message and similar maturity
- Legal pages were tightened for tone and consistency, without expanding scope
- Security wording keeps established technical English where that reads more natural, for example `Responsible Disclosure`
- `x-default` continues to point to `/en/` for landing pages because `/` is a redirect, while `/security/` remains the neutral security entry point

