### PR TITLE
fix: add stable release deployment health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An environment-aware `sitemap.xml` and `robots.txt` endpoint for the public site, so crawler discovery stays correct on both `secpal.app` and `secpal.dev`
 - Environment-aware `security.txt` endpoints for both `/.well-known/security.txt` and `/security.txt`, so disclosure metadata matches the active deployment domain
 - A neutral `/security/` policy URL plus hreflang alternates in `sitemap.xml`, so discovery and multilingual indexing stay aligned
+- A `scripts/release-stable.sh` helper that builds `secpal.app` from an isolated git worktree and publishes versioned stable releases outside the repository checkout
+- A `scripts/rollback-stable.sh` helper that swaps `current` and `previous` stable releases and reloads Nginx after validating the configuration
+- A `scripts/check-stable.sh` helper that verifies the stable release symlinks, static build artifacts, Nginx config, and the live HTTPS redirect behavior for the public domains
+- README guidance for the VPS stable release and rollback workflow, so `secpal.app` can be promoted from `origin/main` without serving directly from the repository checkout
 
 ### Fixed
 
+- German landing and legal pages now point social preview metadata at a dedicated German Open Graph image instead of reusing the English preview card
+- Social previews now use a dedicated `1200x630` Open Graph image and larger copied logo assets from the frontend repository, improving previews in WhatsApp, Signal, LinkedIn, and similar clients
+- Shared links now expose Open Graph and Twitter Card metadata on the localized pages, so preview crawlers that follow the root redirect still land on localized preview metadata
 - Landing page and legal pages now use tighter, aligned English and German copy, a release-ready claim, and more precise `title` and description metadata
 - Landing page wording now emphasizes less paperwork, fewer media breaks, and clearer handovers while reducing repeated phrasing across hero, features, CTA, and legal metadata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed (stable release health checks)
 
 - `scripts/check-stable.sh` no longer fails the nginx binary availability check when `--skip-nginx-validation` is passed, so the script works correctly in restricted shells where the nginx binary is not accessible
+- `release-stable.sh` and `rollback-stable.sh` now use `sudo -n` instead of plain `sudo` so they fail with a clear error message instead of blocking on an interactive password prompt in non-interactive environments
+- `release-stable.sh` cleanup trap now also removes the temporary worktree directory with `rm -rf` so `/tmp` is cleaned up even when `git worktree remove` fails
+- `release-stable.sh` and `rollback-stable.sh` now resolve the nginx binary via `NGINX_BIN` (checking PATH and `/usr/sbin/nginx`) and verify `systemctl` is available before attempting to reload nginx, so failures are actionable rather than "command not found"
+- `check-stable.sh` curl calls now include `--connect-timeout 10 --max-time 30` to prevent indefinite hangs in degraded network or TLS scenarios, and fail with a clear error message on curl errors
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `scripts/check-stable.sh` helper that verifies the stable release symlinks, static build artifacts, Nginx config, and the live HTTPS redirect behavior for the public domains
 - README guidance for the VPS stable release and rollback workflow, so `secpal.app` can be promoted from `origin/main` without serving directly from the repository checkout
 
+### Fixed (stable release health checks)
+
+- `scripts/check-stable.sh` no longer fails the nginx binary availability check when `--skip-nginx-validation` is passed, so the script works correctly in restricted shells where the nginx binary is not accessible
+
 ### Fixed
 
 - German landing and legal pages now point social preview metadata at a dedicated German Open Graph image instead of reusing the English preview card

--- a/README.md
+++ b/README.md
@@ -65,6 +65,57 @@ Run the preflight script before every push:
 ./scripts/preflight.sh
 ```
 
+## Stable release workflow
+
+`dev.secpal.app` can continue to use the live repository checkout. `secpal.app`
+is deployed separately from `/home/secpal/www/secpal.app/current`, so the public
+site is independent from the working tree on the VPS.
+
+### Promote a stable release
+
+Build and publish the latest clean `main` state:
+
+```bash
+bash ./scripts/release-stable.sh origin/main
+```
+
+Build and publish a specific tag or commit:
+
+```bash
+bash ./scripts/release-stable.sh <git-ref>
+```
+
+The script builds from an isolated temporary git worktree, writes a new release
+under `/home/secpal/www/secpal.app/releases/`, updates `current`, preserves the
+old target in `previous`, validates Nginx, and reloads it.
+
+### Roll back the public site
+
+```bash
+bash ./scripts/rollback-stable.sh
+```
+
+The rollback helper swaps `current` and `previous`, validates Nginx, and reloads
+the web server.
+
+### Verify the public deployment
+
+```bash
+bash ./scripts/check-stable.sh
+```
+
+The health-check helper verifies the `current` and `previous` release links,
+checks that the localized static files and `RELEASE.txt` exist, validates the
+Nginx configuration, and confirms that `secpal.app`, `www.secpal.app`,
+`secpal.dev`, and `www.secpal.dev` behave as expected over HTTPS.
+
+If the shell session cannot read the live TLS material and also cannot use
+passwordless `sudo`, you can skip only the `nginx -t` step explicitly:
+
+```bash
+bash ./scripts/check-stable.sh --skip-nginx-validation
+```
+
 ## Project structure
 
 ```text

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -91,7 +91,8 @@ assert_redirect() {
     local status_code
     local redirect_url
 
-    response="$(curl --silent --show-error --output /dev/null --max-redirs 0 --write-out '%{http_code} %{redirect_url}' "$source_url")"
+    response="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --output /dev/null --max-redirs 0 --write-out '%{http_code} %{redirect_url}' "$source_url")" \
+        || fail "curl failed for $source_url: connection or timeout error"
     status_code="${response%% *}"
     redirect_url="${response#* }"
 
@@ -107,7 +108,8 @@ assert_final_destination() {
     local status_code
     local final_url
 
-    response="$(curl --silent --show-error --location --output /dev/null --max-redirs 10 --write-out '%{http_code} %{url_effective}' "$source_url")"
+    response="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --location --output /dev/null --max-redirs 10 --write-out '%{http_code} %{url_effective}' "$source_url")" \
+        || fail "curl failed for $source_url: connection or timeout error"
     status_code="${response%% *}"
     final_url="${response#* }"
 
@@ -124,7 +126,8 @@ assert_http_ok() {
     local url="$1"
     local status_code
 
-    status_code="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$url")"
+    status_code="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --location --output /dev/null --write-out '%{http_code}' "$url")" \
+        || fail "curl failed for $url: connection or timeout error"
     [[ "$status_code" == "200" ]] || fail "Expected HTTP 200 for $url, got $status_code"
 
     log "Verified HTTP 200: $url"

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+DEFAULT_DEPLOY_ROOT="/home/secpal/www/secpal.app"
+PRIMARY_URL="${SECPAL_PRIMARY_URL:-https://secpal.app}"
+PRIMARY_WWW_URL="${SECPAL_PRIMARY_WWW_URL:-https://www.secpal.app}"
+DEV_URL="${SECPAL_DEV_URL:-https://secpal.dev}"
+DEV_WWW_URL="${SECPAL_DEV_WWW_URL:-https://www.secpal.dev}"
+SKIP_NGINX_VALIDATION="${SECPAL_SKIP_NGINX_VALIDATION:-0}"
+NGINX_BIN="${NGINX_BIN:-$(command -v nginx 2>/dev/null || true)}"
+
+if [[ -z "$NGINX_BIN" && -x "/usr/sbin/nginx" ]]; then
+    NGINX_BIN="/usr/sbin/nginx"
+fi
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/check-stable.sh [--skip-nginx-validation] [deploy-root]
+
+Verifies the stable secpal.app deployment layout, validates Nginx, and checks
+the live HTTPS and redirect behavior of the public domains.
+
+Arguments:
+  [deploy-root]  Optional deployment root (default: /home/secpal/www/secpal.app)
+
+Options:
+    --skip-nginx-validation  Skip `nginx -t`
+
+Environment overrides:
+  SECPAL_PRIMARY_URL        Default: https://secpal.app
+  SECPAL_PRIMARY_WWW_URL    Default: https://www.secpal.app
+  SECPAL_DEV_URL            Default: https://secpal.dev
+  SECPAL_DEV_WWW_URL        Default: https://www.secpal.dev
+    SECPAL_SKIP_NGINX_VALIDATION  Set to 1 to skip `nginx -t`
+
+Examples:
+  ./scripts/check-stable.sh
+    ./scripts/check-stable.sh --skip-nginx-validation
+  ./scripts/check-stable.sh /srv/www/secpal.app
+EOF
+}
+
+log() {
+    printf '[check-stable] %s\n' "$1"
+}
+
+fail() {
+    printf '[check-stable] ERROR: %s\n' "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+run_privileged() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "$@"
+        return
+    fi
+
+    require_command sudo
+    sudo "$@"
+}
+
+assert_symlink() {
+    local path="$1"
+
+    [[ -L "$path" ]] || fail "Expected symlink is missing: $path"
+}
+
+assert_directory() {
+    local path="$1"
+
+    [[ -d "$path" ]] || fail "Expected directory is missing: $path"
+}
+
+assert_file() {
+    local path="$1"
+
+    [[ -f "$path" ]] || fail "Expected file is missing: $path"
+}
+
+assert_redirect() {
+    local source_url="$1"
+    local expected_location="$2"
+    local response
+    local status_code
+    local redirect_url
+
+    response="$(curl --silent --show-error --output /dev/null --max-redirs 0 --write-out '%{http_code} %{redirect_url}' "$source_url")"
+    status_code="${response%% *}"
+    redirect_url="${response#* }"
+
+    [[ "$status_code" =~ ^30[1278]$ ]] || fail "Expected redirect from $source_url, got HTTP $status_code"
+    [[ "$redirect_url" == "$expected_location" ]] || fail "Unexpected redirect from $source_url: $redirect_url"
+
+    log "Verified redirect: $source_url -> $redirect_url"
+}
+
+assert_final_destination() {
+    local source_url="$1"
+    local response
+    local status_code
+    local final_url
+
+    response="$(curl --silent --show-error --location --output /dev/null --max-redirs 10 --write-out '%{http_code} %{url_effective}' "$source_url")"
+    status_code="${response%% *}"
+    final_url="${response#* }"
+
+    [[ "$status_code" == "200" ]] || fail "Expected HTTP 200 from $source_url, got $status_code"
+
+    if [[ "$final_url" != "$PRIMARY_URL/" && "$final_url" != "$PRIMARY_URL/en/" && "$final_url" != "$PRIMARY_URL/de/" ]]; then
+        fail "Unexpected final URL for $source_url: $final_url"
+    fi
+
+    log "Verified live page: $source_url -> $final_url"
+}
+
+assert_http_ok() {
+    local url="$1"
+    local status_code
+
+    status_code="$(curl --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$url")"
+    [[ "$status_code" == "200" ]] || fail "Expected HTTP 200 for $url, got $status_code"
+
+    log "Verified HTTP 200: $url"
+}
+
+validate_nginx_config() {
+    if [[ "$SKIP_NGINX_VALIDATION" == "1" ]]; then
+        log "Skipping nginx validation because SECPAL_SKIP_NGINX_VALIDATION=1"
+        return
+    fi
+
+    if "$NGINX_BIN" -t >/dev/null; then
+        return
+    fi
+
+    run_privileged "$NGINX_BIN" -t >/dev/null
+}
+
+DEPLOY_ROOT="$DEFAULT_DEPLOY_ROOT"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --skip-nginx-validation)
+            SKIP_NGINX_VALIDATION="1"
+            shift
+            ;;
+        *)
+            if [[ "$DEPLOY_ROOT" != "$DEFAULT_DEPLOY_ROOT" ]]; then
+                usage
+                exit 1
+            fi
+
+            DEPLOY_ROOT="$1"
+            shift
+            ;;
+    esac
+done
+
+CURRENT_LINK="$DEPLOY_ROOT/current"
+PREVIOUS_LINK="$DEPLOY_ROOT/previous"
+
+require_command curl
+require_command readlink
+[[ -n "$NGINX_BIN" && -x "$NGINX_BIN" ]] || fail "Required command not found: nginx"
+
+assert_symlink "$CURRENT_LINK"
+assert_symlink "$PREVIOUS_LINK"
+
+CURRENT_TARGET="$(readlink -f "$CURRENT_LINK")"
+PREVIOUS_TARGET="$(readlink -f "$PREVIOUS_LINK")"
+CURRENT_RELEASE_DIR="$(cd "$CURRENT_TARGET/.." && pwd)"
+
+assert_directory "$CURRENT_TARGET"
+assert_directory "$PREVIOUS_TARGET"
+assert_file "$CURRENT_TARGET/index.html"
+assert_file "$CURRENT_TARGET/en/index.html"
+assert_file "$CURRENT_TARGET/de/index.html"
+assert_file "$CURRENT_RELEASE_DIR/RELEASE.txt"
+
+log "Current release: $CURRENT_TARGET"
+log "Previous release: $PREVIOUS_TARGET"
+log "Validating nginx configuration"
+validate_nginx_config
+
+assert_final_destination "$PRIMARY_URL/"
+assert_http_ok "$PRIMARY_URL/en/"
+assert_http_ok "$PRIMARY_URL/de/"
+assert_redirect "$PRIMARY_WWW_URL/en/" "$PRIMARY_URL/en/"
+assert_redirect "$DEV_URL/en/" "$PRIMARY_URL/en/"
+assert_redirect "$DEV_WWW_URL/en/" "$PRIMARY_URL/en/"
+
+log "Stable deployment health check passed"

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -172,7 +172,9 @@ PREVIOUS_LINK="$DEPLOY_ROOT/previous"
 
 require_command curl
 require_command readlink
-[[ -n "$NGINX_BIN" && -x "$NGINX_BIN" ]] || fail "Required command not found: nginx"
+if [[ "$SKIP_NGINX_VALIDATION" != "1" ]]; then
+    [[ -n "$NGINX_BIN" && -x "$NGINX_BIN" ]] || fail "Required command not found: nginx"
+fi
 
 assert_symlink "$CURRENT_LINK"
 assert_symlink "$PREVIOUS_LINK"

--- a/scripts/release-stable.sh
+++ b/scripts/release-stable.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_DEPLOY_ROOT="/home/secpal/www/secpal.app"
+SITE_URL="https://secpal.app"
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/release-stable.sh <git-ref> [deploy-root]
+
+Builds secpal.app from the given git ref in an isolated temporary worktree and
+publishes the resulting dist/ directory into a release folder outside the repo.
+
+Arguments:
+  <git-ref>      Tag, branch, or commit to release
+  [deploy-root]  Optional deployment root (default: /home/secpal/www/secpal.app)
+
+Examples:
+  ./scripts/release-stable.sh main
+  ./scripts/release-stable.sh v0.0.1
+  ./scripts/release-stable.sh 1a2b3c4 /srv/www/secpal.app
+EOF
+}
+
+log() {
+    printf '[release-stable] %s\n' "$1"
+}
+
+fail() {
+    printf '[release-stable] ERROR: %s\n' "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+run_privileged() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "$@"
+        return
+    fi
+
+    require_command sudo
+    sudo "$@"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 || $# -gt 2 ]]; then
+    usage
+    if [[ $# -lt 1 || $# -gt 2 ]]; then
+        exit 1
+    fi
+    exit 0
+fi
+
+GIT_REF="$1"
+DEPLOY_ROOT="${2:-$DEFAULT_DEPLOY_ROOT}"
+RELEASES_DIR="$DEPLOY_ROOT/releases"
+CURRENT_LINK="$DEPLOY_ROOT/current"
+PREVIOUS_LINK="$DEPLOY_ROOT/previous"
+WORKTREE_DIR=""
+
+require_command git
+require_command npm
+require_command rsync
+require_command readlink
+
+cd "$REPO_ROOT"
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "Repository root is not a git work tree: $REPO_ROOT"
+git rev-parse --verify "$GIT_REF^{commit}" >/dev/null 2>&1 || fail "Unknown git ref: $GIT_REF"
+
+cleanup() {
+    if [[ -n "$WORKTREE_DIR" && -d "$WORKTREE_DIR" ]]; then
+        cd "$REPO_ROOT"
+        git worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+    fi
+}
+
+trap cleanup EXIT
+
+mkdir -p "$RELEASES_DIR"
+
+WORKTREE_DIR="$(mktemp -d /tmp/secpal-app-release.XXXXXX)"
+log "Creating isolated build worktree for $GIT_REF"
+git worktree add --detach "$WORKTREE_DIR" "$GIT_REF" >/dev/null
+
+cd "$WORKTREE_DIR"
+
+COMMIT_SHA="$(git rev-parse --short HEAD)"
+RELEASE_ID="$(date +%F_%H%M%S)_$COMMIT_SHA"
+RELEASE_DIR="$RELEASES_DIR/$RELEASE_ID"
+TARGET_DIST_DIR="$RELEASE_DIR/dist"
+
+log "Installing dependencies"
+npm ci
+
+log "Building release for $SITE_URL"
+SECPAL_SITE_URL="$SITE_URL" npm run build
+
+log "Publishing release to $TARGET_DIST_DIR"
+mkdir -p "$TARGET_DIST_DIR"
+rsync -a --delete "$WORKTREE_DIR/dist/" "$TARGET_DIST_DIR/"
+
+cat > "$RELEASE_DIR/RELEASE.txt" <<EOF
+Release: $RELEASE_ID
+Git ref: $GIT_REF
+Commit: $(git rev-parse HEAD)
+Built at: $(date --iso-8601=seconds)
+Site URL: $SITE_URL
+Source repo: $REPO_ROOT
+EOF
+
+if [[ -L "$CURRENT_LINK" ]]; then
+    CURRENT_TARGET="$(readlink -f "$CURRENT_LINK")"
+    ln -sfn "$CURRENT_TARGET" "$PREVIOUS_LINK"
+    log "Updated previous release link -> $CURRENT_TARGET"
+fi
+
+ln -sfn "$TARGET_DIST_DIR" "$CURRENT_LINK"
+log "Updated current release link -> $TARGET_DIST_DIR"
+
+log "Validating nginx configuration"
+run_privileged nginx -t
+
+log "Reloading nginx"
+run_privileged systemctl reload nginx
+
+log "Release complete"
+printf '\n'
+printf 'Release ID: %s\n' "$RELEASE_ID"
+printf 'Current:    %s\n' "$TARGET_DIST_DIR"
+if [[ -L "$PREVIOUS_LINK" ]]; then
+    printf 'Previous:   %s\n' "$(readlink -f "$PREVIOUS_LINK")"
+fi

--- a/scripts/release-stable.sh
+++ b/scripts/release-stable.sh
@@ -47,7 +47,9 @@ run_privileged() {
     fi
 
     require_command sudo
-    sudo "$@"
+    if ! sudo -n "$@"; then
+        fail "Unable to run privileged command (passwordless sudo required). Command: $*"
+    fi
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 1 || $# -gt 2 ]]; then
@@ -79,6 +81,7 @@ cleanup() {
     if [[ -n "$WORKTREE_DIR" && -d "$WORKTREE_DIR" ]]; then
         cd "$REPO_ROOT"
         git worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+        rm -rf "$WORKTREE_DIR" >/dev/null 2>&1 || true
     fi
 }
 
@@ -125,8 +128,15 @@ fi
 ln -sfn "$TARGET_DIST_DIR" "$CURRENT_LINK"
 log "Updated current release link -> $TARGET_DIST_DIR"
 
+NGINX_BIN="${NGINX_BIN:-$(command -v nginx 2>/dev/null || true)}"
+if [[ -z "$NGINX_BIN" && -x "/usr/sbin/nginx" ]]; then
+    NGINX_BIN="/usr/sbin/nginx"
+fi
+[[ -n "$NGINX_BIN" && -x "$NGINX_BIN" ]] || fail "Required command not found: nginx"
+command -v systemctl >/dev/null 2>&1 || fail "Required command not found: systemctl"
+
 log "Validating nginx configuration"
-run_privileged nginx -t
+run_privileged "$NGINX_BIN" -t
 
 log "Reloading nginx"
 run_privileged systemctl reload nginx

--- a/scripts/rollback-stable.sh
+++ b/scripts/rollback-stable.sh
@@ -42,7 +42,9 @@ run_privileged() {
     fi
 
     require_command sudo
-    sudo "$@"
+    if ! sudo -n "$@"; then
+        fail "Unable to run privileged command (passwordless sudo required). Command: $*"
+    fi
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 1 ]]; then
@@ -73,8 +75,15 @@ log "Rolling back current release to $PREVIOUS_TARGET"
 ln -sfn "$CURRENT_TARGET" "$PREVIOUS_LINK"
 ln -sfn "$PREVIOUS_TARGET" "$CURRENT_LINK"
 
+NGINX_BIN="${NGINX_BIN:-$(command -v nginx 2>/dev/null || true)}"
+if [[ -z "$NGINX_BIN" && -x "/usr/sbin/nginx" ]]; then
+    NGINX_BIN="/usr/sbin/nginx"
+fi
+[[ -n "$NGINX_BIN" && -x "$NGINX_BIN" ]] || fail "Required command not found: nginx"
+command -v systemctl >/dev/null 2>&1 || fail "Required command not found: systemctl"
+
 log "Validating nginx configuration"
-run_privileged nginx -t
+run_privileged "$NGINX_BIN" -t
 
 log "Reloading nginx"
 run_privileged systemctl reload nginx

--- a/scripts/rollback-stable.sh
+++ b/scripts/rollback-stable.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+DEFAULT_DEPLOY_ROOT="/home/secpal/www/secpal.app"
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/rollback-stable.sh [deploy-root]
+
+Switches secpal.app back to the release referenced by the previous symlink and
+reloads Nginx after validating the configuration.
+
+Arguments:
+  [deploy-root]  Optional deployment root (default: /home/secpal/www/secpal.app)
+
+Examples:
+  ./scripts/rollback-stable.sh
+  ./scripts/rollback-stable.sh /srv/www/secpal.app
+EOF
+}
+
+log() {
+    printf '[rollback-stable] %s\n' "$1"
+}
+
+fail() {
+    printf '[rollback-stable] ERROR: %s\n' "$1" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+run_privileged() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "$@"
+        return
+    fi
+
+    require_command sudo
+    sudo "$@"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -gt 1 ]]; then
+    usage
+    if [[ $# -gt 1 ]]; then
+        exit 1
+    fi
+    exit 0
+fi
+
+DEPLOY_ROOT="${1:-$DEFAULT_DEPLOY_ROOT}"
+CURRENT_LINK="$DEPLOY_ROOT/current"
+PREVIOUS_LINK="$DEPLOY_ROOT/previous"
+
+require_command readlink
+require_command ln
+
+[[ -L "$CURRENT_LINK" ]] || fail "Current release link does not exist: $CURRENT_LINK"
+[[ -L "$PREVIOUS_LINK" ]] || fail "Previous release link does not exist: $PREVIOUS_LINK"
+
+CURRENT_TARGET="$(readlink -f "$CURRENT_LINK")"
+PREVIOUS_TARGET="$(readlink -f "$PREVIOUS_LINK")"
+
+[[ -d "$CURRENT_TARGET" ]] || fail "Current release target is missing: $CURRENT_TARGET"
+[[ -d "$PREVIOUS_TARGET" ]] || fail "Previous release target is missing: $PREVIOUS_TARGET"
+
+log "Rolling back current release to $PREVIOUS_TARGET"
+ln -sfn "$CURRENT_TARGET" "$PREVIOUS_LINK"
+ln -sfn "$PREVIOUS_TARGET" "$CURRENT_LINK"
+
+log "Validating nginx configuration"
+run_privileged nginx -t
+
+log "Reloading nginx"
+run_privileged systemctl reload nginx
+
+log "Rollback complete"
+printf '\n'
+printf 'Current:  %s\n' "$(readlink -f "$CURRENT_LINK")"
+printf 'Previous: %s\n' "$(readlink -f "$PREVIOUS_LINK")"


### PR DESCRIPTION
# Description

Adds a stable release workflow for `secpal.app` that is independent from the live repository checkout on the VPS.

This change adds:
- `scripts/release-stable.sh` to build a chosen git ref in an isolated worktree and publish versioned releases under `/home/secpal/www/secpal.app/releases/`
- `scripts/rollback-stable.sh` to swap `current` and `previous`
- `scripts/check-stable.sh` to verify release symlinks, static artifacts, and live HTTPS behavior
- README and `CHANGELOG.md` updates for the stable release, rollback, and health-check workflow

Related issue: none

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Content or documentation update
- [ ] CI, workflow, or governance change

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `./scripts/preflight.sh` (when git metadata is available)

Additional validation:
- `bash -n scripts/release-stable.sh`
- `bash -n scripts/rollback-stable.sh`
- `bash -n scripts/check-stable.sh`
- `bash ./scripts/check-stable.sh --skip-nginx-validation`

## Checklist

- [x] My change follows the repository conventions and domain policy (`secpal.app` / `secpal.dev` only)
- [x] I performed a self-review of the affected content, code, and workflows
- [x] I updated documentation and `CHANGELOG.md` when required
- [x] My change introduces no new warnings in the validations above

## Self-review

Reviewed the workflow end to end against the actual VPS setup:
- `secpal.app` is served statically from `/home/secpal/www/secpal.app/current`, outside the repo checkout
- the release script preserves the previous target before switching `current`
- the rollback script only swaps symlinks and reloads nginx after validation
- the health-check script verifies the live public URLs and documents the explicit nginx-skip fallback for restricted non-interactive shells where TLS key material is unreadable without sudo

## Fix (commit 849c4bf)

`check-stable.sh` unconditionally required the nginx binary to be present and executable, even when `--skip-nginx-validation` was passed. The nginx availability guard now respects the skip flag, matching the behaviour of the `validate_nginx_config` function.

Residual note:
- `astro build` still emits the existing upstream Vite warning about unused remote helper imports; no new warnings were introduced by this change set