### PR TITLE
fix(landing): document root locale redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CodeQL analysis for the landing-page repository and corresponding branch protection hardening
+- HTTP-level locale redirect guidance for `/`, keeping `secpal.app` static while the web server routes German browsers to `/de/` and all other requests to `/en/`
 - Initial landing page with Astro 5, Tailwind CSS v4, and Tailwind Plus UI Blocks
 - Multilingual routing (`/en/`, `/de/`) with full English and German translations
 - Dark mode support (class-based, `localStorage`-persisted, flash-free)
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed stale SSR locale-routing files from the landing-page worktree so the static Astro build for `dev.secpal.app` is consistent again
 - German landing and legal pages now point social preview metadata at a dedicated German Open Graph image instead of reusing the English preview card
 - Social previews now use a dedicated `1200x630` Open Graph image and larger copied logo assets from the frontend repository, improving previews in WhatsApp, Signal, LinkedIn, and similar clients
 - Shared links now expose Open Graph and Twitter Card metadata on the localized pages, so preview crawlers that follow the root redirect still land on localized preview metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed stale SSR locale-routing files from the landing-page worktree so the static Astro build for `dev.secpal.app` is consistent again
 - German landing and legal pages now point social preview metadata at a dedicated German Open Graph image instead of reusing the English preview card
 - Social previews now use a dedicated `1200x630` Open Graph image and larger copied logo assets from the frontend repository, improving previews in WhatsApp, Signal, LinkedIn, and similar clients
 - Shared links now expose Open Graph and Twitter Card metadata on the localized pages, so preview crawlers that follow the root redirect still land on localized preview metadata

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Built with [Astro](https://astro.build), [Tailwind CSS v4](https://tailwindcss.c
 ## Features
 
 - **Multilingual** — English and German (`/en/`, `/de/`)
+- **HTTP-level root locale redirect** — Nginx sends `/` to `/de/` for German browsers and `/en/` otherwise
 - **Built in public** — product progress and release readiness instead of premature app onboarding
 - **Dark mode** — class-based, persisted in `localStorage`, flash-free
 - **Static** — minimal client-side JS with Astro-first rendering
@@ -107,7 +108,8 @@ bash ./scripts/check-stable.sh
 The health-check helper verifies the `current` and `previous` release links,
 checks that the localized static files and `RELEASE.txt` exist, validates the
 Nginx configuration, and confirms that `secpal.app`, `www.secpal.app`,
-`secpal.dev`, and `www.secpal.dev` behave as expected over HTTPS.
+`secpal.dev`, and `www.secpal.dev` behave as expected over HTTPS, including the
+language-based root redirect on `secpal.app`.
 
 If the shell session cannot read the live TLS material and also cannot use
 passwordless `sudo`, you can skip only the `nginx -t` step explicitly:
@@ -134,6 +136,11 @@ public/
 ## i18n
 
 All user-facing strings live in `src/i18n/en.ts` and `src/i18n/de.ts`. Both files export the same shape defined by the `Translations` type. Add a new locale by creating a new file and extending the locales array in `astro.config.mjs`.
+
+The root route `/` is redirected at the web-server layer. `Accept-Language`
+requests preferring German resolve to `/de/`, while all other requests fall
+back to `/en/`. The Astro site itself remains a static build with localized
+pages under `/en/` and `/de/`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ public/
 
 All user-facing strings live in `src/i18n/en.ts` and `src/i18n/de.ts`. Both files export the same shape defined by the `Translations` type. Add a new locale by creating a new file and extending the locales array in `astro.config.mjs`.
 
-The root route `/` is redirected at the web-server layer. `Accept-Language`
-requests preferring German resolve to `/de/`, while all other requests fall
-back to `/en/`. The Astro site itself remains a static build with localized
-pages under `/en/` and `/de/`.
+In production, the root route `/` is redirected at the web-server (Nginx) layer. `Accept-Language`
+requests preferring German resolve to `/de/`, while all other requests fall back to `/en/`. For
+static builds and local development, `src/pages/index.astro` redirects `/` to `/en/` directly.
+Localized pages are always served under `/en/` and `/de/`.
 
 ## License
 

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -121,26 +121,6 @@ assert_locale_redirect() {
     log "Verified locale redirect: $source_url [$accept_language] -> $redirect_url"
 }
 
-assert_final_destination() {
-    local source_url="$1"
-    local response
-    local status_code
-    local final_url
-
-    response="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --location --output /dev/null --max-redirs 10 --write-out '%{http_code} %{url_effective}' "$source_url")" \
-        || fail "curl failed for $source_url: connection or timeout error"
-    status_code="${response%% *}"
-    final_url="${response#* }"
-
-    [[ "$status_code" == "200" ]] || fail "Expected HTTP 200 from $source_url, got $status_code"
-
-    if [[ "$final_url" != "$PRIMARY_URL/" && "$final_url" != "$PRIMARY_URL/en/" && "$final_url" != "$PRIMARY_URL/de/" ]]; then
-        fail "Unexpected final URL for $source_url: $final_url"
-    fi
-
-    log "Verified live page: $source_url -> $final_url"
-}
-
 assert_http_ok() {
     local url="$1"
     local status_code

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -102,6 +102,25 @@ assert_redirect() {
     log "Verified redirect: $source_url -> $redirect_url"
 }
 
+assert_locale_redirect() {
+    local source_url="$1"
+    local accept_language="$2"
+    local expected_location="$3"
+    local response
+    local status_code
+    local redirect_url
+
+    response="$(curl --silent --show-error --connect-timeout 10 --max-time 30 --output /dev/null --max-redirs 0 --header "Accept-Language: $accept_language" --write-out '%{http_code} %{redirect_url}' "$source_url")" \
+        || fail "curl failed for $source_url with Accept-Language '$accept_language': connection or timeout error"
+    status_code="${response%% *}"
+    redirect_url="${response#* }"
+
+    [[ "$status_code" =~ ^30[1278]$ ]] || fail "Expected locale redirect from $source_url, got HTTP $status_code"
+    [[ "$redirect_url" == "$expected_location" ]] || fail "Unexpected locale redirect from $source_url for '$accept_language': $redirect_url"
+
+    log "Verified locale redirect: $source_url [$accept_language] -> $redirect_url"
+}
+
 assert_final_destination() {
     local source_url="$1"
     local response
@@ -198,7 +217,8 @@ log "Previous release: $PREVIOUS_TARGET"
 log "Validating nginx configuration"
 validate_nginx_config
 
-assert_final_destination "$PRIMARY_URL/"
+assert_locale_redirect "$PRIMARY_URL/" "de-DE,de;q=0.9,en;q=0.8" "$PRIMARY_URL/de/"
+assert_locale_redirect "$PRIMARY_URL/" "en-US,en;q=0.9,de;q=0.8" "$PRIMARY_URL/en/"
 assert_http_ok "$PRIMARY_URL/en/"
 assert_http_ok "$PRIMARY_URL/de/"
 assert_redirect "$PRIMARY_WWW_URL/en/" "$PRIMARY_URL/en/"


### PR DESCRIPTION
# Description

Document the HTTP-level root locale redirect for the static landing page and update the stable deployment check so it verifies the new `Accept-Language` behavior on `secpal.app`.

Related issue: none

Context: the live Nginx vhost changes for `secpal.app` and `dev.secpal.app` were applied directly on the VPS because those files are outside this repository. This PR covers the repository-side documentation and verification updates only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Content or documentation update
- [ ] CI, workflow, or governance change

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `./scripts/preflight.sh` (when git metadata is available)

Additional verification:
- Confirmed live HTTPS behavior after Nginx reload:
  - `secpal.app /` -> `307 /de/` for German-first `Accept-Language`
  - `secpal.app /` -> `307 /en/` for English-first `Accept-Language`
  - `dev.secpal.app /` -> `307 /de/` or `/en/` with the same rule
  - direct `/de/` and `/en/` requests stay `200`
  - `www.secpal.app` still `301` redirects to the apex domain

## Checklist

- [x] My change follows the repository conventions and domain policy (`secpal.app` / `secpal.dev` only)
- [x] I performed a self-review of the affected content, code, and workflows
- [x] I updated documentation and `CHANGELOG.md` when required
- [x] My change introduces no new warnings in the validations above
