### PR TITLE
fix(build): suppress Astro internal helper warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `astro.config.mjs` now filters Astro's known false-positive `UNUSED_EXTERNAL_IMPORT` warning for `@astrojs/internal-helpers/remote`, and the site now tracks `astro@6.0.8`, so local builds finish without upstream warning noise
+
 ### Changed
 
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,24 +13,24 @@ const defaultWarn = viteLogger.warn.bind(viteLogger);
 const defaultWarnOnce = viteLogger.warnOnce.bind(viteLogger);
 
 function isKnownAstroWarning(message) {
-  return typeof message === "string" && message.includes(astroInternalHelpersWarning);
+  return (
+    typeof message === "string" && message.includes(astroInternalHelpersWarning)
+  );
 }
 
-viteLogger.warn = (message, options) => {
-  if (isKnownAstroWarning(message)) {
-    return;
-  }
+function createFilteredWarn(defaultWarnFn) {
+  return (message, options) => {
+    if (isKnownAstroWarning(message)) {
+      return;
+    }
 
-  defaultWarn(message, options);
-};
+    defaultWarnFn(message, options);
+  };
+}
 
-viteLogger.warnOnce = (message, options) => {
-  if (isKnownAstroWarning(message)) {
-    return;
-  }
+viteLogger.warn = createFilteredWarn(defaultWarn);
 
-  defaultWarnOnce(message, options);
-};
+viteLogger.warnOnce = createFilteredWarn(defaultWarnOnce);
 
 // https://astro.build/config
 export default defineConfig({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,34 @@
 
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
+import { createLogger } from "vite";
 
 const siteUrl = process.env.SECPAL_SITE_URL ?? "https://secpal.app";
+const astroInternalHelpersWarning =
+  '"matchHostname", "matchPathname", "matchPort" and "matchProtocol" are imported from external module "@astrojs/internal-helpers/remote" but never used in "node_modules/astro/dist/assets/utils/index.js"';
+const viteLogger = createLogger();
+const defaultWarn = viteLogger.warn.bind(viteLogger);
+const defaultWarnOnce = viteLogger.warnOnce.bind(viteLogger);
+
+function isKnownAstroWarning(message) {
+  return typeof message === "string" && message.includes(astroInternalHelpersWarning);
+}
+
+viteLogger.warn = (message, options) => {
+  if (isKnownAstroWarning(message)) {
+    return;
+  }
+
+  defaultWarn(message, options);
+};
+
+viteLogger.warnOnce = (message, options) => {
+  if (isKnownAstroWarning(message)) {
+    return;
+  }
+
+  defaultWarnOnce(message, options);
+};
 
 // https://astro.build/config
 export default defineConfig({
@@ -17,6 +43,7 @@ export default defineConfig({
     },
   },
   vite: {
+    customLogger: viteLogger,
     plugins: [tailwindcss()],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@tailwindplus/elements": "^1.0.0",
-        "astro": "^6.0.7"
+        "astro": "^6.0.8"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -2705,9 +2705,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.7.tgz",
-      "integrity": "sha512-tCUrtQI+2Dk13xTM07JYrvk16T4ekWqSXh0/dVCunne816ZV+RCs1tomSoTHZi3DJdoaTnLJmkH+uxCC3b1KWw==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.8.tgz",
+      "integrity": "sha512-DCPeb8GKOoFWh+8whB7Qi/kKWD/6NcQ9nd1QVNzJFxgHkea3WYrNroQRq4whmBdjhkYPTLS/1gmUAl2iA2Es2g==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@tailwindplus/elements": "^1.0.0",
-    "astro": "^6.0.7"
+    "astro": "^6.0.8"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",


### PR DESCRIPTION
## Summary

- update `astro` from `6.0.7` to `6.0.8`
- suppress Astro's known false-positive `UNUSED_EXTERNAL_IMPORT` warning via a narrow Vite custom logger filter
- document the build-warning fix in `CHANGELOG.md`

## Validation

- `npm audit --omit=optional`
- `npm run build`
- `npm run lint`
- `npm run typecheck`

## Issue status reviewed

- closes #20
- #21 was closed as a duplicate of #20 after validation
- #15 was closed as no longer reproducible on the current default branch
