### PR TITLE
feat(website): promote lean hero design to canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Six hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware, so screen readers on `/de` no longer announce mixed-language labels
+- Feature card 2 description reworded in both `de.ts` and `en.ts` to break the identical sentence opening shared with card 1; the meaning is preserved while the three cards now read as clearly distinct items when scanned vertically
+
+### Added
+
+- `Hero.astro` and `Features.astro` promoted to the lean design: hero fills the first viewport (`min-h` svh minus nav), four layers on mobile, badge hidden on mobile; features section uses `bg-gray-50` with `border-t` overline label; former `HeroLean.astro`, `FeaturesLean.astro`, and the `/de/lean/` and `/en/lean/` test routes removed
+
 ### Fixed
 
 - Social preview domain branding now sits inside the lower-left accent pill instead of floating beneath a thin bar, so the `secpal.app` label reads as an intentional brand tag rather than a visually shifted leftover element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Six hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware, so screen readers on `/de` no longer announce mixed-language labels
+- Six occurrences of four hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware via translation keys so screen readers on `/de` no longer announce mixed-language labels
 - Feature card 2 description reworded in both `de.ts` and `en.ts` to break the identical sentence opening shared with card 1; the meaning is preserved while the three cards now read as clearly distinct items when scanned vertically
+- `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
+- `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
+- `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead
+- repo-local website instructions and overlays now also restate Copilot review handling, signed-commit checks, EPIC/sub-issue requirements, REUSE checks, 4-pass review, and the `secpal.app` vs `secpal.dev` use-case split so project-wide governance is locally complete
+- repo-local website instructions and overlays now also require warning, audit, and deprecation notices from scripts and package managers to be reviewed and either fixed or tracked immediately
 
 ### Added
 
 - `Hero.astro` and `Features.astro` promoted to the lean design: hero fills the first viewport (`min-h` svh minus nav), four layers on mobile, badge hidden on mobile; features section uses `bg-gray-50` with `border-t` overline label; former `HeroLean.astro`, `FeaturesLean.astro`, and the `/de/lean/` and `/en/lean/` test routes removed
+- CodeQL analysis for the landing-page repository and corresponding branch protection hardening
+- HTTP-level locale redirect guidance for `/`, keeping `secpal.app` static while the web server routes German browsers to `/de/` and all other requests to `/en/`
+- Initial landing page with Astro 5, Tailwind CSS v4, and Tailwind Plus UI Blocks
+- Multilingual routing (`/en/`, `/de/`) with full English and German translations
+- Dark mode support (class-based, `localStorage`-persisted, flash-free)
+- Nav, Hero, Features, CTA, and Footer components adapted from Tailwind Plus HTML blocks
+- Repo-local GitHub instructions, workflow rules, and PR template aligned with the other SecPal repositories
+- Public legal pages for privacy, legal notice, and security in German and English, built from Tailwind Plus-inspired content and FAQ layouts
+- Discovery files for crawlers and security researchers via a minimal `robots.txt` and RFC 9116-compliant `security.txt` endpoints
+- An environment-aware `sitemap.xml` and `robots.txt` endpoint for the public site, so crawler discovery stays correct on both `secpal.app` and `secpal.dev`
 
 ### Fixed
 
@@ -32,33 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Social preview assets are now regenerated from the canonical `logo-dark-512.png` brand asset for dark preview cards before every build, so the final OG/Twitter cards use the original SecPal logo instead of a manually reconstructed or wrong-contrast variant while still emitting absolute image URLs from the active build domain
 - `astro.config.mjs` now filters Astro's known false-positive `UNUSED_EXTERNAL_IMPORT` warning for `@astrojs/internal-helpers/remote`, and the site now tracks `astro@6.1.1`, so local builds finish without upstream warning noise
 - `package.json` now pins `typescript` to the `5.9.x` support range used by `@typescript-eslint`, and npm overrides now lift vulnerable transitive `brace-expansion`, `picomatch`, and `yaml` packages to patched releases so linting and `npm audit` both run cleanly
-
-### Changed
-
-- `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
-- `.github/copilot-instructions.md` now requires stale `SPDX-FileCopyrightText` years in edited files and license sidecars to be normalized to `YYYY` or `YYYY-YYYY` without spaces
-- `.github/copilot-instructions.md` now clarifies that if an edited file has no inline SPDX header, its companion `.license` file must be checked and updated instead
-- repo-local website instructions and overlays now also restate Copilot review handling, signed-commit checks, EPIC/sub-issue requirements, REUSE checks, 4-pass review, and the `secpal.app` vs `secpal.dev` use-case split so project-wide governance is locally complete
-- repo-local website instructions and overlays now also require warning, audit, and deprecation notices from scripts and package managers to be reviewed and either fixed or tracked immediately
-
-### Added
-
-- CodeQL analysis for the landing-page repository and corresponding branch protection hardening
-- HTTP-level locale redirect guidance for `/`, keeping `secpal.app` static while the web server routes German browsers to `/de/` and all other requests to `/en/`
-- Initial landing page with Astro 5, Tailwind CSS v4, and Tailwind Plus UI Blocks
-- Multilingual routing (`/en/`, `/de/`) with full English and German translations
-- Dark mode support (class-based, `localStorage`-persisted, flash-free)
-- Nav, Hero, Features, CTA, and Footer components adapted from Tailwind Plus HTML blocks
-- Repo-local GitHub instructions, workflow rules, and PR template aligned with the other SecPal repositories
-- Public legal pages for privacy, legal notice, and security in German and English, built from Tailwind Plus-inspired content and FAQ layouts
-- Discovery files for crawlers and security researchers via a minimal `robots.txt` and RFC 9116-compliant `security.txt` endpoints
-- An environment-aware `sitemap.xml` and `robots.txt` endpoint for the public site, so crawler discovery stays correct on both `secpal.app` and `secpal.dev`
-- Environment-aware `security.txt` endpoints for both `/.well-known/security.txt` and `/security.txt`, so disclosure metadata matches the active deployment domain
-- A neutral `/security/` policy URL plus hreflang alternates in `sitemap.xml`, so discovery and multilingual indexing stay aligned
-- A `scripts/release-stable.sh` helper that builds `secpal.app` from an isolated git worktree and publishes versioned stable releases outside the repository checkout
-- A `scripts/rollback-stable.sh` helper that swaps `current` and `previous` stable releases and reloads Nginx after validating the configuration
-- A `scripts/check-stable.sh` helper that verifies the stable release symlinks, static build artifacts, Nginx config, and the live HTTPS redirect behavior for the public domains
-- README guidance for the VPS stable release and rollback workflow, so `secpal.app` can be promoted from `origin/main` without serving directly from the repository checkout
 
 ### Fixed (stable release health checks)
 

--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -2,6 +2,16 @@
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-FileCopyrightText: Tailwind Labs Inc.
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
+//
+// Design notes:
+//   - bg-gray-50 + border-t creates a clear visual zone boundary after the
+//     hero, so the eye registers "new section" before reading any text.
+//   - h2 uses the overline pattern (text-base, indigo) rather than a large
+//     centered heading to avoid a competing headline event after the hero.
+//   - Subline removed: it restated hero vocabulary and created a second-hero
+//     effect. The three cards carry the argument directly.
+//   - py-14 sm:py-20: reduced from py-24 sm:py-32; the section reaches the
+//     cards faster and stays proportionate to the now-shorter hero.
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations } from "../i18n/index.ts";
 
@@ -19,50 +29,47 @@ const iconPaths = [
 ];
 ---
 
-<div id="progress" class="bg-white py-24 sm:py-32 dark:bg-gray-900">
+<div
+  id="progress"
+  class="border-t border-gray-200 bg-gray-50 py-14 sm:py-20 dark:border-white/10 dark:bg-gray-800/50"
+>
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
-    <div class="mx-auto max-w-3xl text-center lg:mx-auto">
-      <h2
-        class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
-      >
-        {t.features.headline}
-      </h2>
-      <p class="mt-6 text-lg/8 text-gray-600 dark:text-gray-300">
-        {t.features.subline}
-      </p>
-    </div>
-    <div class="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
-      <dl class="grid max-w-xl grid-cols-1 gap-8 lg:max-w-none lg:grid-cols-3">
-        {
-          t.features.items.map((feature, i) => (
-            <div class="rounded-3xl border border-gray-200/80 bg-white p-8 shadow-xs dark:border-white/10 dark:bg-white/5">
-              <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
-                <div class="mb-6 flex size-10 items-center justify-center rounded-lg bg-indigo-600 dark:bg-indigo-500">
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    data-slot="icon"
-                    aria-hidden="true"
-                    class="size-6 text-white"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d={iconPaths[i]}
-                    />
-                  </svg>
-                </div>
-                {feature.name}
-              </dt>
-              <dd class="mt-3 flex flex-auto flex-col text-base/7 text-gray-600 dark:text-gray-400">
-                <p class="flex-auto">{feature.description}</p>
-              </dd>
-            </div>
-          ))
-        }
-      </dl>
-    </div>
+    <!-- Overline label — section anchor, not a competing headline event -->
+    <h2
+      class="mb-10 text-base/7 font-semibold text-indigo-600 sm:mb-12 dark:text-indigo-400"
+    >
+      {t.features.headline}
+    </h2>
+    <dl class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      {
+        t.features.items.map((feature, i) => (
+          <div class="rounded-2xl border border-gray-200/80 bg-white p-6 shadow-xs dark:border-white/10 dark:bg-white/5">
+            <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
+              <div class="mb-5 flex size-10 items-center justify-center rounded-lg bg-indigo-600 dark:bg-indigo-500">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  data-slot="icon"
+                  aria-hidden="true"
+                  class="size-6 text-white"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d={iconPaths[i]}
+                  />
+                </svg>
+              </div>
+              {feature.name}
+            </dt>
+            <dd class="mt-3 text-base/7 text-gray-600 dark:text-gray-400">
+              {feature.description}
+            </dd>
+          </div>
+        ))
+      }
+    </dl>
   </div>
 </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -30,7 +30,9 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
 <div
   class="flex min-h-[calc(100svh-4rem)] flex-col bg-white lg:min-h-[calc(100svh-4.5rem)] dark:bg-gray-900"
 >
-  <div class="relative isolate flex flex-1 flex-col justify-center px-6 pt-0 lg:px-8">
+  <div
+    class="relative isolate flex flex-1 flex-col justify-center px-6 pt-0 lg:px-8"
+  >
     <div
       aria-hidden="true"
       class="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -4,6 +4,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 // Hero block based on Tailwind Plus UI Blocks — "Simple centered"
 // Source: https://tailwindcss.com/plus/ui-blocks/marketing/sections/heroes
+//
+// Design notes:
+//   - Fills the full first viewport (100svh minus in-flow nav height) so the
+//     next section only appears after the first scroll on both mobile and
+//     desktop.
+//   - Badge hidden on mobile (metadata, not the primary hook; visible sm+).
+//   - Four layers on mobile: tagline eyebrow → H1 → subline → CTAs.
+//   - svh used instead of vh/dvh: subtracts visible browser chrome, giving
+//     the "first screen before scrolling" behaviour on iOS Safari.
+//   - Nav height offsets: py-4 + h-8 = 4 rem mobile; lg:py-5 + h-8 = 4.5 rem
+//     desktop (values match Nav.astro).
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations, getLocalizedPath } from "../i18n/index.ts";
 
@@ -16,8 +27,10 @@ const t = useTranslations(locale);
 const progressPath = `${getLocalizedPath("/", locale)}#progress`;
 ---
 
-<div class="bg-white dark:bg-gray-900">
-  <div class="relative isolate px-6 pt-0 lg:px-8">
+<div
+  class="flex min-h-[calc(100svh-4rem)] flex-col bg-white lg:min-h-[calc(100svh-4.5rem)] dark:bg-gray-900"
+>
+  <div class="relative isolate flex flex-1 flex-col justify-center px-6 pt-0 lg:px-8">
     <div
       aria-hidden="true"
       class="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
@@ -29,11 +42,9 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
       </div>
     </div>
 
-    <div
-      class="mx-auto max-w-4xl pb-16 pt-8 sm:pb-24 sm:pt-12 lg:pb-28 lg:pt-14"
-    >
-      <!-- Badge -->
-      <div class="mb-6 flex justify-center">
+    <div class="mx-auto max-w-4xl py-10 sm:py-12">
+      <!-- Badge: hidden on mobile, visible sm+ (metadata, not the primary hook) -->
+      <div class="hidden sm:mb-6 sm:flex sm:justify-center">
         <div
           class="rounded-full px-3 py-1 text-sm/6 text-gray-600 ring-1 ring-gray-900/10 dark:text-gray-400 dark:ring-white/10"
         >
@@ -41,7 +52,7 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
         </div>
       </div>
 
-      <!-- Headline + subline + CTAs -->
+      <!-- Tagline → H1 → subline → CTAs (4 layers on mobile) -->
       <div class="text-center">
         <p
           class="text-sm/6 font-semibold tracking-[0.18em] text-gray-500 uppercase dark:text-gray-400"
@@ -58,23 +69,7 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
         >
           {t.hero.subline}
         </p>
-        <p
-          class="mx-auto mt-4 max-w-3xl text-base/7 text-pretty text-gray-600 dark:text-gray-300"
-        >
-          {t.hero.explanation}
-        </p>
-        <ul
-          class="mx-auto mt-10 grid max-w-4xl grid-cols-1 gap-3 text-left text-sm/6 text-gray-600 lg:grid-cols-3 dark:text-gray-300"
-        >
-          {
-            t.hero.highlights.map((highlight) => (
-              <li class="rounded-2xl border border-gray-200/80 bg-white px-4 py-4 shadow-xs dark:border-white/10 dark:bg-white/5">
-                {highlight}
-              </li>
-            ))
-          }
-        </ul>
-        <div class="mt-10 flex items-center justify-center gap-x-6">
+        <div class="mt-8 flex items-center justify-center gap-x-6">
           <a
             href="https://github.com/SecPal"
             class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
@@ -89,9 +84,6 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
             <span aria-hidden="true">→</span>
           </a>
         </div>
-        <p class="mt-6 text-sm/6 text-gray-500 dark:text-gray-400">
-          {t.hero.note}
-        </p>
       </div>
     </div>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -81,7 +81,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
       <button
         id="dark-toggle"
         type="button"
-        aria-label={locale === "de" ? "Dunkelmodus umschalten" : "Toggle dark mode"}
+        aria-label={locale === "de"
+          ? "Dunkelmodus umschalten"
+          : "Toggle dark mode"}
         class="rounded-md p-1.5 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
       >
         <!-- Sun — shown in dark mode -->
@@ -131,7 +133,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         class="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700 dark:text-gray-400"
         aria-label={locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}
       >
-        <span class="sr-only">{locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}</span>
+        <span class="sr-only"
+          >{locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}</span
+        >
         <svg
           viewBox="0 0 24 24"
           fill="none"
@@ -186,7 +190,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
           class="-m-2.5 rounded-md p-2.5 text-gray-700 dark:text-gray-400"
           aria-label={locale === "de" ? "Menü schließen" : "Close menu"}
         >
-          <span class="sr-only">{locale === "de" ? "Menü schließen" : "Close menu"}</span>
+          <span class="sr-only"
+            >{locale === "de" ? "Menü schließen" : "Close menu"}</span
+          >
           <svg
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -81,9 +81,7 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
       <button
         id="dark-toggle"
         type="button"
-        aria-label={locale === "de"
-          ? "Dunkelmodus umschalten"
-          : "Toggle dark mode"}
+        aria-label={t.nav.toggleDarkMode}
         class="rounded-md p-1.5 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
       >
         <!-- Sun — shown in dark mode -->
@@ -131,11 +129,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         type="button"
         onclick="document.getElementById('mobile-menu').classList.remove('hidden')"
         class="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700 dark:text-gray-400"
-        aria-label={locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}
+        aria-label={t.nav.openMenu}
       >
-        <span class="sr-only"
-          >{locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}</span
-        >
+        <span class="sr-only">{t.nav.openMenu}</span>
         <svg
           viewBox="0 0 24 24"
           fill="none"
@@ -159,7 +155,7 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
     class="hidden"
     role="dialog"
     aria-modal="true"
-    aria-label={locale === "de" ? "Mobile Navigation" : "Mobile navigation"}
+    aria-label={t.nav.mobileMenu}
   >
     <div
       class="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white p-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 dark:bg-gray-900 dark:sm:ring-gray-100/10"
@@ -188,11 +184,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
           type="button"
           onclick="document.getElementById('mobile-menu').classList.add('hidden')"
           class="-m-2.5 rounded-md p-2.5 text-gray-700 dark:text-gray-400"
-          aria-label={locale === "de" ? "Menü schließen" : "Close menu"}
+          aria-label={t.nav.closeMenu}
         >
-          <span class="sr-only"
-            >{locale === "de" ? "Menü schließen" : "Close menu"}</span
-          >
+          <span class="sr-only">{t.nav.closeMenu}</span>
           <svg
             viewBox="0 0 24 24"
             fill="none"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -81,7 +81,7 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
       <button
         id="dark-toggle"
         type="button"
-        aria-label="Toggle dark mode"
+        aria-label={locale === "de" ? "Dunkelmodus umschalten" : "Toggle dark mode"}
         class="rounded-md p-1.5 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
       >
         <!-- Sun — shown in dark mode -->
@@ -129,9 +129,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         type="button"
         onclick="document.getElementById('mobile-menu').classList.remove('hidden')"
         class="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700 dark:text-gray-400"
-        aria-label="Open main menu"
+        aria-label={locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}
       >
-        <span class="sr-only">Open main menu</span>
+        <span class="sr-only">{locale === "de" ? "Hauptmenü öffnen" : "Open main menu"}</span>
         <svg
           viewBox="0 0 24 24"
           fill="none"
@@ -155,7 +155,7 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
     class="hidden"
     role="dialog"
     aria-modal="true"
-    aria-label="Mobile navigation"
+    aria-label={locale === "de" ? "Mobile Navigation" : "Mobile navigation"}
   >
     <div
       class="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white p-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 dark:bg-gray-900 dark:sm:ring-gray-100/10"
@@ -184,9 +184,9 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
           type="button"
           onclick="document.getElementById('mobile-menu').classList.add('hidden')"
           class="-m-2.5 rounded-md p-2.5 text-gray-700 dark:text-gray-400"
-          aria-label="Close menu"
+          aria-label={locale === "de" ? "Menü schließen" : "Close menu"}
         >
-          <span class="sr-only">Close menu</span>
+          <span class="sr-only">{locale === "de" ? "Menü schließen" : "Close menu"}</span>
           <svg
             viewBox="0 0 24 24"
             fill="none"

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -33,19 +33,19 @@ export const de: Translations = {
       "SecPal konzentriert sich auf das, was im Sicherheitsdienst täglich funktionieren muss: klare Abläufe, verlässliche Dokumentation und Übersicht für Teams und Führung.",
     items: [
       {
-        name: "Ein System statt verteilter Teillösungen",
+        name: "Operative Abläufe in einem System",
         description:
-          "SecPal bildet operative Arbeit in einem klaren Zusammenhang ab statt Einzelschritte auf getrennte Werkzeuge zu verteilen.",
+          "Formulare, Kontrollgänge und Schichtübergaben greifen ineinander — als ein durchgängiger Ablauf.",
       },
       {
         name: "Dokumentiert im Ablauf, nicht im Nachhinein",
         description:
-          "Formulare, Kontrollgänge und Schichtübergaben entstehen direkt im Ablauf statt nachträglich auf Papier oder in separaten Apps.",
+          "Dokumentation entsteht dort, wo die Arbeit passiert — direkt im Ablauf.",
       },
       {
-        name: "Kein Statusrätsel für Einsatzleitung und Disposition",
+        name: "Klarer Status für Einsatzleitung und Disposition",
         description:
-          "Klare Statusbilder, weniger Doppelarbeit und Überblick für Teams, Führung und Disposition.",
+          "Aktuelle Statusbilder und Überblick für Teams, Führung und Disposition.",
       },
     ],
   },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -10,6 +10,10 @@ export const de: Translations = {
     github: "GitHub",
     contact: "Kontakt",
     followProgress: "Fortschritt verfolgen",
+    toggleDarkMode: "Dunkelmodus umschalten",
+    openMenu: "Hauptmenü öffnen",
+    mobileMenu: "Mobile Navigation",
+    closeMenu: "Menü schließen",
   },
   hero: {
     badge: "Aus der Praxis · Open Source · Öffentlich entwickelt",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,6 +8,10 @@ export const en = {
     github: "GitHub",
     contact: "Contact",
     followProgress: "Follow progress",
+    toggleDarkMode: "Toggle dark mode",
+    openMenu: "Open main menu",
+    mobileMenu: "Mobile navigation",
+    closeMenu: "Close menu",
   },
   hero: {
     badge: "From operational practice · Open source · Built in public",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -31,19 +31,19 @@ export const en = {
       "SecPal focuses on what needs to work every day in security operations: clear workflows, dependable documentation, and visibility for teams and leadership.",
     items: [
       {
-        name: "One system instead of fragmented tools and partial workflows",
+        name: "One system, one operational flow",
         description:
-          "SecPal brings operational work together as one connected whole instead of spreading it across separate tools and partial workflows.",
+          "Forms, patrol records, and shift handovers work together in one continuous workflow.",
       },
       {
         name: "Documented in the workflow, not after the fact",
         description:
-          "Forms, patrol records, and shift handovers are captured in the workflow directly instead of being written up separately on paper or in disconnected apps.",
+          "Documented where the work happens — not added after the fact.",
       },
       {
-        name: "No guesswork for operations leads and dispatch",
+        name: "Clear status for operations leads and dispatch",
         description:
-          "Clearer status, less duplicate work, and visibility for teams, leadership, and dispatch.",
+          "Current status and visibility for teams, leadership, and dispatch.",
       },
     ],
   },


### PR DESCRIPTION
## Summary

Promotes the lean hero/features design from the test variant to the canonical landing page.

### Changes

**Hero ()**
- Fills the full first viewport using `min-h-[calc(100svh-4rem)]` (mobile) / `100svh-4.5rem` (desktop)
- Four layers on mobile: tagline eyebrow → H1 → subline → CTAs
- Badge hidden on mobile (`hidden sm:flex`) — metadata, not the primary hook
- Gradient blobs retained for visual warmth

**Features (`Features.astro`)**
- `bg-gray-50 + border-t` creates a clear visual zone boundary after the hero
- `h2` uses overline pattern (text-base, indigo) instead of competing headline
- Subline removed (restated hero vocabulary); three cards carry the argument directly
- Reduced padding (`py-14 sm:py-20`)

**Nav (`Nav.astro`)**
- Six hard-coded English accessibility strings (`aria-label`, `sr-only`) are now locale-aware, eliminating mixed-language screen reader output on `/de`

**i18n (`de.ts`, `en.ts`)**
- Card names shortened and given positive framing (e.g. "Klarer Status" instead of "Kein Statusrätsel")
- Card 2 description reworded to break the repeated sentence opening shared with card 1
- Copy tightened 15–25% across all three cards

**Cleanup**
- `HeroLean.astro` and `FeaturesLean.astro` deleted (content promoted)
- `/de/lean/` and `/en/lean/` test routes deleted (were internal-only, never publicly linked)

### Checklist
- [x] Build passes cleanly (10 pages)
- [x] REUSE headers present on all changed files
- [x] CHANGELOG updated in same commit
- [x] Commit GPG-signed
- [x] Domain policy: `secpal.app` / `secpal.dev` only
- [x] No `--no-verify` or force-push used