### PR TITLE
fix: align site domain policy guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,8 +20,10 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Domain policy is strict: use `secpal.app` only for the public homepage and
   real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the
   PWA/frontend, and `secpal.dev` for dev, staging, testing, and examples.
-  Treat `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
-  `app.secpal.app` remains valid only as the Android application identifier.
+  `dev.secpal.app` is the live staging/development host for this repository
+  (a subdomain of `secpal.app`). Treat `api.secpal.app` and `app.secpal.app`
+  as deprecated web hosts; `app.secpal.app` remains valid only as the Android
+  application identifier.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the
   code, push, and resolve review threads through the approved non-comment
   workflow.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,9 +17,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
 - Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
 - Keep GitHub-facing communication in English.
-- Domain policy is strict: use `secpal.app` for production services and all
-  email addresses, and `secpal.dev` only for dev, staging, testing, and
-  examples.
+- Domain policy is strict: use `secpal.app` only for the public homepage and
+  real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the
+  PWA/frontend, and `secpal.dev` for dev, staging, testing, and examples.
+  Treat `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
+  `app.secpal.app` remains valid only as the Android application identifier.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the
   code, push, and resolve review threads through the approved non-comment
   workflow.
@@ -79,7 +81,7 @@ Before any commit, PR, or merge, announce and verify at least:
 ## Site Rules
 
 - Preserve accessibility, semantic HTML, keyboard navigation, and responsive layouts.
-- Keep copy accurate to the current product and domains. Use `secpal.app` for production content and all email addresses; use `secpal.dev` only for dev, staging, testing, and examples.
+- Keep copy accurate to the current product and domains. Use `secpal.app` for the public website and real email addresses, `app.secpal.dev` and `api.secpal.dev` for app/API hosts, and `secpal.dev` for dev, staging, testing, and examples. `app.secpal.app` is Android identifier-only.
 - Prefer Astro built-ins and existing CSS patterns before introducing new dependencies or runtime code.
 - Run the smallest relevant validation for every change: formatting, lint, typecheck, and build for affected areas.
 

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -16,9 +16,11 @@ At runtime, this file now acts as the repo-local overlay for the `secpal.app` re
 - Enforce SecPal core rules while editing any file: fail fast, no bypass, one topic per change, immediate issue creation for out-of-scope findings, and `CHANGELOG.md` updates for real changes.
 - Use `secpal.app` only for the public homepage and real email addresses,
   `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, and
-  `secpal.dev` for dev, staging, testing, and examples. Treat
-  `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
-  `app.secpal.app` remains valid only as the Android application identifier.
+  `secpal.dev` for dev, staging, testing, and examples. `dev.secpal.app` is
+  the live staging/development host for this repository (a subdomain of
+  `secpal.app`). Treat `api.secpal.app` and `app.secpal.app` as deprecated
+  web hosts; `app.secpal.app` remains valid only as the Android application
+  identifier.
 - Never reply to Copilot review comments with GitHub comment tools; use the
   approved non-comment review workflow instead.
 - Keep commits GPG-signed, use file and line references instead of verbatim code

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -14,8 +14,11 @@ At runtime, this file now acts as the repo-local overlay for the `secpal.app` re
 - Treat `.github/copilot-instructions.md` in this repo as the authoritative runtime baseline.
 - Do not rely on cross-repo inheritance, comments, or external config files being loaded.
 - Enforce SecPal core rules while editing any file: fail fast, no bypass, one topic per change, immediate issue creation for out-of-scope findings, and `CHANGELOG.md` updates for real changes.
-- Use `secpal.app` for production services and all email addresses, and
-  `secpal.dev` only for dev, staging, testing, and examples.
+- Use `secpal.app` only for the public homepage and real email addresses,
+  `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, and
+  `secpal.dev` for dev, staging, testing, and examples. Treat
+  `api.secpal.app` and `app.secpal.app` as deprecated web hosts;
+  `app.secpal.app` remains valid only as the Android application identifier.
 - Never reply to Copilot review comments with GitHub comment tools; use the
   approved non-comment review workflow instead.
 - Keep commits GPG-signed, use file and line references instead of verbatim code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and `app.secpal.app` stays Android identifier-only
+- corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and `app.secpal.app` stays Android identifier-only; explicitly documented `dev.secpal.app` as the live staging/development host for this repository (a subdomain of `secpal.app`)
 - Six occurrences of four hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware via translation keys so screen readers on `/de` no longer announce mixed-language labels
 - Feature card 2 description reworded in both `de.ts` and `en.ts` to break the identical sentence opening shared with card 1; the meaning is preserved while the three cards now read as clearly distinct items when scanned vertically
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and `app.secpal.app` stays Android identifier-only
 - Six occurrences of four hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware via translation keys so screen readers on `/de` no longer announce mixed-language labels
 - Feature card 2 description reworded in both `de.ts` and `en.ts` to break the identical sentence opening shared with card 1; the meaning is preserved while the three cards now read as clearly distinct items when scanned vertically
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,10 @@ This repository contains the public static site for [secpal.app](https://secpal.
 
 Use only the approved SecPal domains in content, configuration, and examples:
 
-- `secpal.app` for production-facing URLs and email addresses
-- `secpal.dev` for development, staging, and examples
+- `secpal.app` for the public website and real email addresses
+- `api.secpal.dev` for the API and `app.secpal.dev` for the PWA/frontend
+- `secpal.dev` for development, staging, testing, and examples
+- `app.secpal.app` only as the Android application identifier
 
 ## Prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ This repository contains the public static site for [secpal.app](https://secpal.
 Use only the approved SecPal domains in content, configuration, and examples:
 
 - `secpal.app` for the public website and real email addresses
+- `dev.secpal.app` as the live staging/development host for this repository (subdomain of `secpal.app`)
 - `api.secpal.dev` for the API and `app.secpal.dev` for the PWA/frontend
 - `secpal.dev` for development, staging, testing, and examples
 - `app.secpal.app` only as the Android application identifier

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 # Domain Policy Enforcement Script
-# Validates that ONLY secpal.app and secpal.dev are used
-# ZERO TOLERANCE for other domains
+# Validates that only approved SecPal domains and identifiers are used
+# ZERO TOLERANCE for other domains or deprecated .app web hosts
 
 set -euo pipefail
 
@@ -17,10 +17,13 @@ NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
 echo "Allowed: secpal.app, secpal.dev"
+echo "Active web hosts: api.secpal.dev, app.secpal.dev"
+echo "Identifier-only: app.secpal.app (Android application ID)"
+echo "Deprecated web hosts: api.secpal.app, app.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-violations=$(grep -r "secpal\." \
+matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -39,25 +42,68 @@ violations=$(grep -r "secpal\." \
     --exclude-dir=".astro" \
     . 2>/dev/null | \
     grep -v -- "check-domains.sh" | \
-    grep -v -- "secpal\.app\|secpal\.dev" | \
     grep -v -- "Forbidden:" | \
     grep -v -- "FORBIDDEN:" | \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 
-if [[ -z "$violations" ]]; then
+violations=$(printf '%s\n' "$matches" | grep -E "secpal\.(com|org|net|io|example)" || true)
+
+deprecated_web_hosts=$(printf '%s\n' "$matches" | \
+    grep -E 'api\.secpal\.app|app\.secpal\.app' | \
+    grep -v -- "appId" | \
+    grep -v -- "applicationId" | \
+    grep -v -- "package name" | \
+    grep -v -- "package/application ID" | \
+    grep -v -- "application ID" | \
+    grep -v -- "Android application identifier" | \
+    grep -v -- "Android identifier" | \
+    grep -v -- "Android package ID" | \
+    grep -v -- "identifier-only" | \
+    grep -v -- "active web hosts" | \
+    grep -v -- "Deprecated Web Hosts" | \
+    grep -v -- "deprecated_web_hosts" | \
+    grep -v -- "android_application_identifier" | \
+    grep -v -- "validation_rule" | \
+    grep -v -- './.github/copilot-instructions.md:' | \
+    grep -v -- './.github/copilot-config.yaml:' | \
+    grep -v -- 'namespace "app\.secpal\.app"' | \
+    grep -v -- 'package app\.secpal\.app;' | \
+    grep -v -- 'package_name' | \
+    grep -v -- 'custom_url_scheme' | \
+    grep -v -- 'getPackageName()' | \
+    grep -v -- 'adb shell monkey -p app\.secpal\.app' | \
+    grep -v -- 'deprecated' | \
+    grep -v -- 'mistaken' | \
+    grep -v -- 'before deployment' | \
+    grep -v -- 'must not appear as active web hosts' | \
+    grep -v -- 'not deployed' | \
+    grep -v -- 'not treated as a deployable web domain' || true)
+
+if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then
     echo -e "${GREEN}✅ Domain Policy Check PASSED${NC}"
-    echo "All domains use secpal.app or secpal.dev"
+    echo "All domain usage matches the approved SecPal split"
     exit 0
 else
     echo -e "${RED}❌ Domain Policy Check FAILED${NC}"
     echo ""
-    echo "Found forbidden domains:"
-    echo "$violations"
-    echo ""
+    if [[ -n "$violations" ]]; then
+        echo "Found forbidden domains:"
+        echo "$violations"
+        echo ""
+    fi
+    if [[ -n "$deprecated_web_hosts" ]]; then
+        echo "Found deprecated .app web-host usage:"
+        echo "$deprecated_web_hosts"
+        echo ""
+    fi
     echo -e "${YELLOW}Policy:${NC}"
-    echo "  - secpal.app: Production services, ALL emails"
-    echo "  - secpal.dev: Development, testing, examples, docs"
+    echo "  - secpal.app: public homepage and real email addresses"
+    echo "  - api.secpal.dev: live API host"
+    echo "  - app.secpal.dev: live PWA/frontend host"
+    echo "  - secpal.dev: development, staging, testing, examples"
+    echo "  - app.secpal.app: Android application identifier only"
+    echo "  - DEPRECATED as web hosts: api.secpal.app, app.secpal.app"
     echo "  - FORBIDDEN: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example"
     echo ""
     echo "Fix these violations before committing."

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -47,7 +47,12 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 
-violations=$(printf '%s\n' "$matches" | grep -E "secpal\.(com|org|net|io|example)" || true)
+# Allowlist approach: flag any secpal.* domain not matching an approved pattern.
+# Approved: secpal.app, secpal.dev, api.secpal.dev, app.secpal.dev, app.secpal.app (identifier context).
+# This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
+violations=$(printf '%s\n' "$matches" | \
+    grep -Ev 'secpal\.(app|dev)([^a-zA-Z0-9-]|$)|api\.secpal\.(dev|app)|app\.secpal\.(dev|app)' | \
+    grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -E 'api\.secpal\.app|app\.secpal\.app' | \
@@ -67,17 +72,14 @@ deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -v -- "validation_rule" | \
     grep -v -- './.github/copilot-instructions.md:' | \
     grep -v -- './.github/copilot-config.yaml:' | \
+    grep -v -- './.github/instructions/' | \
     grep -v -- 'namespace "app\.secpal\.app"' | \
     grep -v -- 'package app\.secpal\.app;' | \
     grep -v -- 'package_name' | \
     grep -v -- 'custom_url_scheme' | \
     grep -v -- 'getPackageName()' | \
     grep -v -- 'adb shell monkey -p app\.secpal\.app' | \
-    grep -v -- 'deprecated' | \
-    grep -v -- 'mistaken' | \
-    grep -v -- 'before deployment' | \
     grep -v -- 'must not appear as active web hosts' | \
-    grep -v -- 'not deployed' | \
     grep -v -- 'not treated as a deployable web domain' || true)
 
 if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then


### PR DESCRIPTION
Fixes SecPal/.github#271

## Summary

- align repo-local website guidance and contribution docs with the approved SecPal domain split
- update the site domain validation script for deprecated `.app` host handling
- add the changelog entry for the governance correction

## Validation

- `./scripts/check-domains.sh`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
