### PR TITLE
fix: share nav height tokens between nav and hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Header spacing and hero first-viewport height now share the same CSS nav tokens, so future nav padding or logo-size changes no longer require duplicated rem offsets in `Hero.astro`
 - Social preview domain branding now sits inside the lower-left accent pill instead of floating beneath a thin bar, so the `secpal.app` label reads as an intentional brand tag rather than a visually shifted leftover element
 - The social preview generator now uses finalized German copy with proper umlauts and matching punctuation, so the generated OG card no longer looks like an ASCII-only draft asset
 - The social preview build step now relies on a declared local `sharp` dependency instead of an implicit transitive install, so `npm run build` remains stable when upstream package trees change

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -13,8 +13,8 @@
 //   - Four layers on mobile: tagline eyebrow → H1 → subline → CTAs.
 //   - svh used instead of vh/dvh: subtracts visible browser chrome, giving
 //     the "first screen before scrolling" behaviour on iOS Safari.
-//   - Nav height offsets: py-4 + h-8 = 4 rem mobile; lg:py-5 + h-8 = 4.5 rem
-//     desktop (values match Nav.astro).
+//   - Nav height offset comes from shared CSS variables so header spacing and
+//     hero viewport math stay in sync.
 import type { Locale } from "../i18n/index.ts";
 import { useTranslations, getLocalizedPath } from "../i18n/index.ts";
 
@@ -28,7 +28,7 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
 ---
 
 <div
-  class="flex min-h-[calc(100svh-4rem)] flex-col bg-white lg:min-h-[calc(100svh-4.5rem)] dark:bg-gray-900"
+  class="flex min-h-[calc(100svh-var(--secpal-nav-height))] flex-col bg-white dark:bg-gray-900"
 >
   <div
     class="relative isolate flex flex-1 flex-col justify-center px-6 pt-0 lg:px-8"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -25,7 +25,7 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
 <header class="bg-white dark:bg-gray-900">
   <nav
     aria-label="Global"
-    class="mx-auto flex max-w-7xl items-center justify-between gap-x-6 px-6 py-4 lg:px-8 lg:py-5"
+    class="mx-auto flex max-w-7xl items-center justify-between gap-x-6 px-6 py-[var(--secpal-nav-padding-y)] lg:px-8"
   >
     <!-- Logo -->
     <div class="flex lg:flex-1">
@@ -33,12 +33,12 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         <span class="sr-only">SecPal</span>
         <img
           src="/logo-light-48.png"
-          class="h-8 w-auto dark:hidden"
+          class="h-[var(--secpal-nav-logo-height)] w-auto dark:hidden"
           alt="SecPal"
         />
         <img
           src="/logo-dark-48.png"
-          class="h-8 w-auto hidden dark:block"
+          class="hidden h-[var(--secpal-nav-logo-height)] w-auto dark:block"
           alt=""
           aria-hidden="true"
         />
@@ -165,12 +165,12 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
           <span class="sr-only">SecPal</span>
           <img
             src="/logo-light-48.png"
-            class="h-8 w-auto dark:hidden"
+            class="h-[var(--secpal-nav-logo-height)] w-auto dark:hidden"
             alt="SecPal"
           />
           <img
             src="/logo-dark-48.png"
-            class="h-8 w-auto hidden dark:block"
+            class="hidden h-[var(--secpal-nav-logo-height)] w-auto dark:block"
             alt=""
             aria-hidden="true"
           />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,3 +5,18 @@
 
 /* Class-based dark mode — toggled via JS on <html> */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Shared nav tokens keep the header spacing and hero viewport offset aligned. */
+:root {
+	--secpal-nav-logo-height: 2rem;
+	--secpal-nav-padding-y: 1rem;
+	--secpal-nav-height: calc(
+		var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2)
+	);
+}
+
+@media (min-width: 1024px) {
+	:root {
+		--secpal-nav-padding-y: 1.25rem;
+	}
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,13 +8,13 @@
 
 /* Shared nav tokens keep the header spacing and hero viewport offset aligned. */
 :root {
-    --secpal-nav-logo-height: 2rem;
-    --secpal-nav-padding-y: 1rem;
-    --secpal-nav-height: calc(var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2));
+  --secpal-nav-logo-height: 2rem;
+  --secpal-nav-padding-y: 1rem;
+  --secpal-nav-height: calc(var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2));
 }
 
 @media (min-width: 1024px) {
-    :root {
-        --secpal-nav-padding-y: 1.25rem;
-    }
+  :root {
+    --secpal-nav-padding-y: 1.25rem;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,15 +8,13 @@
 
 /* Shared nav tokens keep the header spacing and hero viewport offset aligned. */
 :root {
-	--secpal-nav-logo-height: 2rem;
-	--secpal-nav-padding-y: 1rem;
-	--secpal-nav-height: calc(
-		var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2)
-	);
+    --secpal-nav-logo-height: 2rem;
+    --secpal-nav-padding-y: 1rem;
+    --secpal-nav-height: calc(var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2));
 }
 
 @media (min-width: 1024px) {
-	:root {
-		--secpal-nav-padding-y: 1.25rem;
-	}
+    :root {
+        --secpal-nav-padding-y: 1.25rem;
+    }
 }


### PR DESCRIPTION
## Summary

- replace duplicated hero nav-offset constants with shared CSS custom properties
- make `Nav.astro` consume the same shared tokens for vertical padding and logo height
- update the changelog for the fix

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `reuse lint`

## Issue

Refs #31