### PR TITLE
chore(release): version 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.1] - 2026-03-31
+
 ### Changed
 
 - corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and `app.secpal.app` stays Android identifier-only; explicitly documented `dev.secpal.app` as the live staging/development host for this repository (a subdomain of `secpal.app`)


### PR DESCRIPTION
## Summary

Version the CHANGELOG `[Unreleased]` section as `[0.0.1] - 2026-03-31` and add an empty `[Unreleased]` section on top to prepare for the initial public release.

## Validation

- No code changes, CHANGELOG only
- `reuse lint` passes

## Issue

Initial release — no issue reference.