### PR TITLE
chore(governance): reduce Copilot instruction context bloat

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,84 +10,37 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Always-On Rules
 
-- Apply SecPal core rules on every task: fail fast, no bypass, one topic per change, and create a GitHub issue immediately for findings that cannot be fixed in the current scope.
-- Apply branch hygiene from the first local change: inspect branch state before
-  work, never start on local `main`, and do not mix unrelated uncommitted
-  changes into the current task.
-- Before any commit, PR, or merge, announce and verify the required checklist. Stop on the first failed check.
-- Update `CHANGELOG.md` in the same change set for real fixes, features, or breaking changes.
-- Keep GitHub-facing communication in English.
-- Domain policy is strict: use `secpal.app` only for the public homepage and
-  real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the
-  PWA/frontend, and `secpal.dev` for dev, staging, testing, and examples.
-  `dev.secpal.app` is the live staging/development host for this repository
-  (a subdomain of `secpal.app`). Treat `api.secpal.app` and `app.secpal.app`
-  as deprecated web hosts; `app.secpal.app` remains valid only as the Android
-  application identifier.
-- Never reply to Copilot review comments with GitHub comment tools. Fix the
-  code, push, and resolve review threads through the approved non-comment
-  workflow.
-- For work that needs more than one PR, create an EPIC with linked sub-issues
-  before implementation.
-- Do not paste large verbatim code blocks into GitHub comments, issues, or PR
-  descriptions. Reference file paths and line numbers instead.
-- Treat warnings, audit findings, deprecation notices, and similar non-fatal
-  diagnostics from scripts, `composer`, `npm`, and related tooling as
-  actionable: review them, fix them in scope, or create a GitHub issue
-  immediately if they are real but out of scope.
-- Prefer small, content-visible fixes that match the existing Astro and Tailwind patterns. Avoid speculative abstractions.
-- When editing a file or license sidecar that contains
-  `SPDX-FileCopyrightText`, keep the year current: use a single year such as
-  `2026` if it is already the current year, otherwise extend it to a no-spaces
-  range ending in the current year such as `2025-2026`. If the edited file has
-  no inline header but a companion `.license` file exists, check and update
-  that `.license` file instead.
+- Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
+- Keep one topic per change, fail fast, and never use bypasses such as `--no-verify` or force-push.
+- Update `CHANGELOG.md` in the same change set for real fixes, features, and breaking changes.
+- Create a GitHub issue immediately for out-of-scope bugs, technical debt, missing tests, documentation gaps, and actionable warnings you cannot fix now.
+- Keep GitHub-facing communication in English and reference files and lines instead of pasting large code blocks.
+- Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
+- Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
+- Use EPIC plus sub-issues before starting work that will span more than one PR.
+- Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal.app` only as the Android application identifier.
 
-## Branch Hygiene
+## Required Validation
 
-- Before any edit or other write action, run `git status --short --branch` and
-  understand the current branch plus local changes.
-- Never start implementation on local `main`. Create or switch to a dedicated topic branch first.
-- If a non-`main` branch already contains uncommitted changes, continue only
-  when they belong to the same task.
-- If existing changes are unrelated or unclear, stop and ask whether they
-  should be committed, stashed, or split before proceeding.
-- Never create mixed commits by reusing a dirty branch for a new topic.
+Before any commit, PR, or merge, announce the checklist you are executing and stop on the first failed item.
+At minimum verify:
 
-## Required Checklist
-
-Before any commit, PR, or merge, announce and verify at least:
-
-- the smallest relevant validation passed for the affected area: formatting, lint, typecheck, and build when applicable
-- `CHANGELOG.md` was updated in the same change set for real changes
+- the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
+- `CHANGELOG.md` was updated for real changes
 - commits are GPG-signed
-- REUSE compliance was checked when the changed files require it
-- the local 4-pass review was completed before creating a PR
-- tooling warnings and audit/deprecation notices were reviewed and either fixed
-  or tracked immediately
-- no bypass was used, including `--no-verify` or force-push
-- repo-local instructions remain self-contained and do not rely on cross-repo inheritance
-- out-of-scope findings were turned into GitHub issues immediately
+- REUSE compliance was checked when changed files require it
+- the local 4-pass review was completed
+- no bypass was used
 
-## Repository Stack
+## Repository Conventions
 
-- Node 22, Astro 6, Tailwind CSS v4, TypeScript strict mode.
+- Stack: Node 22, Astro 6, Tailwind CSS v4, and TypeScript strict mode.
 - This repository is the public SecPal landing page and static marketing site.
-
-## Architecture
-
-- Keep content and presentation close to the page or component that uses it.
-- Prefer small reusable Astro components over deep abstraction layers.
-- Favor static rendering and minimal client-side JavaScript.
-
-## Site Rules
-
-- Preserve accessibility, semantic HTML, keyboard navigation, and responsive layouts.
-- Keep copy accurate to the current product and domains. Use `secpal.app` for the public website and real email addresses, `app.secpal.dev` and `api.secpal.dev` for app/API hosts, and `secpal.dev` for dev, staging, testing, and examples. `app.secpal.app` is Android identifier-only.
-- Prefer Astro built-ins and existing CSS patterns before introducing new dependencies or runtime code.
-- Run the smallest relevant validation for every change: formatting, lint, typecheck, and build for affected areas.
+- Keep content and presentation close to the page or component that uses them.
+- Favor static rendering, minimal client-side JavaScript, semantic HTML, accessibility, and responsive layouts.
+- Prefer Astro built-ins and existing CSS patterns before new dependencies or runtime code.
 
 ## Scope Notes
 
-- Do not add dependencies or create documentation files unless the task requires it.
-- Treat this file as the runtime baseline for the repo. Repo-specific `.instructions.md` files add detail for matching files.
+- Do not add dependencies or create documentation files unless the task requires them.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -2,31 +2,13 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: secpal.app Runtime Overlay
-description: Reinforces the secpal.app repository baseline when working on files in this repo.
-applyTo: "**"
+description: Provides additional website governance context when a task needs more than the repo baseline.
 ---
 
 # secpal.app Runtime Overlay
 
-The historical filename `org-shared.instructions.md` is retained for continuity.
-At runtime, this file now acts as the repo-local overlay for the `secpal.app` repository.
+Use this file only when a task needs additional repo-wide governance context beyond `.github/copilot-instructions.md`.
 
-- Treat `.github/copilot-instructions.md` in this repo as the authoritative runtime baseline.
-- Do not rely on cross-repo inheritance, comments, or external config files being loaded.
-- Enforce SecPal core rules while editing any file: fail fast, no bypass, one topic per change, immediate issue creation for out-of-scope findings, and `CHANGELOG.md` updates for real changes.
-- Use `secpal.app` only for the public homepage and real email addresses,
-  `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, and
-  `secpal.dev` for dev, staging, testing, and examples. `dev.secpal.app` is
-  the live staging/development host for this repository (a subdomain of
-  `secpal.app`). Treat `api.secpal.app` and `app.secpal.app` as deprecated
-  web hosts; `app.secpal.app` remains valid only as the Android application
-  identifier.
-- Never reply to Copilot review comments with GitHub comment tools; use the
-  approved non-comment review workflow instead.
-- Keep commits GPG-signed, use file and line references instead of verbatim code
-  quotes in GitHub communication, and require EPIC + sub-issues for work that
-  spans more than one PR.
-- Treat warnings, audit findings, deprecation notices, and similar non-fatal
-  diagnostics as actionable; fix them in scope or create a GitHub issue
-  immediately when they are real but out of scope.
+- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
 - Keep changes repo-local, minimal, and consistent with Astro, Tailwind CSS, and static-site conventions.
+- Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the website-specific governance rules
+
 ## [0.0.1] - 2026-03-31
 
 ### Changed


### PR DESCRIPTION
Fixes SecPal/.github#284

## Summary
- reduce the repo-local Copilot runtime baseline to the rules that need to stay always-on
- remove the `applyTo: "**"` auto-loading path from the repo-wide overlay
- document the governance cleanup in `CHANGELOG.md`

## Validation
- `git diff --check`
- `reuse lint`
