### PR TITLE
docs(governance): restore strict runtime clarity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 ## Always-On Rules
 
 - Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
-- TDD is mandatory. Write or update the smallest relevant failing test FIRST, then implement, then refactor with tests green.
+- Validate-first: this repo has no test suite; confirm the smallest relevant check (lint, typecheck, or build) fails before implementing a change and passes after.
 - Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
 - Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
 - Never use bypasses such as `--no-verify` or force-push.
@@ -46,7 +46,6 @@ Before any commit, PR, or merge, announce the checklist you are executing and st
 At minimum verify:
 
 - the active branch and PR scope still address exactly one topic
-- TDD happened: the relevant test failed first and now passes
 - the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
 - out-of-scope findings were turned into GitHub issues immediately
 - `CHANGELOG.md` was updated for real changes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,26 +11,48 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 ## Always-On Rules
 
 - Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
-- Keep one topic per change, fail fast, and never use bypasses such as `--no-verify` or force-push.
+- TDD is mandatory. Write or update the smallest relevant failing test FIRST, then implement, then refactor with tests green.
+- Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
+- Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
+- Never use bypasses such as `--no-verify` or force-push.
 - Update `CHANGELOG.md` in the same change set for real fixes, features, and breaking changes.
-- Create a GitHub issue immediately for out-of-scope bugs, technical debt, missing tests, documentation gaps, and actionable warnings you cannot fix now.
+- Create a GitHub issue immediately for every real out-of-scope bug, technical debt, missing test, documentation gap, warning, audit finding, or deprecation you cannot fix now. Do not leave untracked `TODO`, `FIXME`, or follow-up work.
+- Use EPIC plus sub-issues before implementation whenever work will span more than one PR; if in doubt, choose EPIC plus sub-issues.
 - Keep GitHub-facing communication in English and reference files and lines instead of pasting large code blocks.
 - Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
-- Use EPIC plus sub-issues before starting work that will span more than one PR.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal` only as the Android application identifier.
+
+## Design Principles
+
+- DRY: eliminate duplicated content, styling, and policy handling before it drifts.
+- KISS: prefer the simplest solution that satisfies the current requirement and remains easy to maintain.
+- YAGNI: implement only what the current issue or acceptance criteria require; track future ideas as issues instead of building them now.
+- SOLID: keep responsibilities narrow, interfaces small, and extension points explicit.
+- Fail fast: validate early, stop on the first failed check, and do not accumulate known breakage.
+
+## Issue And PR Discipline
+
+- Every real out-of-scope finding becomes a GitHub issue immediately; no untracked follow-up work is allowed.
+- Complex work uses EPIC plus sub-issues before implementation. PRs should close sub-issues, not the epic, until the final linked step.
+- When local review finds zero issues, commit and push the finished branch before opening any PR.
+- The first PR state must be draft. Do not open a normal PR first.
+- Mark a draft PR ready only after the final self-review in the PR view still finds zero issues.
 
 ## Required Validation
 
 Before any commit, PR, or merge, announce the checklist you are executing and stop on the first failed item.
 At minimum verify:
 
+- the active branch and PR scope still address exactly one topic
+- TDD happened: the relevant test failed first and now passes
 - the smallest relevant validation passed for the touched area: formatting, lint, typecheck, and build when applicable
+- out-of-scope findings were turned into GitHub issues immediately
 - `CHANGELOG.md` was updated for real changes
 - commits are GPG-signed
 - REUSE compliance was checked when changed files require it
-- the local 4-pass review was completed
+- the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
 ## Repository Conventions

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -2,13 +2,18 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: AGPL-3.0-or-later
 name: secpal.app Runtime Overlay
-description: Provides additional website governance context when a task needs more than the repo baseline.
+description: Reinforces strict SecPal governance for all files in this repo.
+applyTo: "**"
 ---
 
 # secpal.app Runtime Overlay
 
-Use this file only when a task needs additional repo-wide governance context beyond `.github/copilot-instructions.md`.
+This file auto-applies to all files in this repo so strict SecPal governance stays always present at runtime.
 
 - `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
+- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch, immediate GitHub issue creation for every real out-of-scope finding, and no bypass.
+- If work needs more than one PR, or probably will, create an EPIC with linked sub-issues before implementation.
+- Design discipline is always-on: DRY, KISS, YAGNI, SOLID, and fail fast.
+- GitHub communication stays in English and uses file and line references instead of large verbatim code quotes.
 - Keep changes repo-local, minimal, and consistent with Astro, Tailwind CSS, and static-site conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working
+- clarified the repo-local PR workflow so finished website work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean
 - aligned the repo-local domain guidance and validation with the renamed Android application identifier `app.secpal`, removing the old identifier-only exception from current website policy text
 - reduced the repo-local Copilot always-on context by replacing the long runtime baseline and removing the auto-loaded overlay fallback, which lowers request size in large VS Code workspaces without dropping the website-specific governance rules
 


### PR DESCRIPTION
Fixes SecPal/.github#310

## Summary
- restore explicit strict governance wording in the website runtime baseline
- restore the always-on website runtime overlay for strict repo-wide governance
- document the rollback and PR-lifecycle clarification in the changelog

## Validation
- `git diff --check`
- `reuse lint`
