### PR TITLE
feat: add android distribution surface

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - clarified the repo-local branch-start and post-merge readiness workflow so new website work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
+
+### Changed
+
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - clarified the repo-local branch-start and post-merge readiness workflow so new website work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,8 +16,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, www.secpal.app, secpal.dev, dev.secpal.app"
+echo "Allowed: secpal.app, www.secpal.app, apk.secpal.app, secpal.dev, dev.secpal.app"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
+echo "Android artifact host: apk.secpal.app"
 echo "Identifier-only: app.secpal (Android application ID)"
 echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
@@ -49,10 +50,10 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, www.secpal.app, secpal.dev (including
-# api/app subdomains), dev.secpal.app, and deprecated-but-allowed api.secpal.app.
+# api/app subdomains), apk.secpal.app, dev.secpal.app, and deprecated-but-allowed api.secpal.app.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])dev\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])dev\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -102,6 +103,7 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app and www.secpal.app: public homepage and real email addresses"
+    echo "  - apk.secpal.app: canonical Android artifact and metadata host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -1,0 +1,198 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
+// Layout adapted from Tailwind Plus marketing blocks, especially
+// "split-with-screenshot" and code-heavy feature sections.
+import type { Locale } from "../i18n/index.ts";
+import {
+  androidChannels,
+  buildLatestMetadataPath,
+  getAndroidDistributionContent,
+} from "../lib/android-distribution.ts";
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const content = getAndroidDistributionContent(locale);
+---
+
+<div class="bg-white dark:bg-gray-900">
+  <section
+    class="relative isolate overflow-hidden border-b border-gray-200 dark:border-white/10"
+  >
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
+    >
+      <div
+        style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"
+        class="relative left-[calc(50%-12rem)] aspect-1155/678 w-160 -translate-x-1/2 rotate-12 bg-linear-to-r from-[#0f766e] to-[#2563eb] opacity-20 sm:left-[calc(50%-26rem)] sm:w-288"
+      >
+      </div>
+    </div>
+
+    <div
+      class="mx-auto grid max-w-7xl gap-16 px-6 py-20 lg:grid-cols-[minmax(0,1fr)_28rem] lg:px-8 lg:py-28"
+    >
+      <div class="max-w-3xl">
+        <p
+          class="text-sm/6 font-semibold tracking-[0.18em] text-indigo-600 uppercase dark:text-indigo-400"
+        >
+          {content.eyebrow}
+        </p>
+        <div
+          class="mt-6 inline-flex rounded-full bg-indigo-50 px-3 py-1 text-sm/6 font-semibold text-indigo-700 ring-1 ring-indigo-700/15 ring-inset dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-400/20"
+        >
+          {content.badge}
+        </div>
+        <h1
+          class="mt-8 text-5xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-6xl dark:text-white"
+        >
+          {content.headline}
+        </h1>
+        <p class="mt-6 max-w-2xl text-lg/8 text-gray-600 dark:text-gray-300">
+          {content.subline}
+        </p>
+        <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
+          <a
+            href="#machine-model"
+            class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+          >
+            {content.primaryCta}
+          </a>
+          <a
+            href="https://github.com/SecPal/android/pull/103"
+            class="text-sm/6 font-semibold text-gray-900 dark:text-white"
+          >
+            {content.secondaryCta}
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+      </div>
+
+      <aside
+        class="rounded-3xl border border-gray-200 bg-gray-50 p-6 shadow-sm dark:border-white/10 dark:bg-white/5"
+      >
+        <p class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+          {content.summaryTitle}
+        </p>
+        <dl class="mt-6 space-y-5">
+          {
+            content.summaryItems.map((item) => (
+              <div>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  {item.label}
+                </dt>
+                <dd class="mt-1 break-all font-mono text-sm text-gray-900 dark:text-gray-100">
+                  {item.value}
+                </dd>
+              </div>
+            ))
+          }
+        </dl>
+      </aside>
+    </div>
+  </section>
+
+  <section
+    class="border-b border-gray-200 bg-gray-50 py-20 dark:border-white/10 dark:bg-gray-800/50"
+  >
+    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+      <div class="max-w-3xl">
+        <h2
+          class="text-base/7 font-semibold text-indigo-600 dark:text-indigo-400"
+        >
+          {content.channelsTitle}
+        </h2>
+        <p class="mt-3 text-lg/8 text-gray-600 dark:text-gray-300">
+          {content.channelsIntro}
+        </p>
+      </div>
+      <div class="mt-10 grid gap-6 lg:grid-cols-2">
+        {
+          androidChannels.map((channel) => (
+            <article class="rounded-2xl border border-gray-200 bg-white p-6 shadow-xs dark:border-white/10 dark:bg-white/5">
+              <p class="text-xs font-semibold tracking-[0.18em] text-gray-500 uppercase dark:text-gray-400">
+                {channel}
+              </p>
+              <h3 class="mt-3 text-xl font-semibold text-gray-900 dark:text-white">
+                {content.channels[channel].name}
+              </h3>
+              <p class="mt-3 text-base/7 text-gray-600 dark:text-gray-300">
+                {content.channels[channel].description}
+              </p>
+              <p class="mt-4 font-mono text-xs text-gray-500 dark:text-gray-400">
+                {buildLatestMetadataPath(channel)}
+              </p>
+            </article>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section id="machine-model" class="py-20">
+    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+      <div class="max-w-3xl">
+        <h2
+          class="text-base/7 font-semibold text-indigo-600 dark:text-indigo-400"
+        >
+          {content.endpointsTitle}
+        </h2>
+        <p class="mt-3 text-lg/8 text-gray-600 dark:text-gray-300">
+          {content.endpointsIntro}
+        </p>
+      </div>
+      <div class="mt-10 grid gap-6 xl:grid-cols-2">
+        {
+          content.endpointGroups.map((group) => (
+            <section class="overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10">
+              <div class="border-b border-white/10 px-6 py-4">
+                <h3 class="text-base font-semibold text-white">
+                  {group.title}
+                </h3>
+              </div>
+              <div class="space-y-3 px-6 py-5 font-mono text-sm text-cyan-200">
+                {group.lines.map((line) => (
+                  <p>{line}</p>
+                ))}
+              </div>
+            </section>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section
+    class="border-y border-gray-200 bg-gray-950 py-20 text-white dark:border-white/10"
+  >
+    <div
+      class="mx-auto grid max-w-7xl gap-10 px-6 lg:grid-cols-[minmax(0,1fr)_22rem] lg:px-8"
+    >
+      <div>
+        <h2 class="text-3xl font-semibold tracking-tight text-balance">
+          {content.infrastructureTitle}
+        </h2>
+        <p class="mt-4 max-w-3xl text-base/7 text-gray-300">
+          {content.infrastructureBody}
+        </p>
+      </div>
+      <ul
+        class="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 text-sm/6 text-gray-200"
+      >
+        {
+          content.infrastructurePoints.map((point) => (
+            <li class="flex gap-3">
+              <span class="mt-1 size-2 shrink-0 rounded-full bg-cyan-300" />
+              <span>{point}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </section>
+</div>

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -64,7 +64,7 @@ const content = getAndroidDistributionContent(locale);
             {content.primaryCta}
           </a>
           <a
-            href="https://github.com/SecPal/android/pull/103"
+            href="https://github.com/SecPal/android"
             class="text-sm/6 font-semibold text-gray-900 dark:text-white"
           >
             {content.secondaryCta}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -53,6 +53,11 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         >{t.nav.progress}</a
       >
       <a
+        href={getLocalizedPath("/android", locale)}
+        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
+        >{t.nav.android}</a
+      >
+      <a
         href={updatesPath}
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
         >{t.nav.updates}</a
@@ -209,6 +214,11 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
               href={progressPath}
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >{t.nav.progress}</a
+            >
+            <a
+              href={getLocalizedPath("/android", locale)}
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+              >{t.nav.android}</a
             >
             <a
               href={updatesPath}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,6 +6,7 @@ import type { Translations } from "./en.ts";
 export const de: Translations = {
   nav: {
     progress: "Fortschritt",
+    android: "Android",
     updates: "Folgen",
     github: "GitHub",
     contact: "Kontakt",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,6 +4,7 @@
 export const en = {
   nav: {
     progress: "Progress",
+    android: "Android",
     updates: "Follow",
     github: "GitHub",
     contact: "Contact",

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { Locale } from "../i18n/index.ts";
+
+export const androidChannels = [
+  "managed_device",
+  "direct_apk",
+  "github_release",
+  "obtainium",
+] as const;
+
+export type AndroidChannel = (typeof androidChannels)[number];
+
+export const androidArtifactHost = "https://apk.secpal.app";
+export const androidLandingPath = "/android/";
+
+export function buildLatestMetadataPath(channel: AndroidChannel): string {
+  return `/android/channels/${channel}/latest.json`;
+}
+
+export function buildLatestArtifactPath(channel: AndroidChannel): string {
+  return `/android/channels/${channel}/app.secpal-latest.apk`;
+}
+
+export function buildLatestChecksumPath(channel: AndroidChannel): string {
+  return `/android/channels/${channel}/SHA256SUMS.txt`;
+}
+
+export function buildVersionedMetadataPath(version: string): string {
+  return `/android/releases/${version}/metadata.json`;
+}
+
+export function buildVersionedArtifactPath(version: string): string {
+  return `/android/releases/${version}/app.secpal-${version}.apk`;
+}
+
+export function buildVersionedChecksumPath(version: string): string {
+  return `/android/releases/${version}/SHA256SUMS.txt`;
+}
+
+export function buildArtifactUrl(path: string): string {
+  return new URL(path, androidArtifactHost).toString();
+}
+
+export const androidDistributionContent = {
+  en: {
+    title: "SecPal Android distribution",
+    description:
+      "Human-facing Android landing flow on secpal.app with stable machine-facing apk.secpal.app endpoint patterns for latest and versioned SecPal releases.",
+    eyebrow: "Android distribution surface",
+    headline:
+      "One Android package, channel-aware distribution, and stable public URLs.",
+    subline:
+      "SecPal keeps Device Owner provisioning, direct APK delivery, GitHub releases, and Obtainium compatibility on the same signed app package: app.secpal.",
+    badge: "Tailored for the single-app Android distribution architecture",
+    primaryCta: "View endpoint model",
+    secondaryCta: "Follow Android work on GitHub",
+    summaryTitle: "Canonical surfaces",
+    summaryItems: [
+      {
+        label: "Human landing",
+        value: "https://secpal.app/android",
+      },
+      {
+        label: "Artifact host",
+        value: "https://apk.secpal.app",
+      },
+      {
+        label: "App package",
+        value: "app.secpal",
+      },
+    ],
+    channelsTitle: "Channels without a second app flavor",
+    channelsIntro:
+      "The APK stays identical. Channel metadata, provisioning context, and rollout policy decide how the same package is delivered and updated.",
+    channels: {
+      managed_device: {
+        name: "Managed device",
+        description:
+          "Private provisioning QR flows for Device Owner enrollment. The machine-facing metadata stays stable while the tenant-bound bootstrap token remains short-lived.",
+      },
+      direct_apk: {
+        name: "Direct APK",
+        description:
+          "Human-driven installs that should always resolve to a latest APK URL, checksum, and metadata document under apk.secpal.app.",
+      },
+      github_release: {
+        name: "GitHub release",
+        description:
+          "Public release notes can continue to live on GitHub Releases while the canonical machine endpoints stay anchored on apk.secpal.app.",
+      },
+      obtainium: {
+        name: "Obtainium",
+        description:
+          "Update tooling can poll a stable JSON endpoint instead of scraping HTML or guessing release filenames.",
+      },
+    },
+    endpointsTitle: "Stable endpoints for humans and machines",
+    endpointsIntro:
+      "The landing route stays human-readable on secpal.app. All machine-facing URLs are defined against apk.secpal.app so later release automation can switch storage backends without changing clients.",
+    endpointGroups: [
+      {
+        title: "Latest channel metadata",
+        lines: [
+          "https://apk.secpal.app/android/channels/{channel}/latest.json",
+          "https://apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk",
+          "https://apk.secpal.app/android/channels/{channel}/SHA256SUMS.txt",
+        ],
+      },
+      {
+        title: "Versioned release assets",
+        lines: [
+          "https://apk.secpal.app/android/releases/{version}/metadata.json",
+          "https://apk.secpal.app/android/releases/{version}/app.secpal-{version}.apk",
+          "https://apk.secpal.app/android/releases/{version}/SHA256SUMS.txt",
+        ],
+      },
+    ],
+    infrastructureTitle:
+      "Hosting is defined. Binary storage is still an explicit release decision.",
+    infrastructureBody:
+      "This repository now defines the public route structure and metadata contract. The backing APK storage choice, such as GitHub Releases, object storage, or a CDN, still needs an explicit release-time decision before automation is wired up.",
+    infrastructurePoints: [
+      "secpal.app/android stays the human-facing entry point.",
+      "apk.secpal.app stays the canonical technical host for APKs, checksums, and metadata.",
+      "The same signed APK must remain available across GitHub and apk.secpal.app.",
+    ],
+    machineModelTitle: "Machine-readable model",
+    machineModelBody:
+      "Clients and future release automation can start from the stable JSON surfaces below while the storage backend decision stays open.",
+    machineModelPrimary: "Channel metadata",
+    machineModelSecondary: "Release URL model",
+  },
+  de: {
+    title: "SecPal Android-Verteilung",
+    description:
+      "Öffentlicher Android-Einstieg auf secpal.app mit stabilen maschinenlesbaren URL-Modellen auf apk.secpal.app für aktuelle und versionierte SecPal-Releases.",
+    eyebrow: "Android-Verteilungsfläche",
+    headline:
+      "Ein Android-Paket, kanalbewusste Verteilung und stabile öffentliche URLs.",
+    subline:
+      "SecPal hält Device-Owner-Provisioning, direkte APK-Verteilung, GitHub-Releases und Obtainium-Kompatibilität auf demselben signierten App-Paket: app.secpal.",
+    badge: "Abgeleitet aus der Single-App-Android-Architektur",
+    primaryCta: "Endpoint-Modell ansehen",
+    secondaryCta: "Android-Entwicklung auf GitHub verfolgen",
+    summaryTitle: "Kanonische Flächen",
+    summaryItems: [
+      {
+        label: "Öffentlicher Einstieg",
+        value: "https://secpal.app/android",
+      },
+      {
+        label: "Artefakt-Host",
+        value: "https://apk.secpal.app",
+      },
+      {
+        label: "App-Paket",
+        value: "app.secpal",
+      },
+    ],
+    channelsTitle: "Kanäle ohne zweite App-Variante",
+    channelsIntro:
+      "Die APK bleibt identisch. Kanal-Metadaten, Provisioning-Kontext und Rollout-Regeln entscheiden, wie dasselbe Paket verteilt und aktualisiert wird.",
+    channels: {
+      managed_device: {
+        name: "Managed Device",
+        description:
+          "Private Provisioning-QR-Flows für Device-Owner-Einschreibung. Die maschinenlesbaren Metadaten bleiben stabil, während der tenantgebundene Bootstrap-Token kurzlebig bleibt.",
+      },
+      direct_apk: {
+        name: "Direkte APK",
+        description:
+          "Menschlich ausgelöste Installationen sollen immer auf eine stabile Latest-APK-URL, Prüfsumme und Metadaten-Datei unter apk.secpal.app zeigen.",
+      },
+      github_release: {
+        name: "GitHub Release",
+        description:
+          "Öffentliche Release Notes können weiter auf GitHub Releases liegen, während die kanonischen Maschinen-Endpunkte auf apk.secpal.app verankert bleiben.",
+      },
+      obtainium: {
+        name: "Obtainium",
+        description:
+          "Update-Werkzeuge können einen stabilen JSON-Endpunkt abfragen, statt HTML zu scrapen oder Dateinamen zu erraten.",
+      },
+    },
+    endpointsTitle: "Stabile Endpunkte für Menschen und Maschinen",
+    endpointsIntro:
+      "Der Einstiegsweg für Menschen bleibt auf secpal.app lesbar. Alle technischen URLs werden gegen apk.secpal.app definiert, damit spätere Release-Automation das Storage-Backend wechseln kann, ohne Clients anzupassen.",
+    endpointGroups: [
+      {
+        title: "Aktuelle Kanal-Metadaten",
+        lines: [
+          "https://apk.secpal.app/android/channels/{channel}/latest.json",
+          "https://apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk",
+          "https://apk.secpal.app/android/channels/{channel}/SHA256SUMS.txt",
+        ],
+      },
+      {
+        title: "Versionierte Release-Artefakte",
+        lines: [
+          "https://apk.secpal.app/android/releases/{version}/metadata.json",
+          "https://apk.secpal.app/android/releases/{version}/app.secpal-{version}.apk",
+          "https://apk.secpal.app/android/releases/{version}/SHA256SUMS.txt",
+        ],
+      },
+    ],
+    infrastructureTitle:
+      "Hosting ist definiert. Binäre Ablage bleibt eine explizite Release-Entscheidung.",
+    infrastructureBody:
+      "Dieses Repository definiert jetzt die öffentliche Routenstruktur und den Metadaten-Vertrag. Die eigentliche APK-Ablage, etwa GitHub Releases, Object Storage oder CDN, braucht vor Release-Automation weiterhin eine explizite Entscheidung.",
+    infrastructurePoints: [
+      "secpal.app/android bleibt der menschliche Einstiegspunkt.",
+      "apk.secpal.app bleibt der kanonische technische Host für APKs, Prüfsummen und Metadaten.",
+      "Dieselbe signierte APK muss auf GitHub und apk.secpal.app verfügbar bleiben.",
+    ],
+  },
+} as const satisfies Record<Locale, unknown>;
+
+export function getAndroidDistributionContent(locale: Locale) {
+  return androidDistributionContent[locale];
+}

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -126,11 +126,6 @@ export const androidDistributionContent = {
       "apk.secpal.app stays the canonical technical host for APKs, checksums, and metadata.",
       "The same signed APK must remain available across GitHub and apk.secpal.app.",
     ],
-    machineModelTitle: "Machine-readable model",
-    machineModelBody:
-      "Clients and future release automation can start from the stable JSON surfaces below while the storage backend decision stays open.",
-    machineModelPrimary: "Channel metadata",
-    machineModelSecondary: "Release URL model",
   },
   de: {
     title: "SecPal Android-Verteilung",

--- a/src/pages/[locale]/android.astro
+++ b/src/pages/[locale]/android.astro
@@ -1,0 +1,33 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { GetStaticPaths } from "astro";
+import Base from "../../layouts/Base.astro";
+import Nav from "../../components/Nav.astro";
+import Footer from "../../components/Footer.astro";
+import AndroidDistributionSurface from "../../components/AndroidDistributionSurface.astro";
+import { locales, type Locale } from "../../i18n/index.ts";
+import { getAndroidDistributionContent } from "../../lib/android-distribution.ts";
+
+export const getStaticPaths = (() =>
+  locales.map((locale) => ({ params: { locale } }))) satisfies GetStaticPaths;
+
+const locale = Astro.params.locale as Locale;
+const content = getAndroidDistributionContent(locale);
+---
+
+<Base
+  title={content.title}
+  description={content.description}
+  lang={locale}
+  canonicalPath={`/${locale}/android/`}
+  alternateEnPath="/en/android/"
+  alternateDePath="/de/android/"
+  xDefaultPath="/android/"
+>
+  <Nav locale={locale} currentPath="/android" />
+  <main>
+    <AndroidDistributionSurface locale={locale} />
+  </main>
+  <Footer locale={locale} />
+</Base>

--- a/src/pages/android.astro
+++ b/src/pages/android.astro
@@ -1,0 +1,27 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import Base from "../layouts/Base.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+import AndroidDistributionSurface from "../components/AndroidDistributionSurface.astro";
+import { getAndroidDistributionContent } from "../lib/android-distribution.ts";
+
+const content = getAndroidDistributionContent("en");
+---
+
+<Base
+  title={content.title}
+  description={content.description}
+  lang="en"
+  canonicalPath="/android/"
+  alternateEnPath="/en/android/"
+  alternateDePath="/de/android/"
+  xDefaultPath="/android/"
+>
+  <Nav locale="en" currentPath="/android" />
+  <main>
+    <AndroidDistributionSurface locale="en" />
+  </main>
+  <Footer locale="en" />
+</Base>

--- a/src/pages/android/channels/[channel]/latest.json.ts
+++ b/src/pages/android/channels/[channel]/latest.json.ts
@@ -49,7 +49,7 @@ export const GET: APIRoute = ({ params, site }) => {
     notes: [
       "The URL structure is stable even before the first public Android release ships.",
       "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
-      "Versioned releases are reserved under /android/releases/{version}/metadata.json, /app.secpal-{version}.apk, and /SHA256SUMS.txt.",
+      "Versioned releases are reserved under /android/releases/{version}/metadata.json, /android/releases/{version}/app.secpal-{version}.apk, and /android/releases/{version}/SHA256SUMS.txt.",
     ],
   };
 

--- a/src/pages/android/channels/[channel]/latest.json.ts
+++ b/src/pages/android/channels/[channel]/latest.json.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { APIRoute, GetStaticPaths } from "astro";
+import {
+  type AndroidChannel,
+  androidArtifactHost,
+  androidChannels,
+  buildArtifactUrl,
+  buildLatestArtifactPath,
+  buildLatestChecksumPath,
+  buildLatestMetadataPath,
+} from "../../../../lib/android-distribution.ts";
+
+export const getStaticPaths = (() =>
+  androidChannels.map((channel) => ({
+    params: { channel },
+  }))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = ({ params, site }) => {
+  const channel = params.channel;
+
+  if (
+    !channel ||
+    !androidChannels.includes(channel as (typeof androidChannels)[number])
+  ) {
+    return new Response(
+      JSON.stringify({ message: "Unknown Android channel" }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      }
+    );
+  }
+
+  const resolvedChannel = channel as AndroidChannel;
+
+  const siteUrl = site ?? new URL("https://secpal.app");
+  const metadataPath = buildLatestMetadataPath(resolvedChannel);
+  const body = {
+    channel: resolvedChannel,
+    package_name: "app.secpal",
+    human_landing_url: new URL("/android/", siteUrl).toString(),
+    metadata_url: buildArtifactUrl(metadataPath),
+    latest_apk_url: buildArtifactUrl(buildLatestArtifactPath(resolvedChannel)),
+    checksum_url: buildArtifactUrl(buildLatestChecksumPath(resolvedChannel)),
+    artifact_host: androidArtifactHost,
+    release_available: false,
+    storage_backend_status: "pending_release_decision",
+    notes: [
+      "The URL structure is stable even before the first public Android release ships.",
+      "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
+      "Versioned releases are reserved under /android/releases/{version}/metadata.json, /app.secpal-{version}.apk, and /SHA256SUMS.txt.",
+    ],
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -20,6 +20,30 @@ const pages = [
     },
   },
   {
+    path: "/android/",
+    alternates: {
+      en: "/en/android/",
+      de: "/de/android/",
+      "x-default": "/android/",
+    },
+  },
+  {
+    path: "/en/android/",
+    alternates: {
+      en: "/en/android/",
+      de: "/de/android/",
+      "x-default": "/android/",
+    },
+  },
+  {
+    path: "/de/android/",
+    alternates: {
+      en: "/en/android/",
+      de: "/de/android/",
+      "x-default": "/android/",
+    },
+  },
+  {
     path: "/en/privacy/",
     alternates: {
       en: "/en/privacy/",


### PR DESCRIPTION
## Summary
- add the public Android landing flow on `secpal.app/android` with localized English and German pages
- define stable machine-facing channel metadata on `apk.secpal.app` path patterns through static JSON endpoints
- align navigation, sitemap, changelog, and repo-local domain policy with the single-package Android distribution architecture

## Testing
- `npm exec prettier -- --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx,astro}'`
- `npm exec eslint -- . --max-warnings 0`
- `npx astro check`
- `npm run build`
- `./scripts/check-domains.sh`
- repo pre-push hook (`format`, `REUSE`, domain policy, `astro check`, `eslint`, `build`, signed commits, PR size)

Refs #46