### PR TITLE
docs: add PR body-file mandate to Issue And PR Discipline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - When local review finds zero issues, commit and push the finished branch before opening any PR.
 - The first PR state must be draft. Do not open a normal PR first.
 - Mark a draft PR ready only after the final self-review in the PR view still finds zero issues.
+- When creating or editing PRs programmatically, write multi-line body content to a file and use `--body-file` to prevent shell escaping issues.
 
 ## Required Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - clarified the repo-local branch-start and post-merge readiness workflow so new website work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working
 - clarified the repo-local PR workflow so finished website work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean


### PR DESCRIPTION
## Summary

Codifies the PR body-file prevention learning from the recent CI failure audit into repo governance. Adds the explicit rule that was missing.

## Changes

### Copilot Instructions (`.github/copilot-instructions.md`)

**Issue And PR Discipline** — new rule:
- When creating or editing PRs programmatically, write multi-line body content to a file and use `--body-file` to prevent shell escaping issues.

## Motivation

PR bodies created with `mcp_github_create_pull_request` double-escape `\n` characters, producing broken formatting. Making `--body-file` an explicit discipline item prevents recurrence.
