### PR TITLE
feat: add versioned Android metadata contract

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,3 +49,10 @@ jobs:
     with:
       node-version: "22"
       build-command: "npm run build"
+
+  test:
+    name: Node Tests
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@main
+    with:
+      node-version: "22"
+      test-command: "npm test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
+- added a concrete Android release metadata template endpoint at `secpal.app/android/releases/{version}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
-- added a concrete Android release metadata template endpoint at `secpal.app/android/releases/{version}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
+- added a concrete Android release metadata template endpoint at `apk.secpal.app/android/releases/{version}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint . --max-warnings 0",
     "typecheck": "astro check",
     "format": "prettier --write --cache '**/*.{md,yml,yaml,json,ts,tsx,js,jsx,astro}'",
+    "test": "node --experimental-strip-types --test tests/**/*.mjs",
     "format:check": "prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx,astro}'"
   },
   "dependencies": {

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -43,6 +43,43 @@ export function buildArtifactUrl(path: string): string {
   return new URL(path, androidArtifactHost).toString();
 }
 
+export interface AndroidVersionedReleaseMetadata {
+  version: string;
+  package_name: "app.secpal";
+  human_landing_url: string;
+  metadata_url: string;
+  versioned_apk_url: string;
+  checksum_url: string;
+  artifact_host: typeof androidArtifactHost;
+  release_available: false;
+  storage_backend_status: "pending_release_decision";
+  notes: string[];
+}
+
+export function buildVersionedMetadataDocument(
+  version: string,
+  siteUrl: URL
+): AndroidVersionedReleaseMetadata {
+  const metadataPath = buildVersionedMetadataPath(version);
+
+  return {
+    version,
+    package_name: "app.secpal",
+    human_landing_url: new URL(androidLandingPath, siteUrl).toString(),
+    metadata_url: buildArtifactUrl(metadataPath),
+    versioned_apk_url: buildArtifactUrl(buildVersionedArtifactPath(version)),
+    checksum_url: buildArtifactUrl(buildVersionedChecksumPath(version)),
+    artifact_host: androidArtifactHost,
+    release_available: false,
+    storage_backend_status: "pending_release_decision",
+    notes: [
+      "The URL structure is stable even before the first public Android release ships.",
+      "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
+      "Channel latest endpoints remain available under /android/channels/{channel}/latest.json for rollout-specific clients.",
+    ],
+  };
+}
+
 export const androidDistributionContent = {
   en: {
     title: "SecPal Android distribution",

--- a/src/pages/android/releases/{version}/metadata.json.ts
+++ b/src/pages/android/releases/{version}/metadata.json.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { APIRoute } from "astro";
+import {
+  androidArtifactHost,
+  androidLandingPath,
+  buildVersionedArtifactPath,
+  buildVersionedChecksumPath,
+  buildVersionedMetadataPath,
+} from "../../../../lib/android-distribution.ts";
+
+const versionPlaceholder = "{version}";
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL("https://secpal.app");
+  const body = {
+    version: versionPlaceholder,
+    package_name: "app.secpal",
+    human_landing_url: new URL(androidLandingPath, siteUrl).toString(),
+    metadata_url: `${androidArtifactHost}${buildVersionedMetadataPath(versionPlaceholder)}`,
+    versioned_apk_url: `${androidArtifactHost}${buildVersionedArtifactPath(versionPlaceholder)}`,
+    checksum_url: `${androidArtifactHost}${buildVersionedChecksumPath(versionPlaceholder)}`,
+    artifact_host: androidArtifactHost,
+    release_available: false,
+    storage_backend_status: "pending_release_decision",
+    notes: [
+      "Replace {version} with the concrete SecPal Android release identifier.",
+      "The URL structure is stable even before the first public Android release ships.",
+      "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
+    ],
+  };
+
+  return new Response(JSON.stringify(body, null, 2), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/android/releases/{version}/metadata.json.ts
+++ b/src/pages/android/releases/{version}/metadata.json.ts
@@ -2,18 +2,33 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { APIRoute } from "astro";
-import { buildVersionedMetadataDocument } from "../../../../lib/android-distribution.ts";
+import {
+  androidArtifactHost,
+  androidLandingPath,
+  buildVersionedArtifactPath,
+  buildVersionedChecksumPath,
+  buildVersionedMetadataPath,
+} from "../../../../lib/android-distribution.ts";
 
+// Use a string placeholder rather than URL() to avoid percent-encoding { and }.
 const versionPlaceholder = "{version}";
 
 export const GET: APIRoute = ({ site }) => {
   const siteUrl = site ?? new URL("https://secpal.app");
-  const metadata = buildVersionedMetadataDocument(versionPlaceholder, siteUrl);
   const body = {
-    ...metadata,
+    version: versionPlaceholder,
+    package_name: "app.secpal",
+    human_landing_url: new URL(androidLandingPath, siteUrl).toString(),
+    metadata_url: `${androidArtifactHost}${buildVersionedMetadataPath(versionPlaceholder)}`,
+    versioned_apk_url: `${androidArtifactHost}${buildVersionedArtifactPath(versionPlaceholder)}`,
+    checksum_url: `${androidArtifactHost}${buildVersionedChecksumPath(versionPlaceholder)}`,
+    artifact_host: androidArtifactHost,
+    release_available: false,
+    storage_backend_status: "pending_release_decision",
     notes: [
       "Replace {version} with the concrete SecPal Android release identifier.",
-      ...metadata.notes,
+      "The URL structure is stable even before the first public Android release ships.",
+      "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
     ],
   };
 

--- a/src/pages/android/releases/{version}/metadata.json.ts
+++ b/src/pages/android/releases/{version}/metadata.json.ts
@@ -2,32 +2,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { APIRoute } from "astro";
-import {
-  androidArtifactHost,
-  androidLandingPath,
-  buildVersionedArtifactPath,
-  buildVersionedChecksumPath,
-  buildVersionedMetadataPath,
-} from "../../../../lib/android-distribution.ts";
+import { buildVersionedMetadataDocument } from "../../../../lib/android-distribution.ts";
 
 const versionPlaceholder = "{version}";
 
 export const GET: APIRoute = ({ site }) => {
   const siteUrl = site ?? new URL("https://secpal.app");
+  const metadata = buildVersionedMetadataDocument(versionPlaceholder, siteUrl);
   const body = {
-    version: versionPlaceholder,
-    package_name: "app.secpal",
-    human_landing_url: new URL(androidLandingPath, siteUrl).toString(),
-    metadata_url: `${androidArtifactHost}${buildVersionedMetadataPath(versionPlaceholder)}`,
-    versioned_apk_url: `${androidArtifactHost}${buildVersionedArtifactPath(versionPlaceholder)}`,
-    checksum_url: `${androidArtifactHost}${buildVersionedChecksumPath(versionPlaceholder)}`,
-    artifact_host: androidArtifactHost,
-    release_available: false,
-    storage_backend_status: "pending_release_decision",
+    ...metadata,
     notes: [
       "Replace {version} with the concrete SecPal Android release identifier.",
-      "The URL structure is stable even before the first public Android release ships.",
-      "Binary storage backing for apk.secpal.app remains an explicit release-time infrastructure decision.",
+      ...metadata.notes,
     ],
   };
 

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  androidArtifactHost,
+  buildVersionedArtifactPath,
+  buildVersionedChecksumPath,
+  buildVersionedMetadataDocument,
+  buildVersionedMetadataPath,
+} from "../src/lib/android-distribution.ts";
+
+test("buildVersionedMetadataDocument returns stable versioned Android release URLs", () => {
+  const version = "1.2.3";
+  const siteUrl = new URL("https://secpal.app");
+
+  const metadata = buildVersionedMetadataDocument(version, siteUrl);
+
+  assert.equal(metadata.version, version);
+  assert.equal(metadata.package_name, "app.secpal");
+  assert.equal(metadata.artifact_host, androidArtifactHost);
+  assert.equal(metadata.human_landing_url, "https://secpal.app/android/");
+  assert.equal(
+    metadata.metadata_url,
+    `https://apk.secpal.app${buildVersionedMetadataPath(version)}`
+  );
+  assert.equal(
+    metadata.versioned_apk_url,
+    `https://apk.secpal.app${buildVersionedArtifactPath(version)}`
+  );
+  assert.equal(
+    metadata.checksum_url,
+    `https://apk.secpal.app${buildVersionedChecksumPath(version)}`
+  );
+  assert.equal(metadata.release_available, false);
+  assert.equal(metadata.storage_backend_status, "pending_release_decision");
+  assert.ok(
+    metadata.notes.some((note) =>
+      note.includes("release-time infrastructure decision")
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared versioned Android release metadata contract helper for stable apk.secpal.app URLs
- publish a concrete template endpoint at /android/releases/{version}/metadata.json for static-site builds
- cover the versioned metadata contract with a focused Node-based regression test and document it in the changelog

## Validation
- node --experimental-strip-types --test tests/android-distribution.test.mjs
- npm run check
- npm run lint
- npm run build

Closes #52.
Part of #46.
