### PR TITLE
feat: add stable Android artifact routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
 - added a concrete Android release metadata template endpoint at `apk.secpal.app/android/releases/{version}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
+- added stable placeholder routes for latest and versioned Android APK/checksum files on `apk.secpal.app`, so the public artifact URL model now resolves with explicit pre-release `404` responses instead of missing route definitions
 
 ### Changed
 

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -43,6 +43,34 @@ export function buildArtifactUrl(path: string): string {
   return new URL(path, androidArtifactHost).toString();
 }
 
+export function isAndroidChannel(value: string): value is AndroidChannel {
+  return androidChannels.includes(value as AndroidChannel);
+}
+
+export function buildPendingAndroidAssetMessage(
+  requestedPath: string,
+  siteUrl: URL
+): string {
+  return [
+    `SecPal Android release artifacts are not published yet for ${requestedPath}.`,
+    "The stable URL exists before the first public release so clients can rely on the canonical endpoint model.",
+    `See ${new URL(androidLandingPath, siteUrl).toString()} for the current Android distribution status.`,
+  ].join("\n");
+}
+
+export function buildPendingAndroidAssetResponse(
+  requestedPath: string,
+  siteUrl: URL
+): Response {
+  return new Response(buildPendingAndroidAssetMessage(requestedPath, siteUrl), {
+    status: 404,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
 export interface AndroidVersionedReleaseMetadata {
   version: string;
   package_name: "app.secpal";

--- a/src/pages/android/channels/[channel]/SHA256SUMS.txt.ts
+++ b/src/pages/android/channels/[channel]/SHA256SUMS.txt.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { APIRoute, GetStaticPaths } from "astro";
+import {
+  androidChannels,
+  buildLatestChecksumPath,
+  buildPendingAndroidAssetResponse,
+  isAndroidChannel,
+} from "../../../../lib/android-distribution.ts";
+
+export const getStaticPaths = (() =>
+  androidChannels.map((channel) => ({
+    params: { channel },
+  }))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = ({ params, site }) => {
+  const channel = params.channel;
+
+  if (!channel || !isAndroidChannel(channel)) {
+    return new Response("Unknown Android channel", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return buildPendingAndroidAssetResponse(
+    buildLatestChecksumPath(channel),
+    siteUrl
+  );
+};

--- a/src/pages/android/channels/[channel]/app.secpal-latest.apk.ts
+++ b/src/pages/android/channels/[channel]/app.secpal-latest.apk.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { APIRoute, GetStaticPaths } from "astro";
+import {
+  androidChannels,
+  buildLatestArtifactPath,
+  buildPendingAndroidAssetResponse,
+  isAndroidChannel,
+} from "../../../../lib/android-distribution.ts";
+
+export const getStaticPaths = (() =>
+  androidChannels.map((channel) => ({
+    params: { channel },
+  }))) satisfies GetStaticPaths;
+
+export const GET: APIRoute = ({ params, site }) => {
+  const channel = params.channel;
+
+  if (!channel || !isAndroidChannel(channel)) {
+    return new Response("Unknown Android channel", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return buildPendingAndroidAssetResponse(
+    buildLatestArtifactPath(channel),
+    siteUrl
+  );
+};

--- a/src/pages/android/channels/[channel]/latest.json.ts
+++ b/src/pages/android/channels/[channel]/latest.json.ts
@@ -9,6 +9,7 @@ import {
   buildLatestArtifactPath,
   buildLatestChecksumPath,
   buildLatestMetadataPath,
+  isAndroidChannel,
 } from "../../../../lib/android-distribution.ts";
 
 export const getStaticPaths = (() =>
@@ -19,10 +20,7 @@ export const getStaticPaths = (() =>
 export const GET: APIRoute = ({ params, site }) => {
   const channel = params.channel;
 
-  if (
-    !channel ||
-    !androidChannels.includes(channel as (typeof androidChannels)[number])
-  ) {
+  if (!channel || !isAndroidChannel(channel)) {
     return new Response(
       JSON.stringify({ message: "Unknown Android channel" }),
       {
@@ -32,7 +30,7 @@ export const GET: APIRoute = ({ params, site }) => {
     );
   }
 
-  const resolvedChannel = channel as AndroidChannel;
+  const resolvedChannel: AndroidChannel = channel;
 
   const siteUrl = site ?? new URL("https://secpal.app");
   const metadataPath = buildLatestMetadataPath(resolvedChannel);

--- a/src/pages/android/releases/{version}/SHA256SUMS.txt.ts
+++ b/src/pages/android/releases/{version}/SHA256SUMS.txt.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { APIRoute } from "astro";
+import {
+  buildPendingAndroidAssetResponse,
+  buildVersionedChecksumPath,
+} from "../../../../lib/android-distribution.ts";
+
+export const GET: APIRoute = ({ params, site }) => {
+  const version = params.version;
+
+  if (!version) {
+    return new Response("Unknown Android version", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return buildPendingAndroidAssetResponse(
+    buildVersionedChecksumPath(version),
+    siteUrl
+  );
+};

--- a/src/pages/android/releases/{version}/SHA256SUMS.txt.ts
+++ b/src/pages/android/releases/{version}/SHA256SUMS.txt.ts
@@ -7,20 +7,16 @@ import {
   buildVersionedChecksumPath,
 } from "../../../../lib/android-distribution.ts";
 
-export const GET: APIRoute = ({ params, site }) => {
-  const version = params.version;
+// Use a string placeholder rather than params.version: Astro does not parse
+// {version} in the directory name as a dynamic route segment.  The request
+// will always arrive with params.version undefined at runtime.
+const versionPlaceholder = "{version}";
 
-  if (!version) {
-    return new Response("Unknown Android version", {
-      status: 404,
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
-    });
-  }
-
+export const GET: APIRoute = ({ site }) => {
   const siteUrl = site ?? new URL("https://secpal.app");
 
   return buildPendingAndroidAssetResponse(
-    buildVersionedChecksumPath(version),
+    buildVersionedChecksumPath(versionPlaceholder),
     siteUrl
   );
 };

--- a/src/pages/android/releases/{version}/app.secpal-{version}.apk.ts
+++ b/src/pages/android/releases/{version}/app.secpal-{version}.apk.ts
@@ -7,20 +7,16 @@ import {
   buildVersionedArtifactPath,
 } from "../../../../lib/android-distribution.ts";
 
-export const GET: APIRoute = ({ params, site }) => {
-  const version = params.version;
+// Use a string placeholder rather than params.version: Astro does not parse
+// {version} in the directory name as a dynamic route segment.  The request
+// will always arrive with params.version undefined at runtime.
+const versionPlaceholder = "{version}";
 
-  if (!version) {
-    return new Response("Unknown Android version", {
-      status: 404,
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
-    });
-  }
-
+export const GET: APIRoute = ({ site }) => {
   const siteUrl = site ?? new URL("https://secpal.app");
 
   return buildPendingAndroidAssetResponse(
-    buildVersionedArtifactPath(version),
+    buildVersionedArtifactPath(versionPlaceholder),
     siteUrl
   );
 };

--- a/src/pages/android/releases/{version}/app.secpal-{version}.apk.ts
+++ b/src/pages/android/releases/{version}/app.secpal-{version}.apk.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { APIRoute } from "astro";
+import {
+  buildPendingAndroidAssetResponse,
+  buildVersionedArtifactPath,
+} from "../../../../lib/android-distribution.ts";
+
+export const GET: APIRoute = ({ params, site }) => {
+  const version = params.version;
+
+  if (!version) {
+    return new Response("Unknown Android version", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const siteUrl = site ?? new URL("https://secpal.app");
+
+  return buildPendingAndroidAssetResponse(
+    buildVersionedArtifactPath(version),
+    siteUrl
+  );
+};

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -6,11 +6,24 @@ import test from "node:test";
 
 import {
   androidArtifactHost,
+  androidChannels,
+  buildLatestArtifactPath,
+  buildLatestChecksumPath,
   buildVersionedArtifactPath,
   buildVersionedChecksumPath,
   buildVersionedMetadataDocument,
   buildVersionedMetadataPath,
 } from "../src/lib/android-distribution.ts";
+import {
+  GET as getLatestArtifact,
+  getStaticPaths as getLatestArtifactStaticPaths,
+} from "../src/pages/android/channels/[channel]/app.secpal-latest.apk.ts";
+import {
+  GET as getLatestChecksum,
+  getStaticPaths as getLatestChecksumStaticPaths,
+} from "../src/pages/android/channels/[channel]/SHA256SUMS.txt.ts";
+import { GET as getVersionedArtifact } from "../src/pages/android/releases/{version}/app.secpal-{version}.apk.ts";
+import { GET as getVersionedChecksum } from "../src/pages/android/releases/{version}/SHA256SUMS.txt.ts";
 
 test("buildVersionedMetadataDocument returns stable versioned Android release URLs", () => {
   const version = "1.2.3";
@@ -40,5 +53,68 @@ test("buildVersionedMetadataDocument returns stable versioned Android release UR
     metadata.notes.some((note) =>
       note.includes("release-time infrastructure decision")
     )
+  );
+});
+
+test("latest Android artifact routes stay stable before the first public release", async () => {
+  assert.deepEqual(
+    getLatestArtifactStaticPaths(),
+    androidChannels.map((channel) => ({ params: { channel } }))
+  );
+  assert.deepEqual(
+    getLatestChecksumStaticPaths(),
+    androidChannels.map((channel) => ({ params: { channel } }))
+  );
+
+  const artifactResponse = await getLatestArtifact({
+    params: { channel: "managed_device" },
+    site: new URL("https://secpal.app"),
+  });
+  const checksumResponse = await getLatestChecksum({
+    params: { channel: "managed_device" },
+    site: new URL("https://secpal.app"),
+  });
+
+  assert.equal(artifactResponse.status, 404);
+  assert.equal(checksumResponse.status, 404);
+  assert.equal(
+    artifactResponse.headers.get("Content-Type"),
+    "text/plain; charset=utf-8"
+  );
+  assert.equal(
+    checksumResponse.headers.get("Content-Type"),
+    "text/plain; charset=utf-8"
+  );
+  assert.equal(artifactResponse.headers.get("Cache-Control"), "no-store");
+  assert.equal(checksumResponse.headers.get("Cache-Control"), "no-store");
+  assert.match(
+    await artifactResponse.text(),
+    new RegExp(buildLatestArtifactPath("managed_device"), "u")
+  );
+  assert.match(
+    await checksumResponse.text(),
+    new RegExp(buildLatestChecksumPath("managed_device"), "u")
+  );
+});
+
+test("versioned Android artifact routes explain pending release availability", async () => {
+  const artifactResponse = await getVersionedArtifact({
+    params: { version: "1.2.3" },
+    site: new URL("https://secpal.app"),
+  });
+  const checksumResponse = await getVersionedChecksum({
+    params: { version: "1.2.3" },
+    site: new URL("https://secpal.app"),
+  });
+
+  assert.equal(artifactResponse.status, 404);
+  assert.equal(checksumResponse.status, 404);
+  assert.match(
+    await artifactResponse.text(),
+    new RegExp(buildVersionedArtifactPath("1.2.3"), "u")
+  );
+  assert.match(
+    await checksumResponse.text(),
+    new RegExp(buildVersionedChecksumPath("1.2.3"), "u")
   );
 });

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -87,34 +87,40 @@ test("latest Android artifact routes stay stable before the first public release
   );
   assert.equal(artifactResponse.headers.get("Cache-Control"), "no-store");
   assert.equal(checksumResponse.headers.get("Cache-Control"), "no-store");
-  assert.match(
-    await artifactResponse.text(),
-    new RegExp(buildLatestArtifactPath("managed_device"), "u")
+  const artifactText = await artifactResponse.text();
+  const checksumText = await checksumResponse.text();
+  assert.ok(
+    artifactText.includes(buildLatestArtifactPath("managed_device")),
+    `expected artifact body to contain ${buildLatestArtifactPath("managed_device")}`
   );
-  assert.match(
-    await checksumResponse.text(),
-    new RegExp(buildLatestChecksumPath("managed_device"), "u")
+  assert.ok(
+    checksumText.includes(buildLatestChecksumPath("managed_device")),
+    `expected checksum body to contain ${buildLatestChecksumPath("managed_device")}`
   );
 });
 
 test("versioned Android artifact routes explain pending release availability", async () => {
+  // These handlers serve at literal /{version}/ paths (not dynamic Astro segments);
+  // they use a {version} string placeholder rather than reading params.version.
   const artifactResponse = await getVersionedArtifact({
-    params: { version: "1.2.3" },
+    params: {},
     site: new URL("https://secpal.app"),
   });
   const checksumResponse = await getVersionedChecksum({
-    params: { version: "1.2.3" },
+    params: {},
     site: new URL("https://secpal.app"),
   });
 
   assert.equal(artifactResponse.status, 404);
   assert.equal(checksumResponse.status, 404);
-  assert.match(
-    await artifactResponse.text(),
-    new RegExp(buildVersionedArtifactPath("1.2.3"), "u")
+  const artifactText = await artifactResponse.text();
+  const checksumText = await checksumResponse.text();
+  assert.ok(
+    artifactText.includes(buildVersionedArtifactPath("{version}")),
+    `expected artifact body to contain ${buildVersionedArtifactPath("{version}")}`
   );
-  assert.match(
-    await checksumResponse.text(),
-    new RegExp(buildVersionedChecksumPath("1.2.3"), "u")
+  assert.ok(
+    checksumText.includes(buildVersionedChecksumPath("{version}")),
+    `expected checksum body to contain ${buildVersionedChecksumPath("{version}")}`
   );
 });


### PR DESCRIPTION
## Summary
- add stable latest and versioned APK/checksum route handlers under `apk.secpal.app/android/...`
- return explicit pre-release `404` placeholder responses until public Android binaries are published
- cover the new route behavior with focused Node tests and keep the JSON metadata route on the shared channel guard

## Testing
- `node --experimental-strip-types --test tests/android-distribution.test.mjs`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Part of #46
