### PR TITLE
fix: localize neutral entry redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - overrode vulnerable transitive `defu` and `vite` packages to patched release ranges through npm overrides so the website toolchain audit findings are remediated without broad dependency-range changes
+- neutral locale entry routes on `/` and `/android` now redirect German browser locales to `/de/...` and all other locales to `/en/...`, so `secpal.app` and `dev.secpal.app` no longer force the English Android page when the browser prefers German
 
 ## [0.0.1] - 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Built with [Astro](https://astro.build), [Tailwind CSS v4](https://tailwindcss.c
 ## Features
 
 - **Multilingual** — English and German (`/en/`, `/de/`)
-- **HTTP-level root locale redirect** — Nginx sends `/` to `/de/` for German browsers and `/en/` otherwise
+- **Locale-aware neutral entry routes** — `/` and `/android` resolve German browsers to `/de/...` and all other requests to `/en/...`
 - **Built in public** — product progress and release readiness instead of premature app onboarding
 - **Dark mode** — class-based, persisted in `localStorage`, flash-free
 - **Static** — minimal client-side JS with Astro-first rendering
@@ -142,9 +142,10 @@ layer. `Accept-Language` requests preferring German resolve to `/de/`, while
 all other requests fall back to `/en/`.
 
 The live development host runs directly on `https://dev.secpal.app`. There, the
-localized pages are served under `/en/` and `/de/`, while `src/pages/index.astro`
-provides the neutral root entry page that redirects browsers to `/en/` and still
-exposes the correct social preview metadata.
+localized pages are served under `/en/` and `/de/`, while the neutral entry
+routes under `/` and `/android` redirect browsers to the locale-specific pages
+based on the browser language and still expose the correct social preview
+metadata.
 
 ## License
 

--- a/src/components/NeutralLocaleRedirectPage.astro
+++ b/src/components/NeutralLocaleRedirectPage.astro
@@ -1,0 +1,100 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import Base from "../layouts/Base.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  canonicalPath: string;
+  alternateEnPath: string;
+  alternateDePath: string;
+  xDefaultPath: string;
+  redirectPath: string;
+  eyebrow: string;
+  headline: string;
+  body: string;
+  englishLabel?: string;
+  germanLabel?: string;
+  noindex?: boolean;
+}
+
+const {
+  title,
+  description,
+  canonicalPath,
+  alternateEnPath,
+  alternateDePath,
+  xDefaultPath,
+  redirectPath,
+  eyebrow,
+  headline,
+  body,
+  englishLabel = "English",
+  germanLabel = "Deutsch",
+  noindex = false,
+} = Astro.props;
+---
+
+<Base
+  title={title}
+  description={description}
+  lang="en"
+  canonicalPath={canonicalPath}
+  alternateEnPath={alternateEnPath}
+  alternateDePath={alternateDePath}
+  xDefaultPath={xDefaultPath}
+>
+  <Fragment slot="head">
+    {noindex && <meta name="robots" content="noindex" />}
+    <meta name="secpal-neutral-redirect-path" content={redirectPath} />
+    <script>
+      import { redirectToPreferredLocale } from "../lib/locale-redirect.ts";
+
+      const redirectPath = document
+        .querySelector('meta[name="secpal-neutral-redirect-path"]')
+        ?.getAttribute("content");
+
+      if (!redirectPath) {
+        throw new Error("Missing neutral locale redirect path.");
+      }
+
+      redirectToPreferredLocale(redirectPath);
+    </script>
+  </Fragment>
+  <main
+    class="flex min-h-screen items-center justify-center bg-white px-6 text-slate-900 dark:bg-slate-900 dark:text-white"
+  >
+    <div class="max-w-xl text-center">
+      <p
+        class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
+      >
+        {eyebrow}
+      </p>
+      <h1
+        class="mt-4 text-4xl font-semibold tracking-tight text-balance sm:text-5xl"
+      >
+        {headline}
+      </h1>
+      <p class="mt-6 text-lg leading-8 text-slate-600 dark:text-slate-300">
+        {body}
+      </p>
+      <div
+        class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
+      >
+        <a
+          href={alternateEnPath}
+          class="rounded-md bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white hover:bg-slate-700 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+        >
+          {englishLabel}
+        </a>
+        <a
+          href={alternateDePath}
+          class="rounded-md border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-900 hover:bg-slate-50 dark:border-white/20 dark:text-white dark:hover:bg-white/5"
+        >
+          {germanLabel}
+        </a>
+      </div>
+    </div>
+  </main>
+</Base>

--- a/src/components/NeutralLocaleRedirectPage.astro
+++ b/src/components/NeutralLocaleRedirectPage.astro
@@ -56,7 +56,8 @@ const {
         ?.getAttribute("content");
 
       if (!redirectPath) {
-        throw new Error("Missing neutral locale redirect path.");
+        // No redirect path meta found — the manual locale links below remain as fallback.
+        return;
       }
 
       redirectToPreferredLocale(redirectPath);

--- a/src/components/NeutralLocaleRedirectPage.astro
+++ b/src/components/NeutralLocaleRedirectPage.astro
@@ -55,12 +55,10 @@ const {
         .querySelector('meta[name="secpal-neutral-redirect-path"]')
         ?.getAttribute("content");
 
-      if (!redirectPath) {
-        // No redirect path meta found — the manual locale links below remain as fallback.
-        return;
+      if (redirectPath) {
+        redirectToPreferredLocale(redirectPath);
       }
-
-      redirectToPreferredLocale(redirectPath);
+      // No redirect path meta found — the manual locale links below remain as fallback.
     </script>
   </Fragment>
   <main

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -3,17 +3,15 @@
 
 import { en } from "./en.ts";
 import { de } from "./de.ts";
+import type { Locale } from "./routing.ts";
+
+export type { Locale } from "./routing.ts";
+export { locales, defaultLocale, getLocalizedPath } from "./routing.ts";
 
 export const translations = { en, de } as const;
-export type Locale = keyof typeof translations;
-export const locales: Locale[] = ["en", "de"];
-export const defaultLocale: Locale = "en";
 
 export function useTranslations(locale: Locale) {
   return translations[locale];
 }
 
-export function getLocalizedPath(path: string, locale: Locale): string {
-  const normalized = path === "/" ? "/" : path.replace(/\/?$/, "/");
-  return `/${locale}${normalized}`;
-}
+

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -13,5 +13,3 @@ export const translations = { en, de } as const;
 export function useTranslations(locale: Locale) {
   return translations[locale];
 }
-
-

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * Routing-only i18n constants and helpers — no translation payload.
+ * Safe to import in client-side redirect code without bundling translation objects.
+ */
+
+export type Locale = "en" | "de";
+export const locales: Locale[] = ["en", "de"];
+export const defaultLocale: Locale = "en";
+
+export function getLocalizedPath(path: string, locale: Locale): string {
+    const normalized = path === "/" ? "/" : path.replace(/\/?$/, "/");
+    return `/${locale}${normalized}`;
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -11,6 +11,6 @@ export const locales: Locale[] = ["en", "de"];
 export const defaultLocale: Locale = "en";
 
 export function getLocalizedPath(path: string, locale: Locale): string {
-    const normalized = path === "/" ? "/" : path.replace(/\/?$/, "/");
-    return `/${locale}${normalized}`;
+  const normalized = path === "/" ? "/" : path.replace(/\/?$/, "/");
+  return `/${locale}${normalized}`;
 }

--- a/src/lib/locale-redirect.ts
+++ b/src/lib/locale-redirect.ts
@@ -6,7 +6,7 @@ import {
   getLocalizedPath,
   locales,
   type Locale,
-} from "../i18n/index.ts";
+} from "../i18n/routing.ts";
 
 export function detectPreferredLocale(
   preferredLanguages?: readonly string[]

--- a/src/lib/locale-redirect.ts
+++ b/src/lib/locale-redirect.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {
+  defaultLocale,
+  getLocalizedPath,
+  locales,
+  type Locale,
+} from "../i18n/index.ts";
+
+export function detectPreferredLocale(
+  preferredLanguages?: readonly string[]
+): Locale {
+  for (const preferredLanguage of preferredLanguages ?? []) {
+    const normalized = preferredLanguage.trim().toLowerCase();
+
+    for (const locale of locales) {
+      if (normalized === locale || normalized.startsWith(`${locale}-`)) {
+        return locale;
+      }
+    }
+  }
+
+  return defaultLocale;
+}
+
+export function buildPreferredLocalePath(
+  path: string,
+  preferredLanguages?: readonly string[]
+): string {
+  return getLocalizedPath(path, detectPreferredLocale(preferredLanguages));
+}
+
+function getNavigatorLanguages(): string[] {
+  if (typeof navigator === "undefined") {
+    return [];
+  }
+
+  const preferredLanguages = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+
+  if (preferredLanguages.length > 0) {
+    return preferredLanguages;
+  }
+
+  return typeof navigator.language === "string" ? [navigator.language] : [];
+}
+
+export function redirectToPreferredLocale(path: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const targetUrl = new URL(
+    buildPreferredLocalePath(path, getNavigatorLanguages()),
+    window.location.origin
+  );
+
+  targetUrl.search = window.location.search;
+  targetUrl.hash = window.location.hash;
+
+  const currentUrl = new URL(window.location.href);
+
+  if (currentUrl.toString() === targetUrl.toString()) {
+    return;
+  }
+
+  window.location.replace(targetUrl);
+}

--- a/src/pages/android.astro
+++ b/src/pages/android.astro
@@ -1,27 +1,18 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import Base from "../layouts/Base.astro";
-import Nav from "../components/Nav.astro";
-import Footer from "../components/Footer.astro";
-import AndroidDistributionSurface from "../components/AndroidDistributionSurface.astro";
-import { getAndroidDistributionContent } from "../lib/android-distribution.ts";
-
-const content = getAndroidDistributionContent("en");
+import NeutralLocaleRedirectPage from "../components/NeutralLocaleRedirectPage.astro";
 ---
 
-<Base
-  title={content.title}
-  description={content.description}
-  lang="en"
+<NeutralLocaleRedirectPage
+  title="SecPal Android distribution"
+  description="Neutral Android entry point on secpal.app with links to the English and German SecPal Android distribution pages."
   canonicalPath="/android/"
   alternateEnPath="/en/android/"
   alternateDePath="/de/android/"
   xDefaultPath="/android/"
->
-  <Nav locale="en" currentPath="/android" />
-  <main>
-    <AndroidDistributionSurface locale="en" />
-  </main>
-  <Footer locale="en" />
-</Base>
+  redirectPath="/android"
+  eyebrow="SecPal Android"
+  headline="Redirecting to the Android page"
+  body="If your browser does not redirect automatically, continue to the English or German SecPal Android distribution page."
+/>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,56 +1,19 @@
 ---
 // SPDX-FileCopyrightText: 2026 SecPal
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import Base from "../layouts/Base.astro";
+import NeutralLocaleRedirectPage from "../components/NeutralLocaleRedirectPage.astro";
 ---
 
-<Base
+<NeutralLocaleRedirectPage
   title="SecPal – A guard’s best friend"
   description="SecPal reduces paperwork, fragmented tools, and operational friction in security operations with one clear workflow."
-  lang="en"
   canonicalPath="/"
   alternateEnPath="/en/"
   alternateDePath="/de/"
   xDefaultPath="/"
->
-  <Fragment slot="head">
-    <meta http-equiv="refresh" content="0;url=/en/" />
-    <meta name="robots" content="noindex" />
-  </Fragment>
-  <main
-    class="flex min-h-screen items-center justify-center bg-white px-6 text-slate-900 dark:bg-slate-900 dark:text-white"
-  >
-    <div class="max-w-xl text-center">
-      <p
-        class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400"
-      >
-        SecPal
-      </p>
-      <h1
-        class="mt-4 text-4xl font-semibold tracking-tight text-balance sm:text-5xl"
-      >
-        Redirecting to the public site
-      </h1>
-      <p class="mt-6 text-lg leading-8 text-slate-600 dark:text-slate-300">
-        If your browser does not redirect automatically, continue to the English
-        or German public site.
-      </p>
-      <div
-        class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
-      >
-        <a
-          href="/en/"
-          class="rounded-md bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white hover:bg-slate-700 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
-        >
-          English
-        </a>
-        <a
-          href="/de/"
-          class="rounded-md border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-900 hover:bg-slate-50 dark:border-white/20 dark:text-white dark:hover:bg-white/5"
-        >
-          Deutsch
-        </a>
-      </div>
-    </div>
-  </main>
-</Base>
+  redirectPath="/"
+  eyebrow="SecPal"
+  headline="Redirecting to the public site"
+  body="If your browser does not redirect automatically, continue to the English or German public site."
+  noindex={true}
+/>

--- a/tests/locale-redirect.test.mjs
+++ b/tests/locale-redirect.test.mjs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildPreferredLocalePath,
+  detectPreferredLocale,
+} from "../src/lib/locale-redirect.ts";
+
+test("detectPreferredLocale prefers German variants and falls back to English", () => {
+  assert.equal(detectPreferredLocale(["de-DE", "en-US"]), "de");
+  assert.equal(detectPreferredLocale(["de", "en"]), "de");
+  assert.equal(detectPreferredLocale(["fr-FR", "en-US"]), "en");
+  assert.equal(detectPreferredLocale([]), "en");
+  assert.equal(detectPreferredLocale(undefined), "en");
+});
+
+test("buildPreferredLocalePath keeps neutral entry routes locale-aware", () => {
+  assert.equal(buildPreferredLocalePath("/", ["de-DE"]), "/de/");
+  assert.equal(buildPreferredLocalePath("/", ["en-GB"]), "/en/");
+  assert.equal(buildPreferredLocalePath("/android", ["de-AT"]), "/de/android/");
+  assert.equal(
+    buildPreferredLocalePath("/android/", ["fr-FR"]),
+    "/en/android/"
+  );
+});


### PR DESCRIPTION
## Summary
- localize the neutral `/` and `/android` entry routes through a shared browser-locale redirect helper instead of forcing the English Android page
- reuse one neutral redirect page component for the entry routes and add tests covering German and English path resolution
- update the changelog and README to match the new neutral-entry behavior on `secpal.app` and `dev.secpal.app`

## Validation
- npm test
- npm run lint
- npm run check
- npm run build
- ./scripts/preflight.sh
- verified live on `dev.secpal.app`:
  - `Accept-Language: de-DE` redirects `/` to `/de/`
  - `Accept-Language: en-US` redirects `/` to `/en/`
  - the deployed `/android/` redirect module resolves German browsers to `/de/android/` and English browsers to `/en/android/`
