### PR TITLE
fix: respect mobile safe-area padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - overrode vulnerable transitive `defu` and `vite` packages to patched release ranges through npm overrides so the website toolchain audit findings are remediated without broad dependency-range changes
-- added safe-area-aware body padding so text and content blocks no longer sit too close to the mobile screen edge on devices with asymmetric viewport insets
+- added safe-area-aware body padding together with `viewport-fit=cover` so text and content blocks no longer sit too close to the mobile screen edge on devices with asymmetric viewport insets
 
 ## [0.0.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - overrode vulnerable transitive `defu` and `vite` packages to patched release ranges through npm overrides so the website toolchain audit findings are remediated without broad dependency-range changes
+- added safe-area-aware body padding so text and content blocks no longer sit too close to the mobile screen edge on devices with asymmetric viewport insets
 
 ## [0.0.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - overrode vulnerable transitive `defu` and `vite` packages to patched release ranges through npm overrides so the website toolchain audit findings are remediated without broad dependency-range changes
-- added safe-area-aware body padding together with `viewport-fit=cover` so text and content blocks no longer sit too close to the mobile screen edge on devices with asymmetric viewport insets
+- added safe-area-aware body padding together with `viewport-fit=cover` and wrapping rules for Android machine-readable cards so text and content blocks no longer sit too close to the mobile screen edge or overflow on devices with asymmetric viewport insets
 
 ## [0.0.1] - 2026-03-31
 

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -114,7 +114,7 @@ const content = getAndroidDistributionContent(locale);
       <div class="mt-10 grid gap-6 lg:grid-cols-2">
         {
           androidChannels.map((channel) => (
-            <article class="rounded-2xl border border-gray-200 bg-white p-6 shadow-xs dark:border-white/10 dark:bg-white/5">
+            <article class="min-w-0 rounded-2xl border border-gray-200 bg-white p-6 shadow-xs dark:border-white/10 dark:bg-white/5">
               <p class="text-xs font-semibold tracking-[0.18em] text-gray-500 uppercase dark:text-gray-400">
                 {channel}
               </p>
@@ -124,7 +124,7 @@ const content = getAndroidDistributionContent(locale);
               <p class="mt-3 text-base/7 text-gray-600 dark:text-gray-300">
                 {content.channels[channel].description}
               </p>
-              <p class="mt-4 font-mono text-xs text-gray-500 dark:text-gray-400">
+              <p class="mt-4 break-all font-mono text-xs text-gray-500 dark:text-gray-400">
                 {buildLatestMetadataPath(channel)}
               </p>
             </article>
@@ -149,7 +149,7 @@ const content = getAndroidDistributionContent(locale);
       <div class="mt-10 grid gap-6 xl:grid-cols-2">
         {
           content.endpointGroups.map((group) => (
-            <section class="overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10">
+            <section class="min-w-0 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10">
               <div class="border-b border-white/10 px-6 py-4">
                 <h3 class="text-base font-semibold text-white">
                   {group.title}
@@ -157,7 +157,7 @@ const content = getAndroidDistributionContent(locale);
               </div>
               <div class="space-y-3 px-6 py-5 font-mono text-sm text-cyan-200">
                 {group.lines.map((line) => (
-                  <p>{line}</p>
+                  <p class="break-all">{line}</p>
                 ))}
               </div>
             </section>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -69,7 +69,10 @@ const previewUrl = canonicalUrl ?? xDefaultUrl;
 <html lang={lang} class="">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta property="og:site_name" content="SecPal" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,6 +11,13 @@
   --secpal-nav-logo-height: 2rem;
   --secpal-nav-padding-y: 1rem;
   --secpal-nav-height: calc(var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2));
+  --secpal-safe-area-padding-inline-start: max(0px, env(safe-area-inset-left));
+  --secpal-safe-area-padding-inline-end: max(0px, env(safe-area-inset-right));
+}
+
+body {
+  padding-inline: var(--secpal-safe-area-padding-inline-start)
+    var(--secpal-safe-area-padding-inline-end);
 }
 
 @media (min-width: 1024px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,7 +10,9 @@
 :root {
   --secpal-nav-logo-height: 2rem;
   --secpal-nav-padding-y: 1rem;
-  --secpal-nav-height: calc(var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2));
+  --secpal-nav-height: calc(
+    var(--secpal-nav-logo-height) + (var(--secpal-nav-padding-y) * 2)
+  );
   --secpal-safe-area-padding-inline-start: max(0px, env(safe-area-inset-left));
   --secpal-safe-area-padding-inline-end: max(0px, env(safe-area-inset-right));
 }

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -38,17 +38,12 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
     "utf8"
   );
 
-  assert.match(
-    component,
-    /<article class="min-w-0 rounded-2xl border border-gray-200 bg-white p-6 shadow-xs/
-  );
-  assert.match(
-    component,
-    /<p class="mt-4 break-all font-mono text-xs text-gray-500 dark:text-gray-400">/
-  );
-  assert.match(
-    component,
-    /<section class="min-w-0 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl/
-  );
-  assert.match(component, /<p class="break-all">\{line\}<\/p>/);
+  // article channel cards have min-w-0 to prevent flex overflow
+  assert.match(component, /<article\b[^>]*class="[^"]*\bmin-w-0\b/);
+  // metadata path paragraph has break-all so long mono URLs wrap
+  assert.match(component, /<p\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b/);
+  // section endpoint groups have min-w-0 to prevent flex overflow
+  assert.match(component, /<section\b[^>]*class="[^"]*\bmin-w-0\b/);
+  // individual endpoint lines have break-all
+  assert.match(component, /<p\b[^>]*class="[^"]*\bbreak-all\b[^"]*">\{line\}/);
 });

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -19,3 +19,12 @@ test("global layout accounts for mobile safe-area insets", () => {
   );
   assert.match(css, /var\(--secpal-safe-area-padding-inline-end\)/);
 });
+
+test("base layout opts into viewport-fit cover for mobile safe areas", () => {
+  const layout = readFileSync(
+    new URL("../src/layouts/Base.astro", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(layout, /viewport-fit=cover/);
+});

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -28,3 +28,27 @@ test("base layout opts into viewport-fit cover for mobile safe areas", () => {
 
   assert.match(layout, /viewport-fit=cover/);
 });
+
+test("android distribution cards wrap long visible machine paths on mobile", () => {
+  const component = readFileSync(
+    new URL(
+      "../src/components/AndroidDistributionSurface.astro",
+      import.meta.url
+    ),
+    "utf8"
+  );
+
+  assert.match(
+    component,
+    /<article class="min-w-0 rounded-2xl border border-gray-200 bg-white p-6 shadow-xs/
+  );
+  assert.match(
+    component,
+    /<p class="mt-4 break-all font-mono text-xs text-gray-500 dark:text-gray-400">/
+  );
+  assert.match(
+    component,
+    /<section class="min-w-0 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl/
+  );
+  assert.match(component, /<p class="break-all">\{line\}<\/p>/);
+});

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+test("global layout accounts for mobile safe-area insets", () => {
+  const css = readFileSync(
+    new URL("../src/styles/global.css", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(css, /safe-area-inset-left/);
+  assert.match(css, /safe-area-inset-right/);
+  assert.match(
+    css,
+    /padding-inline:\s*var\(--secpal-safe-area-padding-inline-start\)/
+  );
+  assert.match(css, /var\(--secpal-safe-area-padding-inline-end\)/);
+});


### PR DESCRIPTION
## Summary
- add safe-area-aware body padding so layout text keeps distance from the physical screen edge on mobile devices with viewport insets
- opt the shared base layout into `viewport-fit=cover` so the safe-area padding actually applies on affected devices
- wrap Android machine-readable paths and endpoint URLs in the visible cards so `/android` no longer overflows horizontally on mobile
- add regression tests that cover the safe-area CSS, the required viewport meta, and the Android page wrapping rules

## Validation
- node --experimental-strip-types --test tests/mobile-safe-area.test.mjs
- npm test
- npm run lint
- npm run check
- SECPAL_SITE_URL=https://dev.secpal.app npm run build
- ./scripts/preflight.sh
- verified live on `dev.secpal.app` that the page ships `viewport-fit=cover`, safe-area CSS, and the Android wrapping markers for the visible machine-readable cards
