### PR TITLE
feat: add public roadmap page (/roadmap/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added public roadmap page at `/roadmap/` (localized as `/en/roadmap/` and `/de/roadmap/`) showing current development focus (Passkeys, employee onboarding), next planned step (Android app), and longer-term direction (shift planning, guard tour system, contract management, service instruction configurator) with a link to the full changelog at `changelog.secpal.app`
+- added roadmap navigation link to desktop and mobile menus, and roadmap paths to the sitemap
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable channel and release-model JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
 - added a concrete Android release metadata template endpoint at `apk.secpal.app/android/releases/{version}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
 - added stable placeholder routes for latest and versioned Android APK/checksum files on `apk.secpal.app`, so the public artifact URL model now resolves with explicit pre-release `404` responses instead of missing route definitions

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -24,7 +24,6 @@ interface Props {
 
 const { locale } = Astro.props;
 const t = useTranslations(locale);
-const progressPath = `${getLocalizedPath("/", locale)}#progress`;
 ---
 
 <div
@@ -73,13 +72,13 @@ const progressPath = `${getLocalizedPath("/", locale)}#progress`;
         </p>
         <div class="mt-8 flex items-center justify-center gap-x-6">
           <a
-            href="https://github.com/SecPal"
+            href={getLocalizedPath("/roadmap", locale)}
             class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
           >
             {t.hero.cta}
           </a>
           <a
-            href={progressPath}
+            href="https://github.com/SecPal"
             class="text-sm/6 font-semibold text-gray-900 dark:text-white"
           >
             {t.hero.ctaSecondary}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -53,11 +53,6 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         >{t.nav.progress}</a
       >
       <a
-        href={getLocalizedPath("/android", locale)}
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.android}</a
-      >
-      <a
         href={getLocalizedPath("/roadmap", locale)}
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
         >{t.nav.roadmap}</a
@@ -219,11 +214,6 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
               href={progressPath}
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >{t.nav.progress}</a
-            >
-            <a
-              href={getLocalizedPath("/android", locale)}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.android}</a
             >
             <a
               href={getLocalizedPath("/roadmap", locale)}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -58,6 +58,11 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
         >{t.nav.android}</a
       >
       <a
+        href={getLocalizedPath("/roadmap", locale)}
+        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
+        >{t.nav.roadmap}</a
+      >
+      <a
         href={updatesPath}
         class="text-sm/6 font-semibold text-gray-900 dark:text-white"
         >{t.nav.updates}</a
@@ -219,6 +224,11 @@ const updatesPath = `${getLocalizedPath("/", locale)}#updates`;
               href={getLocalizedPath("/android", locale)}
               class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
               >{t.nav.android}</a
+            >
+            <a
+              href={getLocalizedPath("/roadmap", locale)}
+              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+              >{t.nav.roadmap}</a
             >
             <a
               href={updatesPath}

--- a/src/components/Roadmap.astro
+++ b/src/components/Roadmap.astro
@@ -1,0 +1,132 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-FileCopyrightText: Tailwind Labs Inc.
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
+//
+// Adapted from Tailwind Plus UI Blocks — "Simple three-column with large icons"
+// Source: https://tailwindcss.com/plus/ui-blocks/marketing/page-sections/feature-sections
+import type { Locale } from "../i18n/index.ts";
+import { useTranslations } from "../i18n/index.ts";
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const t = useTranslations(locale);
+const r = t.roadmap;
+
+type Phase = "now" | "next" | "later";
+
+const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
+  {
+    key: "now",
+    accent:
+      "bg-indigo-600 dark:bg-indigo-500",
+    badge:
+      "inline-flex items-center gap-x-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-700/10 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/20",
+    dot: "bg-indigo-500",
+  },
+  {
+    key: "next",
+    accent: "bg-violet-600 dark:bg-violet-500",
+    badge:
+      "inline-flex items-center gap-x-1.5 rounded-full bg-violet-50 px-2.5 py-1 text-xs font-semibold text-violet-700 ring-1 ring-inset ring-violet-700/10 dark:bg-violet-400/10 dark:text-violet-400 dark:ring-violet-400/20",
+    dot: "bg-violet-500",
+  },
+  {
+    key: "later",
+    accent: "bg-gray-500 dark:bg-gray-400",
+    badge:
+      "inline-flex items-center gap-x-1.5 rounded-full bg-gray-50 px-2.5 py-1 text-xs font-semibold text-gray-600 ring-1 ring-inset ring-gray-500/10 dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20",
+    dot: "bg-gray-400",
+  },
+];
+---
+
+<div class="bg-white py-24 sm:py-32 dark:bg-gray-900">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+
+    <!-- Page header -->
+    <div class="mx-auto max-w-2xl lg:mx-0">
+      <h1
+        class="text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
+      >
+        {r.headline}
+      </h1>
+      <p class="mt-6 text-lg/8 text-gray-600 dark:text-gray-300">
+        {r.subline}
+      </p>
+    </div>
+
+    <!-- Phase columns -->
+    <div class="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
+      <dl class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
+        {
+          phases.map(({ key, accent, badge, dot }) => {
+            const phase = r[key];
+            return (
+              <div class="flex flex-col">
+                <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
+                  <div class={`mb-6 flex size-10 items-center justify-center rounded-lg ${accent}`}>
+                    {key === "now" && (
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
+                        <path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    )}
+                    {key === "next" && (
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
+                        <path d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    )}
+                    {key === "later" && (
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
+                        <path d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    )}
+                  </div>
+                  <span class={badge}>
+                    <svg viewBox="0 0 6 6" aria-hidden="true" class="size-1.5">
+                      <circle cx="3" cy="3" r="3" class={dot} fill="currentColor" />
+                    </svg>
+                    {phase.label}
+                  </span>
+                  <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">{phase.description}</p>
+                </dt>
+                <dd class="mt-4 flex flex-auto flex-col text-base/7 text-gray-600 dark:text-gray-400">
+                  <ul class="flex-auto space-y-4">
+                    {phase.items.map((item: { name: string; description: string }) => (
+                      <li>
+                        <p class="font-semibold text-gray-900 dark:text-white">{item.name}</p>
+                        <p class="mt-1 text-sm/6">{item.description}</p>
+                      </li>
+                    ))}
+                  </ul>
+                </dd>
+              </div>
+            );
+          })
+        }
+      </dl>
+    </div>
+
+    <!-- Changelog link -->
+    <div class="mt-20 border-t border-gray-200 pt-10 dark:border-white/10">
+      <p class="text-sm/6 font-semibold text-gray-900 dark:text-white">
+        {r.changelog.label}
+      </p>
+      <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-400">
+        {r.changelog.description}
+      </p>
+      <p class="mt-4">
+        <a
+          href={r.changelog.href}
+          class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          {r.changelog.link} <span aria-hidden="true">→</span>
+        </a>
+      </p>
+    </div>
+
+  </div>
+</div>

--- a/src/components/Roadmap.astro
+++ b/src/components/Roadmap.astro
@@ -21,8 +21,7 @@ type Phase = "now" | "next" | "later";
 const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
   {
     key: "now",
-    accent:
-      "bg-indigo-600 dark:bg-indigo-500",
+    accent: "bg-indigo-600 dark:bg-indigo-500",
     badge:
       "inline-flex items-center gap-x-1.5 rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-700/10 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/20",
     dot: "bg-indigo-500",
@@ -46,7 +45,6 @@ const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
 
 <div class="bg-white py-24 sm:py-32 dark:bg-gray-900">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
-
     <!-- Page header -->
     <div class="mx-auto max-w-2xl lg:mx-0">
       <h1
@@ -61,46 +59,95 @@ const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
 
     <!-- Phase columns -->
     <div class="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
-      <dl class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
+      <dl
+        class="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3"
+      >
         {
           phases.map(({ key, accent, badge, dot }) => {
             const phase = r[key];
             return (
               <div class="flex flex-col">
                 <dt class="text-base/7 font-semibold text-gray-900 dark:text-white">
-                  <div class={`mb-6 flex size-10 items-center justify-center rounded-lg ${accent}`}>
+                  <div
+                    class={`mb-6 flex size-10 items-center justify-center rounded-lg ${accent}`}
+                  >
                     {key === "now" && (
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
-                        <path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" stroke-linecap="round" stroke-linejoin="round" />
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        aria-hidden="true"
+                        class="size-6 text-white"
+                      >
+                        <path
+                          d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
                       </svg>
                     )}
                     {key === "next" && (
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
-                        <path d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" stroke-linecap="round" stroke-linejoin="round" />
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        aria-hidden="true"
+                        class="size-6 text-white"
+                      >
+                        <path
+                          d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
                       </svg>
                     )}
                     {key === "later" && (
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" class="size-6 text-white">
-                        <path d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" stroke-linecap="round" stroke-linejoin="round" />
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        aria-hidden="true"
+                        class="size-6 text-white"
+                      >
+                        <path
+                          d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
                       </svg>
                     )}
                   </div>
                   <span class={badge}>
                     <svg viewBox="0 0 6 6" aria-hidden="true" class="size-1.5">
-                      <circle cx="3" cy="3" r="3" class={dot} fill="currentColor" />
+                      <circle
+                        cx="3"
+                        cy="3"
+                        r="3"
+                        class={dot}
+                        fill="currentColor"
+                      />
                     </svg>
                     {phase.label}
                   </span>
-                  <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">{phase.description}</p>
+                  <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">
+                    {phase.description}
+                  </p>
                 </dt>
                 <dd class="mt-4 flex flex-auto flex-col text-base/7 text-gray-600 dark:text-gray-400">
                   <ul class="flex-auto space-y-4">
-                    {phase.items.map((item: { name: string; description: string }) => (
-                      <li>
-                        <p class="font-semibold text-gray-900 dark:text-white">{item.name}</p>
-                        <p class="mt-1 text-sm/6">{item.description}</p>
-                      </li>
-                    ))}
+                    {phase.items.map(
+                      (item: { name: string; description: string }) => (
+                        <li>
+                          <p class="font-semibold text-gray-900 dark:text-white">
+                            {item.name}
+                          </p>
+                          <p class="mt-1 text-sm/6">{item.description}</p>
+                        </li>
+                      )
+                    )}
                   </ul>
                 </dd>
               </div>
@@ -123,10 +170,10 @@ const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
           href={r.changelog.href}
           class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
         >
-          {r.changelog.link} <span aria-hidden="true">→</span>
+          {r.changelog.link}
+          <span aria-hidden="true">→</span>
         </a>
       </p>
     </div>
-
   </div>
 </div>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -93,7 +93,7 @@ export const de: Translations = {
         {
           name: "Android-App",
           description:
-            "Native Android-App auf Basis von Capacitor — gleicher Funktionsumfang wie die Web-App, geeignet für gemeinsam genutzte Geräte und den Außendienst.",
+            "Native Android-App — gleicher Funktionsumfang wie die Web-App, geeignet für gemeinsam genutzte Geräte und den Außendienst.",
         },
       ],
     },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -20,8 +20,8 @@ export const de: Translations = {
   hero: {
     badge: "Aus der Praxis · Open Source · Öffentlich entwickelt",
     tagline: "SecPal – A guard’s best friend",
-    headline: "Weniger Reibung im Sicherheitsdienst.",
-    subline: "Weniger Zettelwirtschaft, weniger Medienbrüche, klarere Abläufe.",
+    headline: "Klarere Abläufe im Sicherheitsdienst.",
+    subline: "Weniger Zettelwirtschaft, weniger Medienbrüche — operative Arbeit in einem durchgängigen System.",
     explanation:
       "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf organisieren statt sie über Papier, Chats und Insellösungen zu verteilen.",
     highlights: [

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -107,7 +107,7 @@ export const de: Translations = {
             "Dienstpläne, Schichtzuweisungen und Besetzungsplanung — eingebaut in den operativen Ablauf statt separat verwaltet.",
         },
         {
-          name: "Online-Wächter-Kontroll-System (OWKS)",
+          name: "Online-Wächterkontrollsystem (OWKS)",
           description:
             "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge als natürlicher Teil des Betriebsprotokolls.",
         },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -29,8 +29,8 @@ export const de: Translations = {
       "Informationen bleiben nachvollziehbar — nicht verstreut in Notizen, Kurznachrichten und verteilten Dateien.",
       "SecPal entsteht öffentlich, mit klarem Fokus und nachvollziehbaren Release-Schritten.",
     ],
-    cta: "Entwicklung auf GitHub verfolgen",
-    ctaSecondary: "Zu den Features",
+    cta: "Zur Roadmap",
+    ctaSecondary: "Entwicklung auf GitHub verfolgen",
     note: "Die öffentliche Website zeigt die Produktrichtung, Rechtsinformationen und Kontaktwege. Ein öffentlicher Zugang zur App ist derzeit noch nicht geöffnet.",
   },
   features: {

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -66,67 +66,67 @@ export const de: Translations = {
   roadmap: {
     title: "Roadmap – SecPal",
     description:
-      "Wohin SecPal führt: Was aktuell gebaut wird, was als Nächstes kommt und die längerfristige Richtung.",
-    headline: "Wohin wir uns entwickeln.",
+      "Wohin SecPal sich entwickelt — aktueller Entwicklungsfokus, nächste geplante Schritte und längerfristige Richtung.",
+    headline: "Wohin SecPal sich entwickelt.",
     subline:
-      "SecPal entsteht öffentlich. Diese Seite zeigt den aktuellen Entwicklungsfokus, die nächsten geplanten Schritte und die längerfristige Richtung — ohne feste Daten, ohne Marketingversprechen.",
+      "SecPal entsteht öffentlich. Diese Seite zeigt den aktuellen Entwicklungsfokus, die nächsten geplanten Schritte und die längerfristige Richtung — ohne feste Termine und ohne Marketingversprechen.",
     now: {
       label: "Aktuell",
-      description: "In aktiver Entwicklung.",
+      description: "In aktiver Entwicklung",
       items: [
         {
           name: "Passkeys & WebAuthn",
           description:
-            "Passwortloser Login per Gerätebiometrie oder Security-Key (FIDO2/WebAuthn) — einfacher und sicherer als Passwörter.",
+            "Passwortloser Login per Gerätebiometrie oder Security-Key (FIDO2/WebAuthn) — sicherer und unkomplizierter als Passwörter.",
         },
         {
           name: "Mitarbeiter-Onboarding (BewachV §16)",
           description:
-            "Geführter Onboarding-Ablauf, der alle für die Bewacherregister-Anmeldung erforderlichen Felder erfasst — mit eigenem Token-basierten Einladungslink statt einem Passwort-Reset-Link.",
+            "Strukturiertes Onboarding, das alle für die Bewacherregister-Anmeldung erforderlichen Felder erfasst — mit eigenem Einladungslink statt einem Passwort-Reset als Behelf.",
         },
       ],
     },
     next: {
       label: "Als Nächstes",
-      description: "Für die nahe Zukunft geplant.",
+      description: "Für die nahe Zukunft geplant",
       items: [
         {
           name: "Android-App",
           description:
-            "Native Android-App auf Basis von Capacitor — gleicher Funktionsumfang wie die Web-App, nutzbar auf gemeinsam genutzten Geräten und im Außendienst.",
+            "Native Android-App auf Basis von Capacitor — gleicher Funktionsumfang wie die Web-App, geeignet für gemeinsam genutzte Geräte und den Außendienst.",
         },
       ],
     },
     later: {
       label: "Später",
-      description: "Längerfristige Richtung — ohne feste Termine.",
+      description: "Längerfristige Richtung — ohne feste Termine",
       items: [
         {
           name: "Dienstplanung",
           description:
-            "Dienstpläne, Schichtzuweisungen und Besetzungsplanung als Teil des operativen Ablaufs.",
+            "Dienstpläne, Schichtzuweisungen und Besetzungsplanung — eingebaut in den operativen Ablauf statt separat verwaltet.",
         },
         {
           name: "Wächter-Kontroll-System (WKS)",
           description:
-            "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge direkt im Betriebsprotokoll.",
+            "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge als natürlicher Teil des Betriebsprotokolls.",
         },
         {
           name: "Vertragsverwaltung & digitale Unterschrift",
           description:
-            "Kunden- und Arbeitsverträge an einem Ort verwalten, mit rechtskonformem digitalem Unterschriftenworkflow.",
+            "Kunden- und Arbeitsverträge an einem Ort — mit rechtskonformem Unterschriftenworkflow direkt im System.",
         },
         {
           name: "Dienstanweisungskonfigurator",
           description:
-            "Objektbezogene Dienstanweisungen strukturiert erstellen und verwalten — versioniert und direkt mit Objekten und Schichten verknüpft.",
+            "Objektbezogene Dienstanweisungen erstellen und pflegen — strukturiert, versioniert und direkt mit Objekten und Schichten verknüpft.",
         },
       ],
     },
     changelog: {
-      label: "Zuletzt ausgeliefert",
+      label: "Was ausgeliefert wurde",
       description:
-        "Die vollständige Release-Historie mit jedem ausgelieferten Feature und Fix ist auf changelog.secpal.app veröffentlicht.",
+        "Jedes ausgelieferte Feature und jeden Fix dokumentiert changelog.secpal.app — die vollständige Versionshistorie über API, Web-App und Android.",
       link: "Zum Changelog",
       href: "https://changelog.secpal.app",
     },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -107,7 +107,7 @@ export const de: Translations = {
             "Dienstpläne, Schichtzuweisungen und Besetzungsplanung — eingebaut in den operativen Ablauf statt separat verwaltet.",
         },
         {
-          name: "Wächter-Kontroll-System (WKS)",
+          name: "Online-Wächter-Kontroll-System (OWKS)",
           description:
             "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge als natürlicher Teil des Betriebsprotokolls.",
         },

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -6,6 +6,7 @@ import type { Translations } from "./en.ts";
 export const de: Translations = {
   nav: {
     progress: "Fortschritt",
+    roadmap: "Roadmap",
     android: "Android",
     updates: "Folgen",
     github: "GitHub",
@@ -61,6 +62,74 @@ export const de: Translations = {
     button: "GitHub ansehen",
     buttonSecondary: "Kontakt aufnehmen",
     note: "",
+  },
+  roadmap: {
+    title: "Roadmap – SecPal",
+    description:
+      "Wohin SecPal führt: Was aktuell gebaut wird, was als Nächstes kommt und die längerfristige Richtung.",
+    headline: "Wohin wir uns entwickeln.",
+    subline:
+      "SecPal entsteht öffentlich. Diese Seite zeigt den aktuellen Entwicklungsfokus, die nächsten geplanten Schritte und die längerfristige Richtung — ohne feste Daten, ohne Marketingversprechen.",
+    now: {
+      label: "Aktuell",
+      description: "In aktiver Entwicklung.",
+      items: [
+        {
+          name: "Passkeys & WebAuthn",
+          description:
+            "Passwortloser Login per Gerätebiometrie oder Security-Key (FIDO2/WebAuthn) — einfacher und sicherer als Passwörter.",
+        },
+        {
+          name: "Mitarbeiter-Onboarding (BewachV §16)",
+          description:
+            "Geführter Onboarding-Ablauf, der alle für die Bewacherregister-Anmeldung erforderlichen Felder erfasst — mit eigenem Token-basierten Einladungslink statt einem Passwort-Reset-Link.",
+        },
+      ],
+    },
+    next: {
+      label: "Als Nächstes",
+      description: "Für die nahe Zukunft geplant.",
+      items: [
+        {
+          name: "Android-App",
+          description:
+            "Native Android-App auf Basis von Capacitor — gleicher Funktionsumfang wie die Web-App, nutzbar auf gemeinsam genutzten Geräten und im Außendienst.",
+        },
+      ],
+    },
+    later: {
+      label: "Später",
+      description: "Längerfristige Richtung — ohne feste Termine.",
+      items: [
+        {
+          name: "Dienstplanung",
+          description:
+            "Dienstpläne, Schichtzuweisungen und Besetzungsplanung als Teil des operativen Ablaufs.",
+        },
+        {
+          name: "Wächter-Kontroll-System (WKS)",
+          description:
+            "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge direkt im Betriebsprotokoll.",
+        },
+        {
+          name: "Vertragsverwaltung & digitale Unterschrift",
+          description:
+            "Kunden- und Arbeitsverträge an einem Ort verwalten, mit rechtskonformem digitalem Unterschriftenworkflow.",
+        },
+        {
+          name: "Dienstanweisungskonfigurator",
+          description:
+            "Objektbezogene Dienstanweisungen strukturiert erstellen und verwalten — versioniert und direkt mit Objekten und Schichten verknüpft.",
+        },
+      ],
+    },
+    changelog: {
+      label: "Zuletzt ausgeliefert",
+      description:
+        "Die vollständige Release-Historie mit jedem ausgelieferten Feature und Fix ist auf changelog.secpal.app veröffentlicht.",
+      link: "Zum Changelog",
+      href: "https://changelog.secpal.app",
+    },
   },
   footer: {
     rights: "",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -21,7 +21,8 @@ export const de: Translations = {
     badge: "Aus der Praxis · Open Source · Öffentlich entwickelt",
     tagline: "SecPal – A guard’s best friend",
     headline: "Klarere Abläufe im Sicherheitsdienst.",
-    subline: "Weniger Zettelwirtschaft, weniger Medienbrüche — operative Arbeit in einem durchgängigen System.",
+    subline:
+      "Weniger Zettelwirtschaft, weniger Medienbrüche — operative Arbeit in einem durchgängigen System.",
     explanation:
       "SecPal ist für Sicherheitsdienste gebaut, die operative Arbeit in einem klaren Ablauf organisieren statt sie über Papier, Chats und Insellösungen zu verteilen.",
     highlights: [

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,8 +27,8 @@ export const en = {
       "Information stays traceable instead of disappearing into notes, messages, and scattered files.",
       "SecPal is taking shape in public, with a focused scope and clear release steps.",
     ],
-    cta: "Follow development on GitHub",
-    ctaSecondary: "See the features",
+    cta: "View roadmap",
+    ctaSecondary: "Follow development on GitHub",
     note: "The public website shows the product direction, legal information, and contact paths. Public access to the app is not open yet.",
   },
   features: {
@@ -91,7 +91,7 @@ export const en = {
         {
           name: "Android app",
           description:
-            "Native Android app built on Capacitor — same capabilities as the web app, suitable for shared devices and field use.",
+            "Native Android app — same capabilities as the web app, suitable for shared devices and field use.",
         },
       ],
     },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -19,7 +19,7 @@ export const en = {
     badge: "From operational practice · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
     headline: "Less friction in security operations.",
-    subline: "Less paperwork, fewer fragmented tools, clearer workflows.",
+    subline: "Less paperwork, fewer disconnected tools, clearer workflows.",
     explanation:
       "SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [
@@ -105,7 +105,7 @@ export const en = {
             "Duty rosters, shift assignments, and coverage planning — integrated into the operational workflow rather than managed separately.",
         },
         {
-          name: "Online guard tour system (OWKS)",
+          name: "Online guard tour system",
           description:
             "Checkpoint-based patrol recording via NFC or QR — traceable guard tours as a natural part of the operational log.",
         },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -64,68 +64,68 @@ export const en = {
   roadmap: {
     title: "Roadmap – SecPal",
     description:
-      "Where SecPal is headed: what we are building now, what comes next, and the longer-term direction.",
-    headline: "Where we are headed.",
+      "Where SecPal is headed — current development focus, next planned steps, and longer-term direction.",
+    headline: "Where SecPal is headed.",
     subline:
-      "SecPal is built in the open. This page shows the current development focus, the next planned steps, and the longer-term direction — no hard deadlines, no marketing promises.",
+      "SecPal is built in the open. This page shows the current development focus, the next planned steps, and the longer-term direction — with no fixed dates and no marketing promises.",
     now: {
       label: "Now",
-      description: "Actively in development.",
+      description: "Actively in development",
       items: [
         {
           name: "Passkeys & WebAuthn",
           description:
-            "Password-free login via device biometrics or security keys (FIDO2/WebAuthn) — simpler and more secure than passwords.",
+            "Password-free login via device biometrics or security keys (FIDO2/WebAuthn) — more secure and easier to use than passwords.",
         },
         {
           name: "Employee onboarding (BewachV §16)",
           description:
-            "Guided onboarding flow that captures all fields required for Bewacherregister registration, with a dedicated token-based invite instead of a password-reset link.",
+            "Structured onboarding that collects all fields required for Bewacherregister registration — with a dedicated invite link instead of a password-reset workaround.",
         },
       ],
     },
     next: {
       label: "Next",
-      description: "Planned for the near term.",
+      description: "Planned for the near term",
       items: [
         {
           name: "Android app",
           description:
-            "Native Android app built with Capacitor — same feature set as the web app, usable on shared devices and in the field.",
+            "Native Android app built on Capacitor — same capabilities as the web app, suitable for shared devices and field use.",
         },
       ],
     },
     later: {
       label: "Later",
-      description: "Longer-term direction — no dates attached.",
+      description: "Longer-term direction — no dates attached",
       items: [
         {
           name: "Shift planning",
           description:
-            "Duty rosters, shift assignments, and coverage planning as part of the operational workflow.",
+            "Duty rosters, shift assignments, and coverage planning — integrated into the operational workflow rather than managed separately.",
         },
         {
           name: "Guard tour system (WKS)",
           description:
-            "Checkpoint-based patrol recording with NFC or QR — traceable guard tours directly in the operational log.",
+            "Checkpoint-based patrol recording via NFC or QR — traceable guard tours as a natural part of the operational log.",
         },
         {
           name: "Contract management & digital signatures",
           description:
-            "Manage customer and employment contracts in one place, with a legally binding digital signature workflow.",
+            "Customer and employment contracts in one place, with a legally compliant digital signature workflow.",
         },
         {
           name: "Service instruction configurator",
           description:
-            "Build and manage site-specific service instructions — structured, versioned, and linked directly to the relevant objects and shifts.",
+            "Create and maintain site-specific service instructions — structured, versioned, and linked to the relevant objects and shifts.",
         },
       ],
     },
     changelog: {
-      label: "Recently shipped",
+      label: "What has shipped",
       description:
-        "The full release history with every shipped feature and fix is published at changelog.secpal.app.",
-      link: "View the changelog",
+        "Every released feature and fix is documented at changelog.secpal.app — the full history of what has shipped across API, web app, and Android.",
+      link: "Read the changelog",
       href: "https://changelog.secpal.app",
     },
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -105,7 +105,7 @@ export const en = {
             "Duty rosters, shift assignments, and coverage planning — integrated into the operational workflow rather than managed separately.",
         },
         {
-          name: "Guard tour system (WKS)",
+          name: "Online guard tour system (OWKS)",
           description:
             "Checkpoint-based patrol recording via NFC or QR — traceable guard tours as a natural part of the operational log.",
         },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,6 +4,7 @@
 export const en = {
   nav: {
     progress: "Progress",
+    roadmap: "Roadmap",
     android: "Android",
     updates: "Follow",
     github: "GitHub",
@@ -60,6 +61,74 @@ export const en = {
     buttonSecondary: "Get in touch",
     note: "",
   },
+  roadmap: {
+    title: "Roadmap – SecPal",
+    description:
+      "Where SecPal is headed: what we are building now, what comes next, and the longer-term direction.",
+    headline: "Where we are headed.",
+    subline:
+      "SecPal is built in the open. This page shows the current development focus, the next planned steps, and the longer-term direction — no hard deadlines, no marketing promises.",
+    now: {
+      label: "Now",
+      description: "Actively in development.",
+      items: [
+        {
+          name: "Passkeys & WebAuthn",
+          description:
+            "Password-free login via device biometrics or security keys (FIDO2/WebAuthn) — simpler and more secure than passwords.",
+        },
+        {
+          name: "Employee onboarding (BewachV §16)",
+          description:
+            "Guided onboarding flow that captures all fields required for Bewacherregister registration, with a dedicated token-based invite instead of a password-reset link.",
+        },
+      ],
+    },
+    next: {
+      label: "Next",
+      description: "Planned for the near term.",
+      items: [
+        {
+          name: "Android app",
+          description:
+            "Native Android app built with Capacitor — same feature set as the web app, usable on shared devices and in the field.",
+        },
+      ],
+    },
+    later: {
+      label: "Later",
+      description: "Longer-term direction — no dates attached.",
+      items: [
+        {
+          name: "Shift planning",
+          description:
+            "Duty rosters, shift assignments, and coverage planning as part of the operational workflow.",
+        },
+        {
+          name: "Guard tour system (WKS)",
+          description:
+            "Checkpoint-based patrol recording with NFC or QR — traceable guard tours directly in the operational log.",
+        },
+        {
+          name: "Contract management & digital signatures",
+          description:
+            "Manage customer and employment contracts in one place, with a legally binding digital signature workflow.",
+        },
+        {
+          name: "Service instruction configurator",
+          description:
+            "Build and manage site-specific service instructions — structured, versioned, and linked directly to the relevant objects and shifts.",
+        },
+      ],
+    },
+    changelog: {
+      label: "Recently shipped",
+      description:
+        "The full release history with every shipped feature and fix is published at changelog.secpal.app.",
+      link: "View the changelog",
+      href: "https://changelog.secpal.app",
+    },
+  },
   footer: {
     rights: "",
     links: {
@@ -73,9 +142,9 @@ export const en = {
 
 type DeepLoosen<T> =
   T extends ReadonlyArray<infer U>
-    ? DeepLoosen<U>[]
-    : T extends Record<string, unknown>
-      ? { [K in keyof T]: DeepLoosen<T[K]> }
-      : string;
+  ? DeepLoosen<U>[]
+  : T extends Record<string, unknown>
+  ? { [K in keyof T]: DeepLoosen<T[K]> }
+  : string;
 
 export type Translations = DeepLoosen<typeof en>;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -18,8 +18,8 @@ export const en = {
   hero: {
     badge: "From operational practice · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
-    headline: "Less friction in security operations.",
-    subline: "Less paperwork, fewer disconnected tools, clearer workflows.",
+    headline: "Less paperwork, fewer disconnected tools, clearer security operations.",
+    subline: "SecPal brings operational work into one connected system.",
     explanation:
       "SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
     highlights: [

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -18,7 +18,8 @@ export const en = {
   hero: {
     badge: "From operational practice · Open source · Built in public",
     tagline: "SecPal – A guard’s best friend",
-    headline: "Less paperwork, fewer disconnected tools, clearer security operations.",
+    headline:
+      "Less paperwork, fewer disconnected tools, clearer security operations.",
     subline: "SecPal brings operational work into one connected system.",
     explanation:
       "SecPal is built for security operations that need one clear operational flow instead of spreading day-to-day work across paper notes, chats, and disconnected tools.",
@@ -142,9 +143,9 @@ export const en = {
 
 type DeepLoosen<T> =
   T extends ReadonlyArray<infer U>
-  ? DeepLoosen<U>[]
-  : T extends Record<string, unknown>
-  ? { [K in keyof T]: DeepLoosen<T[K]> }
-  : string;
+    ? DeepLoosen<U>[]
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: DeepLoosen<T[K]> }
+      : string;
 
 export type Translations = DeepLoosen<typeof en>;

--- a/src/pages/[locale]/roadmap.astro
+++ b/src/pages/[locale]/roadmap.astro
@@ -1,0 +1,32 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { GetStaticPaths } from "astro";
+import Base from "../../layouts/Base.astro";
+import Nav from "../../components/Nav.astro";
+import Footer from "../../components/Footer.astro";
+import RoadmapSurface from "../../components/Roadmap.astro";
+import { locales, type Locale, useTranslations } from "../../i18n/index.ts";
+
+export const getStaticPaths = (() =>
+  locales.map((locale) => ({ params: { locale } }))) satisfies GetStaticPaths;
+
+const locale = Astro.params.locale as Locale;
+const t = useTranslations(locale);
+---
+
+<Base
+  title={t.roadmap.title}
+  description={t.roadmap.description}
+  lang={locale}
+  canonicalPath={`/${locale}/roadmap/`}
+  alternateEnPath="/en/roadmap/"
+  alternateDePath="/de/roadmap/"
+  xDefaultPath="/roadmap/"
+>
+  <Nav locale={locale} currentPath="/roadmap" />
+  <main>
+    <RoadmapSurface locale={locale} />
+  </main>
+  <Footer locale={locale} />
+</Base>

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal reduziert Zettelwirtschaft, Medienbrüche und Reibung im Sicherheitsdienst mit einem klaren operativen Ablauf."
+  description="SecPal reduziert Zettelwirtschaft, Medienbrüche und operative Reibung im Sicherheitsdienst — mit einem klaren, durchgängigen Ablauf."
   lang="de"
   canonicalPath="/de/"
 >

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,7 +11,7 @@ import Footer from "../../components/Footer.astro";
 
 <Base
   title="SecPal – A guard’s best friend"
-  description="SecPal reduces paperwork, fragmented tools, and operational friction in security operations with one clear workflow."
+  description="SecPal reduces operational friction in security services — less paperwork, fewer disconnected tools, clearer workflows."
   lang="en"
   canonicalPath="/en/"
 >

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -15,5 +15,4 @@ import NeutralLocaleRedirectPage from "../components/NeutralLocaleRedirectPage.a
   eyebrow="SecPal Roadmap"
   headline="Redirecting to the roadmap"
   body="If your browser does not redirect automatically, continue to the English or German SecPal roadmap page."
-  noindex={true}
 />

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -1,0 +1,19 @@
+---
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import NeutralLocaleRedirectPage from "../components/NeutralLocaleRedirectPage.astro";
+---
+
+<NeutralLocaleRedirectPage
+  title="SecPal Roadmap"
+  description="Neutral roadmap entry point on secpal.app with links to the English and German SecPal roadmap pages."
+  canonicalPath="/roadmap/"
+  alternateEnPath="/en/roadmap/"
+  alternateDePath="/de/roadmap/"
+  xDefaultPath="/roadmap/"
+  redirectPath="/roadmap"
+  eyebrow="SecPal Roadmap"
+  headline="Redirecting to the roadmap"
+  body="If your browser does not redirect automatically, continue to the English or German SecPal roadmap page."
+  noindex={true}
+/>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -28,6 +28,14 @@ const pages = [
     },
   },
   {
+    path: "/roadmap/",
+    alternates: {
+      en: "/en/roadmap/",
+      de: "/de/roadmap/",
+      "x-default": "/roadmap/",
+    },
+  },
+  {
     path: "/en/android/",
     alternates: {
       en: "/en/android/",
@@ -41,6 +49,22 @@ const pages = [
       en: "/en/android/",
       de: "/de/android/",
       "x-default": "/android/",
+    },
+  },
+  {
+    path: "/en/roadmap/",
+    alternates: {
+      en: "/en/roadmap/",
+      de: "/de/roadmap/",
+      "x-default": "/roadmap/",
+    },
+  },
+  {
+    path: "/de/roadmap/",
+    alternates: {
+      en: "/en/roadmap/",
+      de: "/de/roadmap/",
+      "x-default": "/roadmap/",
     },
   },
   {


### PR DESCRIPTION
Adds a localized public roadmap page at `/roadmap/` (English: `/en/roadmap/`, German: `/de/roadmap/`).

The page is structured around three phases with no hard dates:

**Now (active development)**
- Passkeys & WebAuthn — password-free login via FIDO2/WebAuthn
- Employee onboarding (BewachV §16) — guided token-based onboarding with all legally required fields

**Next (planned)**
- Android app — Capacitor-based native Android app

**Later (direction, no dates)**
- Shift planning
- Guard tour system (WKS) — checkpoint-based patrol recording
- Contract management & digital signatures
- Service instruction configurator

A "Recently shipped" section links to `changelog.secpal.app` instead of duplicating content.

The roadmap is intentionally static and hand-curated — no live GitHub API calls, no issue titles as public copy.

**Changes:**
- `Roadmap.astro` component adapted from Tailwind Plus 3-column feature section
- `/[locale]/roadmap.astro` page and `/roadmap.astro` neutral redirect
- Roadmap nav link added to desktop and mobile menus
- Roadmap paths added to `sitemap.xml.ts`
- Translation keys added to `en.ts` and `de.ts`

**Validation:** `npm run build`, `npm run lint`, `npm run typecheck` — all clean.
