### PR TITLE
fix: prevent hero text overflow on narrow mobile viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- hero section in `src/components/Hero.astro` no longer overflows on narrow mobile viewports: the H1 mobile font size steps down from `text-5xl` to `text-4xl` with an intermediate `sm:text-5xl` tier so German compound words like "Sicherheitsdienst" fit within `px-6` padding, `overflow-x-clip` prevents decorative gradient blobs from widening the page, and the CTA row uses a tighter mobile gap while keeping both actions side-by-side — fixing the visual right-shift of headline, subline, and CTA text on devices such as iPhone 13 Pro and iPhone SE
 - overrode vulnerable transitive `defu` and `vite` packages to patched release ranges through npm overrides so the website toolchain audit findings are remediated without broad dependency-range changes
 - neutral locale entry routes on `/` and `/android` now redirect German browser locales to `/de/...` and all other locales to `/en/...`, so `secpal.app` and `dev.secpal.app` no longer force the English Android page when the browser prefers German
 - added safe-area-aware body padding together with `viewport-fit=cover` and wrapping rules for Android machine-readable cards so text and content blocks no longer sit too close to the mobile screen edge or overflow on devices with asymmetric viewport insets

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -27,7 +27,7 @@ const t = useTranslations(locale);
 ---
 
 <div
-  class="flex min-h-[calc(100svh-var(--secpal-nav-height))] flex-col bg-white dark:bg-gray-900"
+  class="flex min-h-[calc(100svh-var(--secpal-nav-height))] flex-col overflow-x-clip bg-white dark:bg-gray-900"
 >
   <div
     class="relative isolate flex flex-1 flex-col justify-center px-6 pt-0 lg:px-8"
@@ -61,7 +61,7 @@ const t = useTranslations(locale);
           {t.hero.tagline}
         </p>
         <h1
-          class="mt-4 text-5xl font-semibold tracking-tight text-balance text-gray-900 sm:text-7xl dark:text-white"
+          class="mt-4 text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl lg:text-7xl dark:text-white"
         >
           {t.hero.headline}
         </h1>
@@ -70,7 +70,7 @@ const t = useTranslations(locale);
         >
           {t.hero.subline}
         </p>
-        <div class="mt-8 flex items-center justify-center gap-x-6">
+        <div class="mt-8 flex items-center justify-center gap-x-4 sm:gap-x-6">
           <a
             href={getLocalizedPath("/roadmap", locale)}
             class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"


### PR DESCRIPTION
## Summary

Fixes the visual right-shift of German hero text on narrow mobile viewports (iPhone 13 Pro, iPhone SE, etc.).

### Root cause

The H1 at `text-5xl` (48px) makes the German compound word "Sicherheitsdienst." wider than the available `px-6`-padded content area on viewports under ~400px. This creates horizontal overflow, shifting all centered text visually rightward.

### Changes

- **H1 font size**: `text-5xl sm:text-7xl` → `text-4xl sm:text-5xl lg:text-7xl` — German compound words now fit within `px-6` padding on all common mobile widths
- **Overflow containment**: `overflow-x-clip` on the hero wrapper prevents decorative gradient blobs from widening the scrollable page area
- **CTA gap**: `gap-x-6` → `gap-x-4 sm:gap-x-6` — tighter mobile spacing, CTAs stay side-by-side

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — 0 warnings
- `npm run build` — 16 pages built successfully
