### PR TITLE
chore: harden AI findings triage guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,13 @@ At minimum verify:
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, accessibility, or static-build guarantees.
+
 ## Repository Conventions
 
 - Stack: Node 22, Astro 6, Tailwind CSS v4, and TypeScript strict mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
+- strengthened repo-local Copilot governance for AI findings: website work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, accessibility, or static-build refactors
 - clarified the repo-local branch-start and post-merge readiness workflow so new website work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working
 - clarified the repo-local PR workflow so finished website work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean


### PR DESCRIPTION
Closes #68
Refs SecPal/.github#367

## Summary

- add AI findings triage guidance to the public website repository baseline
- require proof of defect before merging AI-generated content, accessibility, or static-build refactors

## Validation

- `/home/secpal/code/SecPal/.github/scripts/validate-copilot-instructions.sh`
- targeted markdown lint from `/home/secpal/code/SecPal/.github`
