### PR TITLE
chore: automate Copilot AI validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,7 @@ At minimum verify:
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, accessibility, or static-build guarantees.
+- Reject AI-generated content or build refactors that move critical routes or semantics behind client-only code; prove static output, accessibility, and semantic structure stay intact after the change.
 
 ## Repository Conventions
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,6 +30,10 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
+  copilot-instructions:
+    name: Copilot Instructions
+    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+
   eslint:
     name: ESLint
     uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - strengthened repo-local Copilot governance for AI findings: website work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, accessibility, or static-build refactors
+- wired the central Copilot-instructions validator into `quality.yml` so website pull requests now fail automatically when known static-rendering or accessibility AI-risk guardrails are missing from the runtime baseline
 - clarified the repo-local branch-start and post-merge readiness workflow so new website work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies with `npm ci` where applicable, runs `npm run build` when available, and confirms a clean working tree
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the website runtime overlay now auto-loads repo-wide so these rules remain present while working
 - clarified the repo-local PR workflow so finished website work must be self-reviewed, committed, and pushed before any PR exists, and the first PR state must always be draft until the final PR-view self-review is clean

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -41,7 +41,10 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   // article channel cards have min-w-0 to prevent flex overflow
   assert.match(component, /<article\b[^>]*class="[^"]*\bmin-w-0\b/);
   // metadata path paragraph has break-all so long mono URLs wrap
-  assert.match(component, /<p\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b/);
+  assert.match(
+    component,
+    /<p\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b/
+  );
   // section endpoint groups have min-w-0 to prevent flex overflow
   assert.match(component, /<section\b[^>]*class="[^"]*\bmin-w-0\b/);
   // individual endpoint lines have break-all


### PR DESCRIPTION
## Summary

- wire the shared Copilot-instructions validator into the website quality workflow
- extend website runtime guardrails for static-rendering and accessibility regressions
- format tests/mobile-safe-area.test.mjs to satisfy the existing repository formatting gate that blocked the push

## Testing

- bash /home/holger/code/SecPal/.github/scripts/validate-copilot-instructions.sh

## Issues

- Closes #73
- Part of SecPal/.github#373
