### PR TITLE
Clarify under-1.x compatibility removal guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,7 @@ At minimum verify:
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, accessibility, or static-build guarantees.
 - Reject AI-generated content or build refactors that move critical routes or semantics behind client-only code; prove static output, accessibility, and semantic structure stay intact after the change.
+- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, storage/input aliases, or legacy frontend behavior without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they add risk or maintenance burden.
 
 ## Repository Conventions
 
@@ -83,3 +84,4 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
+- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ At minimum verify:
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, accessibility, or static-build guarantees.
 - Reject AI-generated content or build refactors that move critical routes or semantics behind client-only code; prove static output, accessibility, and semantic structure stay intact after the change.
-- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, storage/input aliases, or legacy frontend behavior without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they add risk or maintenance burden.
+- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, storage/input aliases, or legacy frontend behavior without a proven live caller. Because the SecPal project is still pre-`1.0.0`, prefer removing unnecessary compatibility paths over carrying them forward when they add risk or maintenance burden.
 
 ## Repository Conventions
 
@@ -84,4 +84,4 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
-- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
+- Because the SecPal project is still pre-`1.0.0`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- clarified the repo-local under-`1.x` policy in Copilot governance so website work explicitly prefers removing insecure or obsolete compatibility layers over preserving them without a proven live caller
+- clarified the repo-local pre-`1.0.0` policy in Copilot governance so website work explicitly prefers removing insecure or obsolete compatibility layers over preserving them without a proven live caller
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - strengthened repo-local Copilot governance for AI findings: website work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, accessibility, or static-build refactors
 - wired the central Copilot-instructions validator into `quality.yml` so website pull requests now fail automatically when known static-rendering or accessibility AI-risk guardrails are missing from the runtime baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the repo-local under-`1.x` policy in Copilot governance so website work explicitly prefers removing insecure or obsolete compatibility layers over preserving them without a proven live caller
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions
 - strengthened repo-local Copilot governance for AI findings: website work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, accessibility, or static-build refactors
 - wired the central Copilot-instructions validator into `quality.yml` so website pull requests now fail automatically when known static-rendering or accessibility AI-risk guardrails are missing from the runtime baseline


### PR DESCRIPTION
## Summary
- clarify the repo-local Copilot guidance for the project-wide under-1.x compatibility-removal policy
- document the governance change in the website changelog

## Validation
- git diff --check

Closes #76
