### PR TITLE
Adopt provider-neutral AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ for path-specific or stack-specific rules.
 
 - `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 - `.github/instructions/astro-static.instructions.md`
 
 ## Core Runtime Baseline
@@ -29,7 +30,10 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   branch. When continuing existing work in a dirty worktree, first identify the
   existing changes, keep the current topic scope, and never overwrite changes
   you did not make.
-- Validate-first: this repo has no test suite; confirm the smallest relevant check (lint, typecheck, or build) fails before implementing a change and passes after.
+- Validate-first: confirm the smallest relevant check fails before implementing
+  a change and passes after. Use `npm test` when the touched area is covered by
+  the existing Node test suite; otherwise use the smallest relevant lint,
+  typecheck, or build validation.
 - Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
 - Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
 - Never use bypasses such as `--no-verify` or force-push.
@@ -108,7 +112,7 @@ At minimum verify:
 
 ## Repository Conventions
 
-- Stack: Node 22, Astro 6, Tailwind CSS v4, and TypeScript strict mode.
+- Stack: Node 22, Astro 7, Tailwind CSS v4, and TypeScript strict mode.
 - This repository is the public SecPal landing page and static marketing site.
 - Keep content and presentation close to the page or component that uses them.
 - Favor static rendering, minimal client-side JavaScript, semantic HTML, accessibility, and responsive layouts.

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -10,7 +10,10 @@ applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependa
 
 Applies when editing GitHub Actions workflows and Dependabot configuration in this repository.
 
-- Always set `timeout-minutes` on every job.
+- Always set `timeout-minutes` on jobs that define their own `runs-on` and
+  `steps`. Reusable workflow caller jobs that use `jobs.<id>.uses` cannot
+  declare `timeout-minutes` at this level, so enforce the timeout inside the
+  called reusable workflow instead.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
 - Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
 - Use reusable workflows from the organization templates when they fit the task.

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -10,10 +10,16 @@ applyTo: "**"
 
 This file auto-applies to all files in this repo so strict SecPal governance stays always present at runtime.
 
-- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
-- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch, immediate GitHub issue creation for every real out-of-scope finding, and no bypass.
-- If work needs more than one PR, or probably will, create an EPIC with linked sub-issues before implementation.
+- `AGENTS.md` is the authoritative runtime baseline for this repo.
+  `.github/copilot-instructions.md` is only a compatibility mirror.
+- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch,
+  immediate GitHub issue creation for every real out-of-scope finding, and no
+  bypass.
+- If work needs more than one PR, or probably will, create an EPIC with linked
+  sub-issues before implementation.
 - Design discipline is always-on: DRY, KISS, YAGNI, SOLID, and fail fast.
 - GitHub communication stays in English and uses file and line references instead of large verbatim code quotes.
+- Do not add AI self-references, generated-by text, tool promotion, or AI
+  attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with Astro, Tailwind CSS, and static-site conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,9 +30,9 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
-  copilot-instructions:
-    name: Copilot Instructions
-    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+  ai-instructions:
+    name: AI Instructions
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
 
   eslint:
     name: ESLint

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2026 SecPal
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Quality Checks
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches: [main]
@@ -16,47 +18,51 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
+    with:
+      governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
+    with:
+      governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       node-version: "22"
 
   astro-check:
     name: Astro TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       node-version: "22"
       build-command: "npm run check"
 
   build:
     name: Astro Build
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       node-version: "22"
       build-command: "npm run build"
 
   test:
     name: Node Tests
-    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       node-version: "22"
       test-command: "npm test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Edit this file first. Keep the focused overlay files below aligned when a rule a
 ## Focused Overlays
 
 - `.github/instructions/org-shared.instructions.md`
+- `.github/instructions/github-workflows.instructions.md`
 - `.github/instructions/astro-static.instructions.md`
 
 ## Core Runtime Baseline
@@ -26,7 +27,10 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   branch. When continuing existing work in a dirty worktree, first identify the
   existing changes, keep the current topic scope, and never overwrite changes
   you did not make.
-- Validate-first: this repo has no test suite; confirm the smallest relevant check (lint, typecheck, or build) fails before implementing a change and passes after.
+- Validate-first: confirm the smallest relevant check fails before implementing
+  a change and passes after. Use `npm test` when the touched area is covered by
+  the existing Node test suite; otherwise use the smallest relevant lint,
+  typecheck, or build validation.
 - Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
 - Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
 - Never use bypasses such as `--no-verify` or force-push.
@@ -105,7 +109,7 @@ At minimum verify:
 
 ## Repository Conventions
 
-- Stack: Node 22, Astro 6, Tailwind CSS v4, and TypeScript strict mode.
+- Stack: Node 22, Astro 7, Tailwind CSS v4, and TypeScript strict mode.
 - This repository is the public SecPal landing page and static marketing site.
 - Keep content and presentation close to the page or component that uses them.
 - Favor static rendering, minimal client-side JavaScript, semantic HTML, accessibility, and responsive layouts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,13 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# SecPal/secpal.app Copilot Instructions
+# SecPal/secpal.app Agent Instructions
 
-This file mirrors the authoritative root `AGENTS.md` for tooling
-that automatically loads `.github/copilot-instructions.md`.
-Edit `AGENTS.md` first. Keep the focused overlay files aligned
-for path-specific or stack-specific rules.
+This file is the authoritative, provider-neutral runtime baseline for this repository.
+Edit this file first. Keep the focused overlay files below aligned when a rule also needs path-specific or stack-specific enforcement.
 
-## Authoritative Sources
+## Focused Overlays
 
-- `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/astro-static.instructions.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- corrected the provider-neutral governance baseline so `AGENTS.md` and the Copilot mirror now advertise the workflow overlay, describe the existing `npm test` suite accurately, track Astro 7 instead of Astro 6, and pin the shared reusable quality workflows plus their `governance-ref` inputs to the reviewed `.github` SHA for reproducible validation
 - refactored `mobile-safe-area` test assertions: extracted complex inline regex literals to named constants and restored the coupled `break-all`+`{line}` assertion so endpoint-line paragraph failures remain diagnosable without weakening test coverage
 - clarified the repo-local pre-`1.0.0` policy in Copilot governance so website work explicitly prefers removing insecure or obsolete compatibility layers over preserving them without a proven live caller
 - mandated `--body-file` for programmatic PR creation to prevent shell escaping issues in Copilot governance instructions


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` as the provider-neutral instruction baseline for `secpal.app`
- refresh `.github/copilot-instructions.md` into an explicit compatibility mirror of `AGENTS.md`
- align the repo-local instruction overlays and quality workflow wiring with the new AI-instructions validation path

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/secpal.app` on `main` failed because `AGENTS.md` was missing and the Copilot instructions did not satisfy the new mirror contract.
- Passing proof after implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/secpal.app` on `ai-instructions/provider-neutral-rollout`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Testing
- bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/secpal.app
