### PR TITLE
Clarify Tailwind Plus license file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- replaced the stub `LICENSES/LicenseRef-TailwindPlus.txt` summary with the
+  published Tailwind Plus license text and clarified that
+  `LicenseRef-TailwindPlus` is the repo's SPDX reference for Tailwind
+  Plus-derived components
 - replaced the repo-local `markdownlint-cli2` pre-commit and preflight path with pinned `markdownlint-cli@0.49.0` usage and removed the stale `cli2` file references from export/licensing metadata
 - expanded the public privacy notice so it now covers the SecPal Android app, beta distribution, Google Play / third-party store context, and app-data deletion contact paths in addition to the website itself
 - refocused the public Android landing page on end users: stable and beta are now presented as simple download choices, rollout methods are explained without pretending to be separate APK channels, and the deeper machine-readable endpoints are tucked behind secondary technical details

--- a/LICENSES/LicenseRef-TailwindPlus.txt
+++ b/LICENSES/LicenseRef-TailwindPlus.txt
@@ -1,9 +1,233 @@
 Tailwind Plus License
 
-Catalyst UI Kit components by Tailwind Labs Inc.
+Personal License
 
-Copyright (c) Tailwind Labs Inc.
+Tailwind Labs Inc. grants you an on-going, non-exclusive license to use the
+Components, Templates, and Libraries.
 
-Licensed under the Tailwind Plus License.
+The license grants permission to one individual (the Licensee) to access and
+use the Components, Templates, and Libraries.
 
-Full license text: https://tailwindcss.com/plus/license
+You can:
+
+- Use the Components, Templates, and Libraries to create unlimited End
+  Products.
+- Modify the Components and Templates to create derivative components and
+  templates. Those components and templates are subject to this license.
+- Use the Components, Templates, and Libraries to create unlimited End
+  Products for unlimited Clients.
+- Use the Components, Templates, and Libraries to create End Products where
+  the End Product is sold to End Users.
+- Use the Components, Templates, and Libraries to create End Products that are
+  open source and freely available to End Users.
+
+You cannot:
+
+- Use the Components, Templates, or Libraries to create End Products that are
+  designed to allow an End User to build their own End Products using the
+  Components, Templates, Libraries, or derivatives of them.
+- Re-distribute the Components, Templates, Libraries, or derivatives of them
+  separately from an End Product, neither in code or as design assets.
+- Share your access to the Components, Templates, or Libraries with any other
+  individuals.
+- Use the Components, Templates, or Libraries to produce anything that may be
+  deemed by Tailwind Labs Inc, in their sole and absolute discretion, to be
+  competitive or in conflict with the business of Tailwind Labs Inc.
+
+Example usage
+
+Examples of usage allowed by the license:
+
+- Creating a personal website by yourself.
+- Creating a website or web application for a client that will be owned by
+  that client.
+- Creating a commercial SaaS application (like an invoicing app for example)
+  where end users have to pay a fee to use the application.
+- Creating a commercial self-hosted web application that is sold to end users
+  for a one-time fee.
+- Creating a web application where the primary purpose is clearly not to simply
+  re-distribute the components or libraries (like a conference organization app
+  that uses them for its UI for example) that is free and open source, where
+  the source code is publicly available.
+
+Examples of usage not allowed by the license:
+
+- Creating a repository of your favorite Tailwind Plus components, templates,
+  or libraries (or derivatives of them) and publishing it publicly.
+- Creating a UI library using Tailwind Plus components, templates, or
+  libraries and making it available either for sale or for free.
+- Creating a UI library that requires end users to install or otherwise depend
+  on the Tailwind Plus libraries in order to function, even if it does not
+  include our libraries directly.
+- Converting a Tailwind Plus template to another framework and making it
+  available either for sale or for free.
+- Creating a Figma or Sketch UI kit based on the Tailwind Plus component
+  designs.
+- Creating a "website builder" project where end users can build their own
+  websites using components, templates, or libraries included with or derived
+  from Tailwind Plus.
+- Creating a theme, template, or project starter kit using the components,
+  templates, or libraries and making it available either for sale or for free.
+- Creating an admin panel tool (like Laravel Nova or ActiveAdmin) that is made
+  available either for sale or for free.
+
+In simple terms, use Tailwind Plus for anything you like as long as it doesn't
+compete with Tailwind Plus.
+
+Personal License Definitions
+
+Licensee is the individual who has purchased a Personal License.
+
+Components, Templates, and Libraries are the source code and design assets made
+available to the Licensee after purchasing a Tailwind Plus license.
+"Libraries" specifically refers to the Elements JavaScript library provided by
+Tailwind Labs Inc. for use with Tailwind Plus.
+
+End Product is any artifact produced that incorporates the Components,
+Templates, Libraries, or derivatives of them.
+
+End User is a user of an End Product.
+
+Client is an individual or entity receiving custom professional services
+directly from the Licensee, produced specifically for that individual or
+entity. Customers of software-as-a-service products are not considered clients
+for the purpose of this document.
+
+Team License
+
+Tailwind Labs Inc. grants you an on-going, non-exclusive license to use the
+Components, Templates, and Libraries.
+
+The license grants permission for up to 25 Employees and Contractors of the
+Licensee to access and use the Components, Templates, and Libraries.
+
+You can:
+
+- Use the Components, Templates, and Libraries to create unlimited End
+  Products.
+- Modify the Components and Templates to create derivative components and
+  templates. Those components and templates are subject to this license.
+- Use the Components, Templates, and Libraries to create unlimited End
+  Products for unlimited Clients.
+- Use the Components, Templates, and Libraries to create End Products where
+  the End Product is sold to End Users.
+- Use the Components, Templates, and Libraries to create End Products that are
+  open source and freely available to End Users.
+
+You cannot:
+
+- Use the Components, Templates, or Libraries to create End Products that are
+  designed to allow an End User to build their own End Products using the
+  Components, Templates, Libraries, or derivatives of them.
+- Re-distribute the Components, Templates, Libraries, or derivatives of them
+  separately from an End Product.
+- Use the Components, Templates, or Libraries to create End Products that are
+  the property of any individual or entity other than the Licensee or Clients
+  of the Licensee.
+- Grant access to the Components, Templates, or Libraries to individuals who
+  are not an Employee or Contractor of the Licensee.
+- Use the Components, Templates, or Libraries to produce anything that may be
+  deemed by Tailwind Labs Inc, in their sole and absolute discretion, to be
+  competitive or in conflict with the business of Tailwind Labs Inc.
+
+Example usage
+
+Examples of usage allowed by the license:
+
+- Creating a website for your company.
+- Creating a website or web application for a client that will be owned by
+  that client.
+- Creating a commercial SaaS application (like an invoicing app for example)
+  where end users have to pay a fee to use the application.
+- Creating a commercial self-hosted web application that is sold to end users
+  for a one-time fee.
+- Creating a web application where the primary purpose is clearly not to simply
+  re-distribute the components, templates, or libraries (like a conference
+  organization app that uses them for its UI for example) that is free and
+  open source, where the source code is publicly available.
+
+Examples of use not allowed by the license:
+
+- Creating a repository of your favorite Tailwind Plus components, templates,
+  or libraries (or derivatives of them) and publishing it publicly.
+- Creating a UI library using Tailwind Plus components, templates, or
+  libraries and making it available either for sale or for free.
+- Creating a UI library that requires end users to install or otherwise depend
+  on the Tailwind Plus libraries in order to function, even if it does not
+  include our libraries directly.
+- Converting a Tailwind Plus template to another framework and making it
+  available either for sale or for free.
+- Creating a "website builder" project where end users can build their own
+  websites using components, templates, or libraries included with or derived
+  from Tailwind Plus.
+- Creating a theme or template using the components, templates, or libraries
+  and making it available either for sale or for free.
+- Creating an admin panel tool (like Laravel Nova or ActiveAdmin) that is made
+  available either for sale or for free.
+- Creating any End Product that is not the sole property of either your
+  company or a client of your company. For example your
+  employees/contractors can't use your company Tailwind Plus license to build
+  their own websites or side projects.
+- Giving someone access to Tailwind Plus when they purchase a product from you.
+  For example, you can't use a Team License as a way to give someone access to
+  Tailwind Plus when they purchase an online course from you.
+- Selling access to your team account to people who don't work for your
+  company.
+
+Team License Definitions
+
+Licensee is the business entity who has purchased a Team License.
+
+Components, Templates, and Libraries are the source code and design assets made
+available to the Licensee after purchasing a Tailwind Plus license.
+"Libraries" specifically refers to the Elements JavaScript library provided by
+Tailwind Labs Inc. for use with Tailwind Plus.
+
+End Product is any artifact produced that incorporates the Components,
+Templates, Libraries, or derivatives of them.
+
+End User is a user of an End Product.
+
+Employee is a full-time or part-time employee of the Licensee.
+
+Contractor is an individual or business entity contracted to perform services
+for the Licensee.
+
+Client is an individual or entity receiving custom professional services
+directly from the Licensee, produced specifically for that individual or
+entity. Customers of software-as-a-service products are not considered clients
+for the purpose of this document.
+
+Enforcement
+
+If you are found to be in violation of the license, access to your Tailwind
+Plus account will be terminated, and a refund may be issued at our discretion.
+When license violation is blatant and malicious (such as intentionally
+redistributing the Components, Templates, or Libraries through private warez
+channels), no refund will be issued.
+
+The copyright of the Components, Templates, and Libraries is owned by Tailwind
+Labs Inc. You are granted only the permissions described in this license; all
+other rights are reserved. Tailwind Labs Inc. reserves the right to pursue
+legal remedies for any unauthorized use of the Components, Templates, or
+Libraries outside the scope of this license.
+
+Liability
+
+Tailwind Labs Inc.'s liability to you for costs, damages, or other losses
+arising from your use of the Components, Templates, or Libraries — including
+third-party claims against you — is limited to a refund of your license fee.
+Tailwind Labs Inc. may not be held liable for any consequential damages related
+to your use of the Components, Templates, or Libraries.
+
+This Agreement is governed by the laws of the Province of Ontario and the
+applicable laws of Canada. Legal proceedings related to this Agreement may only
+be brought in the courts of Ontario. You agree to service of process at the
+e-mail address on your original order.
+
+Questions?
+
+Unsure which license you need, or unsure if your use case is covered by our
+licenses?
+
+Email us at support@tailwindcss.com with your questions.

--- a/README.md
+++ b/README.md
@@ -151,4 +151,7 @@ metadata.
 
 AGPL-3.0-or-later — see [LICENSE](LICENSE).
 
-UI blocks are adapted from [Tailwind Plus](https://tailwindcss.com/plus) and licensed under the Tailwind Plus License — see [LICENSES/LicenseRef-TailwindPlus.txt](LICENSES/LicenseRef-TailwindPlus.txt).
+Tailwind Plus-derived components use `LicenseRef-TailwindPlus`; the repository
+vendors the published Tailwind Plus license text, including the Personal and
+Team sections published by Tailwind Labs, in
+[LICENSES/LicenseRef-TailwindPlus.txt](LICENSES/LicenseRef-TailwindPlus.txt).


### PR DESCRIPTION
Before this change, `rg -n "^(Personal License|Team License)$" LICENSES/LicenseRef-TailwindPlus.txt` returned no matches, so `LicenseRef-TailwindPlus` pointed to a short summary stub instead of the published Tailwind Plus license text.

## What changed

- replaced `LICENSES/LicenseRef-TailwindPlus.txt` with the published Tailwind Plus license text, including the Personal and Team sections
- clarified in `README.md` that `LicenseRef-TailwindPlus` maps to the vendored Tailwind Plus license text in this repository
- recorded the licensing decision in `CHANGELOG.md`

## Validation

- failing invariant before the change: `rg -n "^(Personal License|Team License)$" LICENSES/LicenseRef-TailwindPlus.txt` returned no matches
- passing invariant after the change: the same command now returns `3:Personal License` and `96:Team License`
- `reuse lint`
- `npm run format:check`
- `git diff --check`

## Follow-up before ready

- final self-review in the PR view is still required before marking this draft ready
- GitHub Actions checks have not run yet in this local workflow
- no linked workspace changes were needed; `SecPal/changelog` was available for context only and was not modified
- no additional site lint/typecheck/build checks were run because the diff is limited to repo licensing and markdown metadata files, not Astro or TypeScript sources

Closes #149
