### PR TITLE
Refresh roadmap priorities after shipped milestones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added a public roadmap page at `/roadmap/`, localized as `/en/roadmap/` and `/de/roadmap/`
-- documented current roadmap focus (Passkeys, employee onboarding), next planned step (Android app), and longer-term direction (shift planning, guard tour system, contract management, service instruction configurator)
+- documented current roadmap focus (shift planning), the next planned step (online guard tour system), and longer-term direction (contract management and service instruction configurator)
+- added a Node regression test that keeps the English and German roadmap copy aligned with the current shift-planning focus and the next OWKS milestone
 - linked the roadmap page to the full changelog at `changelog.secpal.app`
 - added roadmap navigation link to desktop and mobile menus, and roadmap paths to the sitemap
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable latest and versioned release JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- refreshed the English and German roadmap copy so shift planning is the current focus, OWKS is the next milestone, and completed passkey, onboarding, and Android distribution work is no longer shown as in progress
 - replaced the stub `LICENSES/LicenseRef-TailwindPlus.txt` summary with the
   published Tailwind Plus license text and clarified that
   `LicenseRef-TailwindPlus` is the repo's SPDX reference for Tailwind

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -76,14 +76,9 @@ export const de: Translations = {
       description: "In aktiver Entwicklung",
       items: [
         {
-          name: "Passkeys & WebAuthn",
+          name: "Dienstplanung",
           description:
-            "Passwortloser Login per Gerätebiometrie oder Security-Key (FIDO2/WebAuthn) — sicherer und unkomplizierter als Passwörter.",
-        },
-        {
-          name: "Mitarbeiter-Onboarding (BewachV §16)",
-          description:
-            "Strukturiertes Onboarding, das alle für die Bewacherregister-Anmeldung erforderlichen Felder erfasst — mit eigenem Einladungslink statt einem Passwort-Reset als Behelf.",
+            "Dienstpläne, Schichtzuweisungen und Besetzungsplanung — eingebaut in den operativen Ablauf statt separat verwaltet.",
         },
       ],
     },
@@ -92,9 +87,9 @@ export const de: Translations = {
       description: "Für die nahe Zukunft geplant",
       items: [
         {
-          name: "Android-App",
+          name: "Online-Wächterkontrollsystem (OWKS)",
           description:
-            "Native Android-App — gleicher Funktionsumfang wie die Web-App, geeignet für gemeinsam genutzte Geräte und den Außendienst.",
+            "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge als natürlicher Teil des Betriebsprotokolls.",
         },
       ],
     },
@@ -102,16 +97,6 @@ export const de: Translations = {
       label: "Später",
       description: "Längerfristige Richtung — ohne feste Termine",
       items: [
-        {
-          name: "Dienstplanung",
-          description:
-            "Dienstpläne, Schichtzuweisungen und Besetzungsplanung — eingebaut in den operativen Ablauf statt separat verwaltet.",
-        },
-        {
-          name: "Online-Wächterkontrollsystem (OWKS)",
-          description:
-            "Checkpoint-basierte Kontrollgangerfassung per NFC oder QR — nachvollziehbare Kontrollgänge als natürlicher Teil des Betriebsprotokolls.",
-        },
         {
           name: "Vertragsverwaltung & digitale Unterschrift",
           description:

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -74,14 +74,9 @@ export const en = {
       description: "Actively in development",
       items: [
         {
-          name: "Passkeys & WebAuthn",
+          name: "Shift planning",
           description:
-            "Password-free login via device biometrics or security keys (FIDO2/WebAuthn) — more secure and easier to use than passwords.",
-        },
-        {
-          name: "Employee onboarding (BewachV §16)",
-          description:
-            "Structured onboarding that collects all fields required for Bewacherregister registration — with a dedicated invite link instead of a password-reset workaround.",
+            "Duty rosters, shift assignments, and coverage planning — integrated into the operational workflow rather than managed separately.",
         },
       ],
     },
@@ -90,9 +85,9 @@ export const en = {
       description: "Planned for the near term",
       items: [
         {
-          name: "Android app",
+          name: "Online guard tour system",
           description:
-            "Native Android app — same capabilities as the web app, suitable for shared devices and field use.",
+            "Checkpoint-based patrol recording via NFC or QR — traceable guard tours as a natural part of the operational log.",
         },
       ],
     },
@@ -100,16 +95,6 @@ export const en = {
       label: "Later",
       description: "Longer-term direction — no dates attached",
       items: [
-        {
-          name: "Shift planning",
-          description:
-            "Duty rosters, shift assignments, and coverage planning — integrated into the operational workflow rather than managed separately.",
-        },
-        {
-          name: "Online guard tour system",
-          description:
-            "Checkpoint-based patrol recording via NFC or QR — traceable guard tours as a natural part of the operational log.",
-        },
         {
           name: "Contract management & digital signatures",
           description:

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -46,19 +46,11 @@ test("roadmap reflects the current shift-planning and OWKS priorities", () => {
     "expected completed German onboarding work to be removed from Aktuell"
   );
   assert.ok(
-    !englishNowNames.includes("Android distribution"),
-    "expected English Android distribution work to be removed from Now"
+    !englishNextNames.includes("Android app"),
+    "expected English Android app work to be removed from Next"
   );
   assert.ok(
-    !germanNowNames.includes("Android-Verteilung"),
-    "expected German Android distribution work to be removed from Aktuell"
-  );
-  assert.ok(
-    !englishNextNames.includes("Direct download & beta distribution"),
-    "expected English Android rollout follow-up to be removed from Next"
-  );
-  assert.ok(
-    !germanNextNames.includes("Direktdownload & Beta-Verteilung"),
-    "expected German Android rollout follow-up to be removed from Next"
+    !germanNextNames.includes("Android-App"),
+    "expected German Android app work to be removed from Als Nächstes"
   );
 });

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { en } from "../src/i18n/en.ts";
+import { de } from "../src/i18n/de.ts";
+
+test("roadmap reflects the current shift-planning and OWKS priorities", () => {
+  const englishNowNames = en.roadmap.now.items.map((item) => item.name);
+  const germanNowNames = de.roadmap.now.items.map((item) => item.name);
+  const englishNextNames = en.roadmap.next.items.map((item) => item.name);
+  const germanNextNames = de.roadmap.next.items.map((item) => item.name);
+
+  assert.ok(
+    englishNowNames.includes("Shift planning"),
+    "expected English roadmap to treat shift planning as current work"
+  );
+  assert.ok(
+    germanNowNames.includes("Dienstplanung"),
+    "expected German roadmap to treat shift planning as current work"
+  );
+  assert.ok(
+    englishNextNames.includes("Online guard tour system"),
+    "expected English roadmap to reserve the next milestone for the online guard tour system"
+  );
+  assert.ok(
+    germanNextNames.includes("Online-Wächterkontrollsystem (OWKS)"),
+    "expected German roadmap to reserve the next milestone for the OWKS"
+  );
+  assert.ok(
+    !englishNowNames.includes("Passkeys & WebAuthn"),
+    "expected shipped English passkeys work to be removed from Now"
+  );
+  assert.ok(
+    !germanNowNames.includes("Passkeys & WebAuthn"),
+    "expected shipped German passkeys work to be removed from Aktuell"
+  );
+  assert.ok(
+    !englishNowNames.includes("Employee onboarding (BewachV §16)"),
+    "expected completed English onboarding work to be removed from Now"
+  );
+  assert.ok(
+    !germanNowNames.includes("Mitarbeiter-Onboarding (BewachV §16)"),
+    "expected completed German onboarding work to be removed from Aktuell"
+  );
+  assert.ok(
+    !englishNowNames.includes("Android distribution"),
+    "expected English Android distribution work to be removed from Now"
+  );
+  assert.ok(
+    !germanNowNames.includes("Android-Verteilung"),
+    "expected German Android distribution work to be removed from Aktuell"
+  );
+  assert.ok(
+    !englishNextNames.includes("Direct download & beta distribution"),
+    "expected English Android rollout follow-up to be removed from Next"
+  );
+  assert.ok(
+    !germanNextNames.includes("Direktdownload & Beta-Verteilung"),
+    "expected German Android rollout follow-up to be removed from Next"
+  );
+});

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -12,6 +12,18 @@ test("roadmap reflects the current shift-planning and OWKS priorities", () => {
   const germanNowNames = de.roadmap.now.items.map((item) => item.name);
   const englishNextNames = en.roadmap.next.items.map((item) => item.name);
   const germanNextNames = de.roadmap.next.items.map((item) => item.name);
+  const englishLaterNames = en.roadmap.later.items.map((item) => item.name);
+  const germanLaterNames = de.roadmap.later.items.map((item) => item.name);
+  const englishActiveNames = [
+    ...englishNowNames,
+    ...englishNextNames,
+    ...englishLaterNames,
+  ];
+  const germanActiveNames = [
+    ...germanNowNames,
+    ...germanNextNames,
+    ...germanLaterNames,
+  ];
 
   assert.ok(
     englishNowNames.includes("Shift planning"),
@@ -30,27 +42,35 @@ test("roadmap reflects the current shift-planning and OWKS priorities", () => {
     "expected German roadmap to reserve the next milestone for the OWKS"
   );
   assert.ok(
-    !englishNowNames.includes("Passkeys & WebAuthn"),
-    "expected shipped English passkeys work to be removed from Now"
+    !englishActiveNames.includes("Passkeys & WebAuthn"),
+    "expected shipped English passkeys work to be removed from the active roadmap phases"
   );
   assert.ok(
-    !germanNowNames.includes("Passkeys & WebAuthn"),
-    "expected shipped German passkeys work to be removed from Aktuell"
+    !germanActiveNames.includes("Passkeys & WebAuthn"),
+    "expected shipped German passkeys work to be removed from the active roadmap phases"
   );
   assert.ok(
-    !englishNowNames.includes("Employee onboarding (BewachV §16)"),
-    "expected completed English onboarding work to be removed from Now"
+    !englishActiveNames.includes("Employee onboarding (BewachV §16)"),
+    "expected completed English onboarding work to be removed from the active roadmap phases"
   );
   assert.ok(
-    !germanNowNames.includes("Mitarbeiter-Onboarding (BewachV §16)"),
-    "expected completed German onboarding work to be removed from Aktuell"
+    !germanActiveNames.includes("Mitarbeiter-Onboarding (BewachV §16)"),
+    "expected completed German onboarding work to be removed from the active roadmap phases"
   );
   assert.ok(
-    !englishNextNames.includes("Android app"),
-    "expected English Android app work to be removed from Next"
+    !englishActiveNames.includes("Android distribution"),
+    "expected English Android distribution work to be removed from the active roadmap phases"
   );
   assert.ok(
-    !germanNextNames.includes("Android-App"),
-    "expected German Android app work to be removed from Als Nächstes"
+    !germanActiveNames.includes("Android-Verteilung"),
+    "expected German Android distribution work to be removed from the active roadmap phases"
+  );
+  assert.ok(
+    !englishActiveNames.includes("Android app"),
+    "expected English Android app work to be removed from the active roadmap phases"
+  );
+  assert.ok(
+    !germanActiveNames.includes("Android-App"),
+    "expected German Android app work to be removed from the active roadmap phases"
   );
 });


### PR DESCRIPTION
## Why

Reproduced defect: the public roadmap copy in `src/i18n/en.ts` and `src/i18n/de.ts` still advertised completed or intentionally removed work as active roadmap items. The stale entries covered passkeys, onboarding, and Android distribution follow-up instead of the current product priorities.

## What Changed

- moved shift planning to `Now` / `Aktuell`
- moved the online guard tour system to `Next` / `Als Nächstes`
- removed completed passkey, onboarding, and Android distribution items from the active roadmap phases
- added a focused regression test for the localized roadmap priorities
- updated `CHANGELOG.md` to match the refreshed roadmap scope

## Validation

- `node --experimental-strip-types --test tests/roadmap-copy.test.mjs`
- `npm test`
- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm run build`

## Before Marking Ready

- linked workspaces: none required for this PR
- remaining follow-up: GitHub Actions and the final PR-view self-review still need to stay clean before moving this draft out of draft state

Closes #148
