### PR TITLE
Simplify the SecPal site navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- reduced the localized main navigation to Workflow, Roadmap, and Android;
+  kept contact solely as the primary header action and GitHub as a secondary
+  technical path in the closing CTA and footer; added active states for
+  Roadmap and Android; and preserved valid homepage anchors when switching
+  languages
 - tightened the localized homepage copy to separate product direction from
   development status, with professional contact now also the primary header
   action

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,9 +26,12 @@ const t = useTranslations(locale);
 
 const otherLocale: Locale = locale === "en" ? "de" : "en";
 const otherLocalePath = getLocalizedPath(currentPath, otherLocale);
+const roadmapPath = getLocalizedPath("/roadmap", locale);
 const androidPath = getLocalizedPath("/android", locale);
-const progressPath = `${getLocalizedPath("/", locale)}#progress`;
+const workflowPath = `${getLocalizedPath("/", locale)}#workflow`;
 const contactPath = `${getLocalizedPath("/", locale)}#contact`;
+const isRoadmapCurrent = currentPath === "/roadmap";
+const isAndroidCurrent = currentPath === "/android";
 const heroTone = tone === "androidHero";
 const headerBackgroundClass = heroTone
   ? "bg-transparent"
@@ -47,6 +50,11 @@ const mobileMenuCloseClass =
   transparent || heroTone
     ? "-m-2.5 rounded-md p-2.5 text-gray-900 dark:text-white"
     : "-m-2.5 rounded-md p-2.5 text-gray-700 dark:text-gray-400";
+const desktopLinkClass = "text-sm/6 font-semibold";
+const mobileLinkClass =
+  "-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold hover:bg-gray-50 dark:hover:bg-white/5";
+const defaultNavTextClass = "text-gray-900 dark:text-white";
+const activeNavTextClass = "text-indigo-600 dark:text-indigo-400";
 ---
 
 <!-- @tailwindplus/elements is loaded in Base.astro via script tag -->
@@ -81,29 +89,24 @@ const mobileMenuCloseClass =
     <!-- Desktop nav links -->
     <div class="hidden lg:flex lg:gap-x-6 2xl:gap-x-12">
       <a
-        href={progressPath}
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.progress}</a
+        href={workflowPath}
+        class:list={[desktopLinkClass, defaultNavTextClass]}>{t.nav.workflow}</a
       >
       <a
-        href={getLocalizedPath("/roadmap", locale)}
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.roadmap}</a
+        href={roadmapPath}
+        aria-current={isRoadmapCurrent ? "page" : undefined}
+        class:list={[
+          desktopLinkClass,
+          isRoadmapCurrent ? activeNavTextClass : defaultNavTextClass,
+        ]}>{t.nav.roadmap}</a
       >
       <a
         href={androidPath}
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.android}</a
-      >
-      <a
-        href={contactPath}
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.contact}</a
-      >
-      <a
-        href="https://github.com/SecPal"
-        class="text-sm/6 font-semibold text-gray-900 dark:text-white"
-        >{t.nav.github}</a
+        aria-current={isAndroidCurrent ? "page" : undefined}
+        class:list={[
+          desktopLinkClass,
+          isAndroidCurrent ? activeNavTextClass : defaultNavTextClass,
+        ]}>{t.nav.android}</a
       >
     </div>
 
@@ -112,6 +115,7 @@ const mobileMenuCloseClass =
       <!-- Language switcher -->
       <a
         href={otherLocalePath}
+        data-language-switch
         class:list={[
           "hidden text-xs font-semibold uppercase tracking-wide lg:block",
           utilityControlClass,
@@ -257,34 +261,31 @@ const mobileMenuCloseClass =
         <div class="-my-6 divide-y divide-gray-500/10 dark:divide-white/10">
           <div class="space-y-2 py-6">
             <a
-              href={progressPath}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.progress}</a
+              href={workflowPath}
+              class:list={[mobileLinkClass, defaultNavTextClass]}
+              >{t.nav.workflow}</a
             >
             <a
-              href={getLocalizedPath("/roadmap", locale)}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.roadmap}</a
+              href={roadmapPath}
+              aria-current={isRoadmapCurrent ? "page" : undefined}
+              class:list={[
+                mobileLinkClass,
+                isRoadmapCurrent ? activeNavTextClass : defaultNavTextClass,
+              ]}>{t.nav.roadmap}</a
             >
             <a
               href={androidPath}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.android}</a
-            >
-            <a
-              href={contactPath}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.contact}</a
-            >
-            <a
-              href="https://github.com/SecPal"
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
-              >{t.nav.github}</a
+              aria-current={isAndroidCurrent ? "page" : undefined}
+              class:list={[
+                mobileLinkClass,
+                isAndroidCurrent ? activeNavTextClass : defaultNavTextClass,
+              ]}>{t.nav.android}</a
             >
             <!-- Language switcher in mobile menu -->
             <a
               href={otherLocalePath}
-              class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5"
+              data-language-switch
+              class:list={[mobileLinkClass, defaultNavTextClass]}
             >
               {otherLocale === "de" ? "Deutsch" : "English"}
             </a>

--- a/src/components/Workflow.astro
+++ b/src/components/Workflow.astro
@@ -24,6 +24,7 @@ const t = useTranslations(locale);
 ---
 
 <section
+  id="workflow"
   aria-labelledby="workflow-heading"
   class="bg-white py-20 sm:py-24 dark:bg-gray-900"
 >

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -5,11 +5,9 @@ import type { Translations } from "./en.ts";
 
 export const de: Translations = {
   nav: {
-    progress: "Fortschritt",
+    workflow: "Ablauf",
     roadmap: "Roadmap",
     android: "Android",
-    github: "GitHub",
-    contact: "Kontakt",
     headerCta: "Kontakt aufnehmen",
     toggleDarkMode: "Dunkelmodus umschalten",
     openMenu: "Hauptmenü öffnen",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -3,11 +3,9 @@
 
 export const en = {
   nav: {
-    progress: "Progress",
+    workflow: "Workflow",
     roadmap: "Roadmap",
     android: "Android",
-    github: "GitHub",
-    contact: "Contact",
     headerCta: "Get in touch",
     toggleDarkMode: "Toggle dark mode",
     openMenu: "Open main menu",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -130,6 +130,33 @@ const previewUrl = canonicalUrl ?? xDefaultUrl;
           var mobileMenu = document.getElementById("mobile-menu");
           var mobileMenuOpen = document.getElementById("mobile-menu-open");
           var mobileMenuClose = document.getElementById("mobile-menu-close");
+          document
+            .querySelectorAll("[data-language-switch]")
+            .forEach(function (link) {
+              link.addEventListener("click", function () {
+                var isHomepage =
+                  window.location.pathname === "/de/" ||
+                  window.location.pathname === "/en/";
+                if (!isHomepage || !window.location.hash) {
+                  return;
+                }
+
+                var anchorId;
+                var targetUrl;
+                try {
+                  anchorId = decodeURIComponent(window.location.hash.slice(1));
+                  targetUrl = new URL(link.href, window.location.href);
+                } catch {
+                  return;
+                }
+                if (!document.getElementById(anchorId)) {
+                  return;
+                }
+
+                targetUrl.hash = window.location.hash;
+                link.href = targetUrl.toString();
+              });
+            });
           if (btn) {
             btn.addEventListener("click", function () {
               var isDark = document.documentElement.classList.toggle("dark");

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -130,33 +130,40 @@ const previewUrl = canonicalUrl ?? xDefaultUrl;
           var mobileMenu = document.getElementById("mobile-menu");
           var mobileMenuOpen = document.getElementById("mobile-menu-open");
           var mobileMenuClose = document.getElementById("mobile-menu-close");
-          document
-            .querySelectorAll("[data-language-switch]")
-            .forEach(function (link) {
-              link.addEventListener("click", function () {
-                var isHomepage =
-                  window.location.pathname === "/de/" ||
-                  window.location.pathname === "/en/";
-                if (!isHomepage || !window.location.hash) {
-                  return;
+          var languageSwitchTargets = Array.from(
+            document.querySelectorAll("[data-language-switch]")
+          ).map(function (link) {
+            return {
+              link: link,
+              href: link.getAttribute("href") || link.href,
+            };
+          });
+          var syncLanguageSwitchTargets = function () {
+            var isHomepage =
+              window.location.pathname === "/de/" ||
+              window.location.pathname === "/en/";
+            var validHash = "";
+            if (isHomepage && window.location.hash) {
+              try {
+                var anchorId = decodeURIComponent(
+                  window.location.hash.slice(1)
+                );
+                if (document.getElementById(anchorId)) {
+                  validHash = window.location.hash;
                 }
+              } catch {}
+            }
 
-                var anchorId;
-                var targetUrl;
-                try {
-                  anchorId = decodeURIComponent(window.location.hash.slice(1));
-                  targetUrl = new URL(link.href, window.location.href);
-                } catch {
-                  return;
-                }
-                if (!document.getElementById(anchorId)) {
-                  return;
-                }
-
-                targetUrl.hash = window.location.hash;
-                link.href = targetUrl.toString();
-              });
+            languageSwitchTargets.forEach(function (target) {
+              try {
+                var targetUrl = new URL(target.href, window.location.href);
+                targetUrl.hash = validHash;
+                target.link.href = targetUrl.toString();
+              } catch {}
             });
+          };
+          syncLanguageSwitchTargets();
+          window.addEventListener("hashchange", syncLanguageSwitchTargets);
           if (btn) {
             btn.addEventListener("click", function () {
               var isDark = document.documentElement.classList.toggle("dark");

--- a/tests/cta-section.test.mjs
+++ b/tests/cta-section.test.mjs
@@ -123,9 +123,8 @@ test("desktop and mobile navigation point to the localized contact section", () 
     nav,
     /const contactPath = `\$\{getLocalizedPath\("\/", locale\)\}#contact`;/
   );
-  assert.equal(nav.match(/href=\{contactPath\}/g)?.length, 4);
-  assert.equal(nav.match(/\{t\.nav\.contact\}/g)?.length, 2);
-  assert.doesNotMatch(nav, /updatesPath|t\.nav\.updates|#updates/);
+  assert.equal(nav.match(/href=\{contactPath\}/g)?.length, 2);
+  assert.doesNotMatch(nav, /\{t\.nav\.contact\}/);
   assert.equal(headerCtaAnchors.length, 2);
   assert.match(
     headerCtaAnchors[0],
@@ -152,15 +151,12 @@ test("desktop and mobile navigation point to the localized contact section", () 
     nav,
     /id="dark-toggle"[\s\S]*?class:list=\{\[[\s\S]*?"[^"]*min-h-\[44px\][^"]*min-w-\[44px\][^"]*"[\s\S]*?utilityControlClass[\s\S]*?\]\}/
   );
-  assert.equal(nav.match(/href="https:\/\/github\.com\/SecPal"/g)?.length, 2);
-  assert.equal(nav.match(/\{t\.nav\.github\}/g)?.length, 2);
-  assert.doesNotMatch(nav, /t\.nav\.followProgress/);
-  assert.ok(!("updates" in de.nav));
-  assert.ok(!("updates" in en.nav));
-  assert.ok(!("followProgress" in de.nav));
-  assert.ok(!("followProgress" in en.nav));
-  assert.equal(de.nav.contact, "Kontakt");
-  assert.equal(en.nav.contact, "Contact");
+  assert.doesNotMatch(nav, /href="https:\/\/github\.com\/SecPal"/);
+  assert.doesNotMatch(nav, /\{t\.nav\.github\}/);
+  assert.ok(!("contact" in de.nav));
+  assert.ok(!("contact" in en.nav));
+  assert.ok(!("github" in de.nav));
+  assert.ok(!("github" in en.nav));
   assert.equal(de.nav.headerCta, "Kontakt aufnehmen");
   assert.equal(en.nav.headerCta, "Get in touch");
 });

--- a/tests/navigation-structure.test.mjs
+++ b/tests/navigation-structure.test.mjs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { de } from "../src/i18n/de.ts";
+import { en } from "../src/i18n/en.ts";
+
+const nav = readFileSync(
+  new URL("../src/components/Nav.astro", import.meta.url),
+  "utf8"
+);
+const layout = readFileSync(
+  new URL("../src/layouts/Base.astro", import.meta.url),
+  "utf8"
+);
+const workflow = readFileSync(
+  new URL("../src/components/Workflow.astro", import.meta.url),
+  "utf8"
+);
+const hero = readFileSync(
+  new URL("../src/components/Hero.astro", import.meta.url),
+  "utf8"
+);
+const features = readFileSync(
+  new URL("../src/components/Features.astro", import.meta.url),
+  "utf8"
+);
+const cta = readFileSync(
+  new URL("../src/components/CTA.astro", import.meta.url),
+  "utf8"
+);
+const footer = readFileSync(
+  new URL("../src/components/Footer.astro", import.meta.url),
+  "utf8"
+);
+
+function sectionBetween(start, end) {
+  const startIndex = nav.indexOf(start);
+  const endIndex = nav.indexOf(end, startIndex);
+
+  assert.ok(startIndex >= 0, `Missing section marker: ${start}`);
+  assert.ok(endIndex > startIndex, `Missing section marker: ${end}`);
+  return nav.slice(startIndex, endIndex);
+}
+
+function anchorsForPath(pathName) {
+  return (
+    nav.match(
+      new RegExp(`<a\\s+[^>]*href=\\{${pathName}\\}[\\s\\S]*?</a`, "g")
+    ) ?? []
+  );
+}
+
+test("desktop navigation contains only workflow, roadmap, and Android links", () => {
+  const desktopLinks = sectionBetween(
+    "<!-- Desktop nav links -->",
+    "<!-- Right-side: language switcher + dark toggle + CTA -->"
+  );
+
+  assert.equal(desktopLinks.match(/<a\b/g)?.length, 3);
+  assert.deepEqual(
+    [...desktopLinks.matchAll(/href=\{(\w+Path)\}/g)].map((match) => match[1]),
+    ["workflowPath", "roadmapPath", "androidPath"]
+  );
+  assert.match(desktopLinks, /\{t\.nav\.workflow\}/);
+  assert.match(desktopLinks, /\{t\.nav\.roadmap\}/);
+  assert.match(desktopLinks, /\{t\.nav\.android\}/);
+  assert.doesNotMatch(desktopLinks, /contact|github/i);
+});
+
+test("mobile navigation contains the same content links followed by language", () => {
+  const mobileLinks = sectionBetween(
+    '<div class="space-y-2 py-6">',
+    "</div>\n        </div>\n      </div>"
+  );
+
+  assert.equal(mobileLinks.match(/<a\b/g)?.length, 4);
+  assert.deepEqual(
+    [...mobileLinks.matchAll(/href=\{(\w+Path)\}/g)].map((match) => match[1]),
+    ["workflowPath", "roadmapPath", "androidPath", "otherLocalePath"]
+  );
+  assert.match(mobileLinks, /\{t\.nav\.workflow\}/);
+  assert.match(mobileLinks, /\{t\.nav\.roadmap\}/);
+  assert.match(mobileLinks, /\{t\.nav\.android\}/);
+  assert.doesNotMatch(mobileLinks, /contact|github/i);
+});
+
+test("navigation targets and section anchors keep their distinct purposes", () => {
+  assert.match(
+    nav,
+    /const workflowPath = `\$\{getLocalizedPath\("\/", locale\)\}#workflow`;/
+  );
+  assert.match(
+    nav,
+    /const contactPath = `\$\{getLocalizedPath\("\/", locale\)\}#contact`;/
+  );
+  assert.match(
+    nav,
+    /const roadmapPath = getLocalizedPath\("\/roadmap", locale\);/
+  );
+  assert.match(
+    nav,
+    /const androidPath = getLocalizedPath\("\/android", locale\);/
+  );
+  assert.ok(!nav.includes(["progress", "Path"].join("")));
+  assert.match(
+    workflow,
+    /<section\s+id="workflow"\s+aria-labelledby="workflow-heading"/
+  );
+  assert.match(hero, /href="#progress"/);
+  assert.match(
+    features,
+    /<section\s+id="progress"\s+aria-labelledby="features-heading"/
+  );
+});
+
+test("contact is only the highlighted header action and GitHub stays secondary", () => {
+  const headerCtaAnchors =
+    nav
+      .match(/<a\s+href=\{contactPath\}[\s\S]*?<\/a>/g)
+      ?.filter((anchor) => anchor.includes("{t.nav.headerCta}")) ?? [];
+
+  assert.equal(nav.match(/href=\{contactPath\}/g)?.length, 2);
+  assert.equal(headerCtaAnchors.length, 2);
+  assert.doesNotMatch(
+    nav,
+    /t\.nav\.contact|t\.nav\.github|github\.com\/SecPal/
+  );
+  assert.equal(cta.match(/https:\/\/github\.com\/SecPal/g)?.length, 1);
+  assert.equal(footer.match(/https:\/\/github\.com\/SecPal/g)?.length, 1);
+});
+
+test("navigation translations are aligned and obsolete fields are removed", () => {
+  assert.equal(de.nav.workflow, "Ablauf");
+  assert.equal(en.nav.workflow, "Workflow");
+  assert.equal(de.nav.headerCta, "Kontakt aufnehmen");
+  assert.equal(en.nav.headerCta, "Get in touch");
+  assert.deepEqual(Object.keys(de.nav), Object.keys(en.nav));
+
+  for (const translations of [de, en]) {
+    assert.ok(!("progress" in translations.nav));
+    assert.ok(!("contact" in translations.nav));
+    assert.ok(!("github" in translations.nav));
+  }
+});
+
+test("roadmap and Android expose mutually exclusive active page states", () => {
+  const workflowAnchors = anchorsForPath("workflowPath");
+  const roadmapAnchors = anchorsForPath("roadmapPath");
+  const androidAnchors = anchorsForPath("androidPath");
+
+  assert.match(nav, /const isRoadmapCurrent = currentPath === "\/roadmap";/);
+  assert.match(nav, /const isAndroidCurrent = currentPath === "\/android";/);
+  assert.equal(
+    nav.match(/aria-current=\{isRoadmapCurrent \? "page" : undefined\}/g)
+      ?.length,
+    2
+  );
+  assert.equal(
+    nav.match(/aria-current=\{isAndroidCurrent \? "page" : undefined\}/g)
+      ?.length,
+    2
+  );
+  assert.match(nav, /text-indigo-600 dark:text-indigo-400/);
+  assert.equal(workflowAnchors.length, 2);
+  assert.equal(roadmapAnchors.length, 2);
+  assert.equal(androidAnchors.length, 2);
+  for (const anchor of workflowAnchors) {
+    assert.doesNotMatch(anchor, /aria-current/);
+  }
+  for (const anchor of roadmapAnchors) {
+    assert.match(
+      anchor,
+      /aria-current=\{isRoadmapCurrent \? "page" : undefined\}/
+    );
+    assert.doesNotMatch(anchor, /isAndroidCurrent/);
+  }
+  for (const anchor of androidAnchors) {
+    assert.match(
+      anchor,
+      /aria-current=\{isAndroidCurrent \? "page" : undefined\}/
+    );
+    assert.doesNotMatch(anchor, /isRoadmapCurrent/);
+  }
+});
+
+test("both language links preserve only existing homepage hashes", () => {
+  assert.equal(nav.match(/\bdata-language-switch\b/g)?.length, 2);
+  assert.match(layout, /querySelectorAll\("\[data-language-switch\]"\)/);
+  assert.match(
+    layout,
+    /window\.location\.pathname === "\/de\/"[\s\S]*window\.location\.pathname === "\/en\/"/
+  );
+  assert.match(layout, /window\.location\.hash/);
+  assert.match(layout, /document\.getElementById\(anchorId\)/);
+  assert.match(layout, /targetUrl\.hash = window\.location\.hash/);
+  assert.match(layout, /link\.href = targetUrl\.toString\(\)/);
+});

--- a/tests/navigation-structure.test.mjs
+++ b/tests/navigation-structure.test.mjs
@@ -4,6 +4,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { runInNewContext } from "node:vm";
 
 import { de } from "../src/i18n/de.ts";
 import { en } from "../src/i18n/en.ts";
@@ -187,15 +188,72 @@ test("roadmap and Android expose mutually exclusive active page states", () => {
   }
 });
 
-test("both language links preserve only existing homepage hashes", () => {
+test("both language links proactively preserve only existing homepage hashes", () => {
   assert.equal(nav.match(/\bdata-language-switch\b/g)?.length, 2);
-  assert.match(layout, /querySelectorAll\("\[data-language-switch\]"\)/);
-  assert.match(
-    layout,
-    /window\.location\.pathname === "\/de\/"[\s\S]*window\.location\.pathname === "\/en\/"/
+
+  const inlineScript = layout.match(
+    /<script is:inline>\s*([\s\S]*?)\s*<\/script>/
+  )?.[1];
+  assert.ok(
+    inlineScript,
+    "Base layout must contain its inline behavior script"
   );
-  assert.match(layout, /window\.location\.hash/);
-  assert.match(layout, /document\.getElementById\(anchorId\)/);
-  assert.match(layout, /targetUrl\.hash = window\.location\.hash/);
-  assert.match(layout, /link\.href = targetUrl\.toString\(\)/);
+
+  const documentListeners = new Map();
+  const windowListeners = new Map();
+  const languageLinks = [
+    {
+      href: "https://secpal.app/de/",
+      getAttribute: (name) => (name === "href" ? "/de/" : null),
+      addEventListener() {},
+    },
+    {
+      href: "https://secpal.app/de/",
+      getAttribute: (name) => (name === "href" ? "/de/" : null),
+      addEventListener() {},
+    },
+  ];
+  const existingAnchors = new Set(["workflow", "progress", "contact"]);
+  const window = {
+    location: new URL("https://secpal.app/en/#workflow"),
+    matchMedia: () => ({ matches: false }),
+    addEventListener: (type, listener) => windowListeners.set(type, listener),
+  };
+  const document = {
+    activeElement: null,
+    body: { style: { overflow: "" } },
+    documentElement: { classList: { add() {} } },
+    addEventListener: (type, listener) => documentListeners.set(type, listener),
+    getElementById: (id) => (existingAnchors.has(id) ? {} : null),
+    querySelector: () => null,
+    querySelectorAll: (selector) =>
+      selector === "[data-language-switch]" ? languageLinks : [],
+  };
+
+  runInNewContext(inlineScript, {
+    URL,
+    document,
+    localStorage: { getItem: () => null },
+    window,
+  });
+  documentListeners.get("DOMContentLoaded")?.();
+
+  assert.deepEqual(
+    languageLinks.map((link) => link.href),
+    ["https://secpal.app/de/#workflow", "https://secpal.app/de/#workflow"]
+  );
+
+  window.location = new URL("https://secpal.app/en/#contact");
+  windowListeners.get("hashchange")?.();
+  assert.deepEqual(
+    languageLinks.map((link) => link.href),
+    ["https://secpal.app/de/#contact", "https://secpal.app/de/#contact"]
+  );
+
+  window.location = new URL("https://secpal.app/en/#missing");
+  windowListeners.get("hashchange")?.();
+  assert.deepEqual(
+    languageLinks.map((link) => link.href),
+    ["https://secpal.app/de/", "https://secpal.app/de/"]
+  );
 });

--- a/tests/workflow-section.test.mjs
+++ b/tests/workflow-section.test.mjs
@@ -103,7 +103,10 @@ test("workflow component keeps the process semantic, responsive, and text-free",
   assert.match(component, /SPDX-FileCopyrightText: 2026 SecPal/);
   assert.match(component, /SPDX-FileCopyrightText: Tailwind Labs Inc\./);
   assert.ok(component.includes(expectedLicenseLine));
-  assert.match(component, /<section\s+aria-labelledby="workflow-heading"/);
+  assert.match(
+    component,
+    /<section\s+id="workflow"\s+aria-labelledby="workflow-heading"/
+  );
   assert.equal(component.match(/<h2\b/g)?.length, 1);
   assert.match(component, /<h2\s+id="workflow-heading"/);
   assert.equal(component.match(/<ol\b/g)?.length, 1);


### PR DESCRIPTION
## Problem

- The former Progress navigation item linked to the general problem section instead of the five-step workflow it described.
- Contact appeared both as a normal navigation item and as the primary header action.
- GitHub had too much prominence in the desktop and mobile main navigation.
- Roadmap and Android subpages did not identify the current page.

## Evidence

- The base-branch navigation built its Progress destination from `#progress`, which belongs to the problem section in `src/components/Features.astro`; `src/components/Workflow.astro` had no dedicated section anchor.
- `src/components/Nav.astro` rendered contact four times across normal links and highlighted actions, and rendered GitHub in both desktop and mobile navigation.
- The localized Roadmap and Android pages already passed `currentPath` to the navigation, but the links did not expose `aria-current`.

## Changes

- Replaced Progress with a localized Workflow link and added the dedicated `#workflow` section anchor.
- Reduced desktop and mobile main navigation to Workflow, Roadmap, and Android.
- Kept contact solely as the highlighted header and mobile-dialog action.
- Removed GitHub from the main navigation while retaining it in the closing CTA and footer.
- Added mutually exclusive `aria-current="page"` states for Roadmap and Android.
- Preserved valid homepage anchors when switching languages, with the existing non-JavaScript paths remaining as the fallback.

## Tests

- `npm test` — 42 tests passed.
- `reuse lint` — REUSE 3.3 compliant.
- `./scripts/preflight.sh` — formatting, Markdown, domain policy, Astro checks, ESLint, build, signature, and PR-size checks passed.
- Browser matrix covered 320×568, 360×640, 390×844, 430×932, 768×1024, 1024×768, 1280×800, and 1440×900.
- Browser checks covered German and English, light and dark mode, default and 125% base font size, localized homepages, Roadmap, and Android.
- Keyboard and focus checks covered the mobile focus trap, Tab, Shift+Tab, Escape, focus restoration, same-page target focus, background `inert`, and scroll lock.
- Verified no horizontal overflow and no browser console errors.

## Scope and readiness

- No layout, content, or design changes outside the navigation and the new Workflow anchor.
- The Hero link and existing page structure remain unchanged.
- The final local and pull-request diff reviews found no remaining in-scope issues or out-of-scope findings that require tracking.
- No in-scope dependency or failing check prevents readiness. All workflow runs concluded successfully and the pull request reports a clean merge state.
- The pull request remains a draft as required. GitHub's status rollup still exposes the completed REUSE job as in progress even though the same job reports a successful conclusion and completion timestamp; the successful parent workflow and clean merge state are unaffected.
