### PR TITLE
Prevent localized labels from causing horizontal overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- prevented long German roadmap and Android download labels from causing
+  horizontal page overflow when the browser base font size is enlarged
 - aligned the mobile menu's visual and keyboard order and moved focus to
   same-page destinations when dialog links are activated
 - completed mobile navigation keyboard behavior with focus containment, Escape

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -137,7 +137,12 @@ const content = getAndroidDistributionContent(locale);
               <p class="min-h-4 text-xs font-semibold tracking-[0.18em] text-gray-500 uppercase dark:text-gray-400">
                 {option.badge}
               </p>
-              <h3 class="mt-2.5 text-2xl font-semibold text-gray-900 dark:text-white">
+              <h3
+                class:list={[
+                  "mt-2.5 text-2xl font-semibold text-gray-900 dark:text-white",
+                  locale === "de" ? "break-words" : null,
+                ]}
+              >
                 {option.name}
               </h3>
               <p class="mt-2.5 text-base/7 text-gray-600 dark:text-gray-300">

--- a/src/components/Roadmap.astro
+++ b/src/components/Roadmap.astro
@@ -141,7 +141,12 @@ const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
                     {phase.items.map(
                       (item: { name: string; description: string }) => (
                         <li>
-                          <p class="font-semibold text-gray-900 dark:text-white">
+                          <p
+                            class:list={[
+                              "font-semibold text-gray-900 dark:text-white",
+                              locale === "de" ? "break-words" : null,
+                            ]}
+                          >
                             {item.name}
                           </p>
                           <p class="mt-1 text-sm/6">{item.description}</p>

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -7,6 +7,7 @@ import { readFileSync } from "node:fs";
 
 import { de } from "../src/i18n/de.ts";
 import { en } from "../src/i18n/en.ts";
+import { androidDistributionContent } from "../src/lib/android-distribution.ts";
 
 test("global layout accounts for mobile safe-area insets", () => {
   const css = readFileSync(
@@ -210,5 +211,38 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   assert.match(
     component,
     /<dd\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b[^"]*"[^>]*>\s*\{\s*item\.value\s*\}\s*<\/dd>/
+  );
+});
+
+test("long German roadmap and Android labels wrap without changing English typography", () => {
+  const roadmap = readFileSync(
+    new URL("../src/components/Roadmap.astro", import.meta.url),
+    "utf8"
+  );
+  const androidDistribution = readFileSync(
+    new URL(
+      "../src/components/AndroidDistributionSurface.astro",
+      import.meta.url
+    ),
+    "utf8"
+  );
+
+  assert.ok(
+    de.roadmap.later.items.some(
+      (item) => item.name === "Dienstanweisungskonfigurator"
+    )
+  );
+  assert.ok(
+    androidDistributionContent.de.downloadOptions.some(
+      (option) => option.name === "Direktdownload"
+    )
+  );
+  assert.match(
+    roadmap,
+    /<p\s+class:list=\{\[\s*"font-semibold text-gray-900 dark:text-white",\s*locale === "de" \? "break-words" : null,\s*\]\}/
+  );
+  assert.match(
+    androidDistribution,
+    /<h3\s+class:list=\{\[\s*"mt-2\.5 text-2xl font-semibold text-gray-900 dark:text-white",\s*locale === "de" \? "break-words" : null,\s*\]\}/
   );
 });


### PR DESCRIPTION
# Description

Long German labels caused horizontal page overflow when the browser base font
size was increased to 125 percent. The unbroken
`Dienstanweisungskonfigurator` roadmap label expanded the document to 377 px
at 320 and 360 px viewports, while `Direktdownload` expanded the Android page
to 329 px at a 320 px viewport. The roadmap also overflowed at the reported
1024 px desktop width.

This change applies safe word wrapping to German roadmap item names and Android
download option headings. The wrapping class is locale-scoped, so the English
render path and existing typography remain unchanged. Regression coverage
names both overflowing labels and verifies that their rendering elements keep
the German-only wrapping safeguard. The changelog records the fix.

Fixes #235

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

- [x] `npm run format:check`
- [x] `npm test` (43 tests)
- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run build`
- [x] `reuse lint`
- [x] `./scripts/preflight.sh` through the pre-push hook
- [x] Browser validation for `/de/roadmap/` at 320, 360, and 1024 px and
      `/de/android/` at 320 px, in light and dark mode at normal and 125 percent
      base font size
- [x] Causal browser check reproducing the reported overflow when the wrapping
      class is removed at runtime
- [x] Signed commit verification

## Checklist

- [x] The change follows the repository conventions and domain policy.
- [x] The branch and pull request contain one topic.
- [x] A four-pass self-review covered correctness, accessibility, static output,
      DRY, KISS, YAGNI, SOLID, quality, and issue management.
- [x] `CHANGELOG.md` is updated.
- [x] No out-of-scope finding or untracked follow-up was identified.
- [x] The validations above introduce no warnings.

## Draft readiness

No local dependency or unresolved implementation check blocks this change.
The pull request remains draft pending GitHub CI completion and the required
final self-review in the pull request view.
