### PR TITLE
Align public Android distribution model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- made direct SecPal downloads the primary public Android distribution path,
+  positioned the public Google Play release as a later step, removed visible
+  beta distribution while retaining the internal track infrastructure, and
+  limited public technical endpoints to available direct downloads
 - reduced the localized main navigation to Workflow, Roadmap, and Android;
   kept contact solely as the primary header action and GitHub as a secondary
   technical path in the closing CTA and footer; added active states for

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -3,7 +3,10 @@
 // SPDX-FileCopyrightText: Tailwind Labs Inc.
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 import type { Locale } from "../i18n/index.ts";
-import { getAndroidDistributionContent } from "../lib/android-distribution.ts";
+import {
+  androidDirectDownloadAvailable,
+  getAndroidDistributionContent,
+} from "../lib/android-distribution.ts";
 
 interface Props {
   locale: Locale;
@@ -65,17 +68,28 @@ const content = getAndroidDistributionContent(locale);
           {content.subline}
         </p>
         <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
-          <a
-            href={content.heroPrimary.href}
-            class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-          >
-            {content.heroPrimary.label}
-          </a>
+          {
+            content.heroPrimary.href ? (
+              <a
+                href={content.heroPrimary.href}
+                class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              >
+                {content.heroPrimary.label}
+              </a>
+            ) : (
+              <span
+                aria-disabled="true"
+                class="rounded-md bg-indigo-200 px-4 py-2.5 text-sm font-semibold text-indigo-400 shadow-xs dark:bg-indigo-500/10 dark:text-indigo-300/40"
+              >
+                {content.heroPrimary.label}
+              </span>
+            )
+          }
           {
             content.heroSecondary.href ? (
               <a
                 href={content.heroSecondary.href}
-                class="rounded-md bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-white/5 dark:text-white dark:ring-white/15 dark:hover:bg-white/10"
+                class="rounded-md bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-white/5 dark:text-white dark:ring-white/15 dark:hover:bg-white/10"
               >
                 {content.heroSecondary.label}
               </a>
@@ -130,7 +144,7 @@ const content = getAndroidDistributionContent(locale);
           {content.downloadIntro}
         </p>
       </div>
-      <div class="mt-10 grid gap-6 lg:grid-cols-3">
+      <div class="mt-10 grid gap-6 lg:grid-cols-2">
         {
           content.downloadOptions.map((option) => (
             <article class="flex h-full min-w-0 flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-xs dark:border-white/10 dark:bg-white/5">
@@ -153,7 +167,7 @@ const content = getAndroidDistributionContent(locale);
                   <a
                     href={option.href}
                     class:list={[
-                      "inline-flex rounded-full px-4 py-2 text-sm font-semibold",
+                      "inline-flex rounded-full px-4 py-2 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
                       option.kind === "primary"
                         ? "bg-indigo-600 text-white hover:bg-indigo-500"
                         : "bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
@@ -170,14 +184,11 @@ const content = getAndroidDistributionContent(locale);
                   </span>
                 )}
                 <div class="mt-3 min-h-[1.5rem]">
-                  {"secondaryLink" in option ? (
+                  {option.secondaryLink ? (
                     <p class="text-sm/6 text-gray-500 dark:text-gray-400">
-                      <span class="font-medium">
-                        {option.secondaryLink.eyebrow}:{" "}
-                      </span>
                       <a
                         href={option.secondaryLink.href}
-                        class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+                        class="font-semibold text-indigo-600 hover:text-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300"
                       >
                         {option.secondaryLink.label}
                       </a>
@@ -192,8 +203,8 @@ const content = getAndroidDistributionContent(locale);
       <div
         class="mt-8 rounded-3xl border border-amber-200 bg-amber-50 px-6 py-5 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100"
       >
-        <p class="text-sm font-semibold">{content.betaNoticeTitle}</p>
-        <p class="mt-2 text-sm/7">{content.betaNoticeBody}</p>
+        <p class="text-sm font-semibold">{content.releaseNoticeTitle}</p>
+        <p class="mt-2 text-sm/7">{content.releaseNoticeBody}</p>
       </div>
     </div>
   </section>
@@ -224,45 +235,45 @@ const content = getAndroidDistributionContent(locale);
         </dl>
       </div>
 
-      <section
-        class="mt-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10"
-      >
-        <div class="border-b border-white/10 px-6 py-4">
-          <h3 class="text-base font-semibold text-white">
-            {content.technicalDetailsTitle}
-          </h3>
-        </div>
-        <div class="px-6 py-5">
-          <p class="mb-5 text-sm/7 text-cyan-100/85">
-            {content.technicalDetailsIntro}
-          </p>
-          <div class="grid gap-6 xl:grid-cols-2">
-            {
-              content.endpointGroups.map((group) => (
-                <section class="min-w-0 overflow-hidden rounded-3xl border border-white/10 bg-black/20">
-                  <div class="border-b border-white/10 px-6 py-4">
-                    <h3 class="text-base font-semibold text-white">
-                      {group.title}
-                    </h3>
-                  </div>
-                  <div class="space-y-3 px-6 py-5 text-sm">
-                    {group.entries.map((entry) => (
-                      <div class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
-                        <p class="text-xs font-semibold tracking-[0.18em] text-cyan-100/70 uppercase">
-                          {entry.label}
-                        </p>
-                        <p class="mt-2 break-all font-mono text-cyan-200">
-                          {entry.href}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              ))
-            }
-          </div>
-        </div>
-      </section>
+      {
+        androidDirectDownloadAvailable ? (
+          <section class="mt-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10">
+            <div class="border-b border-white/10 px-6 py-4">
+              <h3 class="text-base font-semibold text-white">
+                {content.technicalDetailsTitle}
+              </h3>
+            </div>
+            <div class="px-6 py-5">
+              <p class="mb-5 text-sm/7 text-cyan-100/85">
+                {content.technicalDetailsIntro}
+              </p>
+              <div class="grid gap-6 xl:grid-cols-2">
+                {content.endpointGroups.map((group) => (
+                  <section class="min-w-0 overflow-hidden rounded-3xl border border-white/10 bg-black/20">
+                    <div class="border-b border-white/10 px-6 py-4">
+                      <h3 class="text-base font-semibold text-white">
+                        {group.title}
+                      </h3>
+                    </div>
+                    <div class="space-y-3 px-6 py-5 text-sm">
+                      {group.entries.map((entry) => (
+                        <div class="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                          <p class="text-xs font-semibold tracking-[0.18em] text-cyan-100/70 uppercase">
+                            {entry.label}
+                          </p>
+                          <p class="mt-2 break-all font-mono text-cyan-200">
+                            {entry.href}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </div>
+          </section>
+        ) : null
+      }
     </div>
   </section>
 </div>

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -3,10 +3,7 @@
 // SPDX-FileCopyrightText: Tailwind Labs Inc.
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-TailwindPlus
 import type { Locale } from "../i18n/index.ts";
-import {
-  androidDirectDownloadAvailable,
-  getAndroidDistributionContent,
-} from "../lib/android-distribution.ts";
+import { getAndroidDistributionContent } from "../lib/android-distribution.ts";
 
 interface Props {
   locale: Locale;
@@ -215,7 +212,7 @@ const content = getAndroidDistributionContent(locale);
       </div>
 
       {
-        androidDirectDownloadAvailable ? (
+        content.endpointGroups.length > 0 ? (
           <section class="mt-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-950 shadow-xl ring-1 ring-gray-900/10 dark:border-white/10 dark:ring-white/10">
             <div class="border-b border-white/10 px-6 py-4">
               <h3 class="text-base font-semibold text-white">

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -67,42 +67,28 @@ const content = getAndroidDistributionContent(locale);
         <p class="mt-6 max-w-2xl text-lg/8 text-gray-600 dark:text-gray-300">
           {content.subline}
         </p>
-        <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
-          {
-            content.heroPrimary.href ? (
-              <a
-                href={content.heroPrimary.href}
-                class="rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-              >
-                {content.heroPrimary.label}
-              </a>
-            ) : (
-              <span
-                aria-disabled="true"
-                class="rounded-md bg-indigo-200 px-4 py-2.5 text-sm font-semibold text-indigo-400 shadow-xs dark:bg-indigo-500/10 dark:text-indigo-300/40"
-              >
-                {content.heroPrimary.label}
-              </span>
-            )
-          }
-          {
-            content.heroSecondary.href ? (
-              <a
-                href={content.heroSecondary.href}
-                class="rounded-md bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-white/5 dark:text-white dark:ring-white/15 dark:hover:bg-white/10"
-              >
-                {content.heroSecondary.label}
-              </a>
-            ) : (
-              <span
-                aria-disabled="true"
-                class="rounded-md bg-white px-4 py-2.5 text-sm font-semibold text-gray-400 ring-1 ring-gray-200 ring-inset dark:bg-white/5 dark:text-gray-500 dark:ring-white/10"
-              >
-                {content.heroSecondary.label}
-              </span>
-            )
-          }
-        </div>
+        {
+          content.heroPrimary || content.heroSecondary ? (
+            <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
+              {content.heroPrimary ? (
+                <a
+                  href={content.heroPrimary.href}
+                  class="inline-flex min-h-[44px] items-center justify-center rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                >
+                  {content.heroPrimary.label}
+                </a>
+              ) : null}
+              {content.heroSecondary ? (
+                <a
+                  href={content.heroSecondary.href}
+                  class="inline-flex min-h-[44px] items-center justify-center rounded-md bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-white/5 dark:text-white dark:ring-white/15 dark:hover:bg-white/10"
+                >
+                  {content.heroSecondary.label}
+                </a>
+              ) : null}
+            </div>
+          ) : null
+        }
       </div>
 
       <aside
@@ -162,40 +148,33 @@ const content = getAndroidDistributionContent(locale);
               <p class="mt-2.5 text-base/7 text-gray-600 dark:text-gray-300">
                 {option.description}
               </p>
-              <div class="mt-auto pt-5">
-                {option.href ? (
-                  <a
-                    href={option.href}
-                    class:list={[
-                      "inline-flex rounded-full px-4 py-2 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
-                      option.kind === "primary"
-                        ? "bg-indigo-600 text-white hover:bg-indigo-500"
-                        : "bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
-                    ]}
-                  >
-                    {option.cta}
-                  </a>
-                ) : (
-                  <span
-                    aria-disabled="true"
-                    class="inline-flex rounded-full bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-400 dark:bg-white/5 dark:text-gray-500"
-                  >
-                    {option.cta}
-                  </span>
-                )}
-                <div class="mt-3 min-h-[1.5rem]">
+              {option.action || option.secondaryLink ? (
+                <div class="mt-auto pt-5">
+                  {option.action ? (
+                    <a
+                      href={option.action.href}
+                      class:list={[
+                        "inline-flex min-h-[44px] items-center rounded-full px-4 py-2 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
+                        option.kind === "primary"
+                          ? "bg-indigo-600 text-white hover:bg-indigo-500"
+                          : "bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
+                      ]}
+                    >
+                      {option.action.label}
+                    </a>
+                  ) : null}
                   {option.secondaryLink ? (
-                    <p class="text-sm/6 text-gray-500 dark:text-gray-400">
+                    <p class="mt-3 text-sm/6 text-gray-500 dark:text-gray-400">
                       <a
                         href={option.secondaryLink.href}
-                        class="font-semibold text-indigo-600 hover:text-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300"
+                        class="inline-flex min-h-[44px] items-center font-semibold text-indigo-600 hover:text-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300"
                       >
                         {option.secondaryLink.label}
                       </a>
                     </p>
                   ) : null}
                 </div>
-              </div>
+              ) : null}
             </article>
           ))
         }

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -147,14 +147,50 @@ interface AndroidDistributionOption {
   cta: string;
   kind: "primary" | "secondary";
   secondaryLink?: {
-    eyebrow: string;
     label: string;
     href: string;
   };
 }
 
-const androidStableDownloadAvailable = false;
-const androidBetaDownloadAvailable = false;
+interface AndroidDistributionEndpointGroup {
+  title: string;
+  entries: {
+    label: string;
+    href: string;
+  }[];
+}
+
+interface AndroidDistributionContent {
+  title: string;
+  description: string;
+  eyebrow: string;
+  headline: string;
+  subline: string;
+  badge: string;
+  heroPrimary: AndroidDistributionCallToAction;
+  heroSecondary: AndroidDistributionCallToAction;
+  summaryTitle: string;
+  summaryItems: {
+    label: string;
+    value: string;
+  }[];
+  downloadTitle: string;
+  downloadIntro: string;
+  downloadOptions: AndroidDistributionOption[];
+  releaseNoticeTitle: string;
+  releaseNoticeBody: string;
+  technicalDetailsTitle: string;
+  technicalDetailsIntro: string;
+  endpointGroups: AndroidDistributionEndpointGroup[];
+  verificationTitle: string;
+  verificationItems: {
+    label: string;
+    value: string;
+  }[];
+}
+
+export const androidDirectDownloadAvailable = false;
+export const androidPublicPlayStoreAvailable = false;
 
 export function buildTrackLatestMetadataDocument(
   track: AndroidReleaseTrack,
@@ -219,28 +255,190 @@ export function buildVersionedMetadataDocument(
   };
 }
 
-export const androidDistributionContent = {
-  en: {
-    title: "SecPal Android distribution",
+export function buildAndroidDistributionContent(
+  locale: Locale,
+  directDownloadAvailable: boolean,
+  publicPlayStoreAvailable: boolean
+): AndroidDistributionContent {
+  const directDownloadUrl = directDownloadAvailable
+    ? buildArtifactUrl(buildLatestArtifactPath())
+    : null;
+  const publicPlayStoreUrl = publicPlayStoreAvailable
+    ? androidPlayStoreUrl
+    : null;
+  const endpointGroups: AndroidDistributionEndpointGroup[] =
+    directDownloadAvailable
+      ? [
+          {
+            title: locale === "de" ? "Aktuelle Version" : "Current release",
+            entries: [
+              {
+                label: "Manifest",
+                href: buildArtifactUrl(buildLatestMetadataPath()),
+              },
+              {
+                label: "APK",
+                href: buildArtifactUrl(buildLatestArtifactPath()),
+              },
+              {
+                label: locale === "de" ? "Checksummen" : "Checksums",
+                href: buildArtifactUrl(buildLatestChecksumPath()),
+              },
+            ],
+          },
+          {
+            title:
+              locale === "de" ? "Versionierte Releases" : "Versioned releases",
+            entries: [
+              {
+                label: locale === "de" ? "Metadaten" : "Metadata",
+                href: buildArtifactUrl(
+                  buildVersionedMetadataPath("{versionCode}")
+                ),
+              },
+              {
+                label: "APK",
+                href: buildArtifactUrl(
+                  buildVersionedArtifactPath("{versionCode}")
+                ),
+              },
+              {
+                label: locale === "de" ? "Checksummen" : "Checksums",
+                href: buildArtifactUrl(
+                  buildVersionedChecksumPath("{versionCode}")
+                ),
+              },
+            ],
+          },
+        ]
+      : [];
+
+  if (locale === "de") {
+    return {
+      title: "SecPal für Android",
+      description:
+        "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur späteren öffentlichen Veröffentlichung im Play Store.",
+      eyebrow: "SecPal für Android",
+      headline: "SecPal. Immer dabei.",
+      subline: directDownloadAvailable
+        ? "Die aktuelle Android-Version von SecPal kann direkt über secpal.app heruntergeladen werden. SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase. Eine öffentliche Veröffentlichung im Play Store folgt später."
+        : "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet. SecPal befindet sich in einer frühen 0.x-Entwicklungsphase. Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
+      badge: directDownloadAvailable
+        ? "Direkter Download verfügbar"
+        : "Direkter Download in Vorbereitung",
+      heroPrimary: {
+        label: directDownloadAvailable
+          ? "Android-Version herunterladen"
+          : "Android-Version in Vorbereitung",
+        href: directDownloadUrl,
+      },
+      heroSecondary: {
+        label: publicPlayStoreAvailable
+          ? "Im Play Store öffnen"
+          : "Play Store folgt später",
+        href: publicPlayStoreUrl,
+      },
+      summaryTitle: "Kurzüberblick",
+      summaryItems: [
+        {
+          label: "App",
+          value: "SecPal für Android",
+        },
+        {
+          label: "Öffentlicher Bezugsweg",
+          value: "Direkter Download über SecPal",
+        },
+        {
+          label: "Entwicklungsphase",
+          value: "Frühe 0.x-Versionen",
+        },
+        {
+          label: "Play Store",
+          value: "Öffentliche Veröffentlichung später",
+        },
+      ],
+      downloadTitle: "Download-Möglichkeiten",
+      downloadIntro:
+        "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der späteren öffentlichen Veröffentlichung im Play Store.",
+      downloadOptions: [
+        {
+          badge: directDownloadAvailable ? "Verfügbar" : "In Vorbereitung",
+          name: "Direkter Download",
+          description: directDownloadAvailable
+            ? "Die aktuelle Android-Version wird direkt über secpal.app bereitgestellt und kann anhand von Signatur und Prüfsumme überprüft werden."
+            : "Die erste öffentlich angebotene Android-Version wird über secpal.app bereitgestellt.",
+          href: directDownloadUrl,
+          cta: directDownloadAvailable
+            ? "APK herunterladen"
+            : "Download in Vorbereitung",
+          kind: "primary",
+          ...(directDownloadAvailable
+            ? {
+                secondaryLink: {
+                  label: "Manifest öffnen",
+                  href: buildArtifactUrl(buildLatestMetadataPath()),
+                },
+              }
+            : {}),
+        },
+        {
+          badge: publicPlayStoreAvailable ? "Öffentlich verfügbar" : "Später",
+          name: "Play Store",
+          description: publicPlayStoreAvailable
+            ? "SecPal ist zusätzlich öffentlich im Play Store verfügbar."
+            : "Eine öffentliche Veröffentlichung im Play Store ist für einen späteren Schritt vorgesehen.",
+          href: publicPlayStoreUrl,
+          cta: publicPlayStoreAvailable
+            ? "Im Play Store öffnen"
+            : "Noch nicht öffentlich verfügbar",
+          kind: "secondary",
+        },
+      ],
+      releaseNoticeTitle: "Hinweis zu frühen 0.x-Versionen",
+      releaseNoticeBody:
+        "Frühe 0.x-Versionen befinden sich in aktiver Entwicklung. Funktionen und Abläufe können sich mit weiteren Versionen verändern.",
+      technicalDetailsTitle: "Technische Links",
+      technicalDetailsIntro:
+        "Für Direktdownloads, Verifikation und automatische Updates.",
+      endpointGroups,
+      verificationTitle: "Technische Eckdaten",
+      verificationItems: [
+        {
+          label: "Android-Paketname",
+          value: "app.secpal",
+        },
+        {
+          label: "Signing SHA-256",
+          value: androidAppSigningCertificateSha256,
+        },
+      ],
+    };
+  }
+
+  return {
+    title: "SecPal for Android",
     description:
-      "SecPal is also available as an Android app, with Play Store and direct download options on secpal.app.",
+      "Information about the SecPal Android release, direct downloads from secpal.app, and the later public release on Google Play.",
     eyebrow: "SecPal for Android",
     headline: "SecPal in your pocket.",
-    subline:
-      "Get SecPal from the Play Store. Direct download will also be available on secpal.app.",
-    badge: "Play Store or direct download",
+    subline: directDownloadAvailable
+      ? "The current SecPal Android release can be downloaded directly from secpal.app. SecPal remains in an early 0.x development phase. A public release on Google Play will follow later."
+      : "The first SecPal Android release is being prepared for direct download from secpal.app. SecPal remains in an early 0.x development phase. A public release on Google Play is planned for later.",
+    badge: directDownloadAvailable
+      ? "Direct download available"
+      : "Direct download in preparation",
     heroPrimary: {
-      label: "Open Play Store",
-      href: androidPlayStoreUrl,
-    } satisfies AndroidDistributionCallToAction,
+      label: directDownloadAvailable
+        ? "Download Android release"
+        : "Android release in preparation",
+      href: directDownloadUrl,
+    },
     heroSecondary: {
-      label: androidStableDownloadAvailable
-        ? "Download APK"
-        : "Direct download soon",
-      href: androidStableDownloadAvailable
-        ? "https://apk.secpal.app/android/app.secpal-latest.apk"
-        : null,
-    } satisfies AndroidDistributionCallToAction,
+      label: publicPlayStoreAvailable
+        ? "Open Google Play"
+        : "Google Play release later",
+      href: publicPlayStoreUrl,
+    },
     summaryTitle: "At a glance",
     summaryItems: [
       {
@@ -248,130 +446,62 @@ export const androidDistributionContent = {
         value: "SecPal for Android",
       },
       {
-        label: "Recommended",
-        value: "Play Store",
-      },
-      {
-        label: "Alternative",
+        label: "Public distribution",
         value: "Direct download from SecPal",
       },
       {
-        label: "Also available",
-        value: "Beta version",
+        label: "Development phase",
+        value: "Early 0.x releases",
+      },
+      {
+        label: "Google Play",
+        value: "Public release later",
       },
     ],
     downloadTitle: "Download options",
     downloadIntro:
-      "SecPal is available in the Play Store. Direct download and beta will also be published on secpal.app.",
+      "Public Android distribution distinguishes between direct download from SecPal and the later public release on Google Play.",
     downloadOptions: [
       {
-        badge: "Recommended",
-        name: "Play Store",
-        description:
-          "The simplest way to install SecPal and receive updates through the Play Store.",
-        href: androidPlayStoreUrl,
-        cta: "Open Play Store",
-        kind: "primary",
-      } satisfies AndroidDistributionOption,
-      {
-        badge: "Direct",
-        name: "Direct Download",
-        description: "The direct APK download on secpal.app will follow.",
-        href: androidStableDownloadAvailable
-          ? "https://apk.secpal.app/android/app.secpal-latest.apk"
-          : null,
-        cta: androidStableDownloadAvailable
+        badge: directDownloadAvailable ? "Available" : "In preparation",
+        name: "Direct download",
+        description: directDownloadAvailable
+          ? "The current Android release is provided directly through secpal.app and can be verified using its signature and checksum."
+          : "The first publicly offered Android release will be provided through secpal.app.",
+        href: directDownloadUrl,
+        cta: directDownloadAvailable
           ? "Download APK"
-          : "Direct download soon",
-        secondaryLink: {
-          eyebrow: "Update manifest",
-          label: "Open Stable Manifest",
-          href: "https://apk.secpal.app/android/latest.json",
-        },
-        kind: "secondary",
-      } satisfies AndroidDistributionOption,
+          : "Download in preparation",
+        kind: "primary",
+        ...(directDownloadAvailable
+          ? {
+              secondaryLink: {
+                label: "Open manifest",
+                href: buildArtifactUrl(buildLatestMetadataPath()),
+              },
+            }
+          : {}),
+      },
       {
-        badge: "Optional",
-        name: "Beta version",
-        description:
-          "The beta track will be published separately on secpal.app.",
-        href: androidBetaDownloadAvailable
-          ? "https://apk.secpal.app/android/beta/app.secpal-latest.apk"
-          : null,
-        cta: androidBetaDownloadAvailable
-          ? "Download Beta APK"
-          : "Beta coming soon",
-        secondaryLink: {
-          eyebrow: "Update manifest",
-          label: "Open Beta Manifest",
-          href: "https://apk.secpal.app/android/beta/latest.json",
-        },
+        badge: publicPlayStoreAvailable ? "Publicly available" : "Later",
+        name: "Google Play",
+        description: publicPlayStoreAvailable
+          ? "SecPal is also publicly available on Google Play."
+          : "A public release on Google Play is planned for a later step.",
+        href: publicPlayStoreUrl,
+        cta: publicPlayStoreAvailable
+          ? "Open Google Play"
+          : "Not publicly available yet",
         kind: "secondary",
-      } satisfies AndroidDistributionOption,
+      },
     ],
-    betaNoticeTitle: "About the beta version",
-    betaNoticeBody:
-      "The beta version includes new features earlier, but it may still contain issues and can change before the regular release.",
+    releaseNoticeTitle: "About early 0.x releases",
+    releaseNoticeBody:
+      "Early 0.x releases are under active development. Features and workflows may change in later releases.",
     technicalDetailsTitle: "Technical links",
     technicalDetailsIntro:
       "For direct downloads, verification, and automated updates.",
-    endpointGroups: [
-      {
-        title: "Stable",
-        entries: [
-          {
-            label: "Manifest",
-            href: "https://apk.secpal.app/android/stable/latest.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/stable/app.secpal-latest.apk",
-          },
-          {
-            label: "Checksums",
-            href: "https://apk.secpal.app/android/stable/SHA256SUMS.txt",
-          },
-          {
-            label: "Stable alias",
-            href: "https://apk.secpal.app/android/latest.json",
-          },
-        ],
-      },
-      {
-        title: "Beta",
-        entries: [
-          {
-            label: "Manifest",
-            href: "https://apk.secpal.app/android/beta/latest.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/beta/app.secpal-latest.apk",
-          },
-          {
-            label: "Checksums",
-            href: "https://apk.secpal.app/android/beta/SHA256SUMS.txt",
-          },
-        ],
-      },
-      {
-        title: "Versioned releases",
-        entries: [
-          {
-            label: "Metadata",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/metadata.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/app.secpal-{versionCode}.apk",
-          },
-          {
-            label: "Checksums",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/SHA256SUMS.txt",
-          },
-        ],
-      },
-    ],
+    endpointGroups,
     verificationTitle: "Technical summary",
     verificationItems: [
       {
@@ -383,171 +513,21 @@ export const androidDistributionContent = {
         value: androidAppSigningCertificateSha256,
       },
     ],
-  },
-  de: {
-    title: "SecPal Android-Verteilung",
-    description:
-      "SecPal gibt es auch als Android-App, mit Play Store und Direktdownload auf secpal.app.",
-    eyebrow: "SecPal für Android",
-    headline: "SecPal. Immer dabei.",
-    subline:
-      "Laden Sie SecPal aus dem Play Store. Der Direktdownload wird zusätzlich auf secpal.app bereitgestellt.",
-    badge: "Play Store oder Direktdownload",
-    heroPrimary: {
-      label: "Play Store öffnen",
-      href: androidPlayStoreUrl,
-    } satisfies AndroidDistributionCallToAction,
-    heroSecondary: {
-      label: androidStableDownloadAvailable
-        ? "APK herunterladen"
-        : "Direktdownload folgt",
-      href: androidStableDownloadAvailable
-        ? "https://apk.secpal.app/android/app.secpal-latest.apk"
-        : null,
-    } satisfies AndroidDistributionCallToAction,
-    summaryTitle: "Kurzüberblick",
-    summaryItems: [
-      {
-        label: "App",
-        value: "SecPal für Android",
-      },
-      {
-        label: "Empfohlen",
-        value: "Play Store",
-      },
-      {
-        label: "Alternative",
-        value: "Direktdownload von SecPal",
-      },
-      {
-        label: "Außerdem verfügbar",
-        value: "Beta-Version",
-      },
-    ],
-    downloadTitle: "Download-Möglichkeiten",
-    downloadIntro:
-      "SecPal ist im Play Store verfügbar. Direktdownload und Beta werden zusätzlich auf secpal.app bereitgestellt.",
-    downloadOptions: [
-      {
-        badge: "Empfohlen",
-        name: "Play Store",
-        description:
-          "Der einfachste Weg, SecPal zu installieren und Updates über den Play Store zu erhalten.",
-        href: androidPlayStoreUrl,
-        cta: "Play Store öffnen",
-        kind: "primary",
-      } satisfies AndroidDistributionOption,
-      {
-        badge: "Direkt",
-        name: "Direktdownload",
-        description: "Der direkte APK-Download auf secpal.app folgt.",
-        href: androidStableDownloadAvailable
-          ? "https://apk.secpal.app/android/app.secpal-latest.apk"
-          : null,
-        cta: androidStableDownloadAvailable
-          ? "APK herunterladen"
-          : "Direktdownload folgt",
-        secondaryLink: {
-          eyebrow: "Update-Manifest",
-          label: "Stable-Manifest öffnen",
-          href: "https://apk.secpal.app/android/latest.json",
-        },
-        kind: "secondary",
-      } satisfies AndroidDistributionOption,
-      {
-        badge: "Optional",
-        name: "Beta-Version",
-        description: "Die Beta wird separat auf secpal.app bereitgestellt.",
-        href: androidBetaDownloadAvailable
-          ? "https://apk.secpal.app/android/beta/app.secpal-latest.apk"
-          : null,
-        cta: androidBetaDownloadAvailable
-          ? "Beta-APK herunterladen"
-          : "Beta folgt",
-        secondaryLink: {
-          eyebrow: "Update-Manifest",
-          label: "Beta-Manifest öffnen",
-          href: "https://apk.secpal.app/android/beta/latest.json",
-        },
-        kind: "secondary",
-      } satisfies AndroidDistributionOption,
-    ],
-    betaNoticeTitle: "Hinweis zur Beta-Version",
-    betaNoticeBody:
-      "Die Beta-Version enthält neue Funktionen früher, kann aber noch Fehler enthalten und sich bis zur regulären Veröffentlichung noch ändern.",
-    technicalDetailsTitle: "Technische Links",
-    technicalDetailsIntro:
-      "Für Direktdownloads, Verifikation und automatische Updates.",
-    endpointGroups: [
-      {
-        title: "Stable",
-        entries: [
-          {
-            label: "Manifest",
-            href: "https://apk.secpal.app/android/stable/latest.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/stable/app.secpal-latest.apk",
-          },
-          {
-            label: "Checksummen",
-            href: "https://apk.secpal.app/android/stable/SHA256SUMS.txt",
-          },
-          {
-            label: "Stable-Alias",
-            href: "https://apk.secpal.app/android/latest.json",
-          },
-        ],
-      },
-      {
-        title: "Beta",
-        entries: [
-          {
-            label: "Manifest",
-            href: "https://apk.secpal.app/android/beta/latest.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/beta/app.secpal-latest.apk",
-          },
-          {
-            label: "Checksummen",
-            href: "https://apk.secpal.app/android/beta/SHA256SUMS.txt",
-          },
-        ],
-      },
-      {
-        title: "Versionierte Releases",
-        entries: [
-          {
-            label: "Metadata",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/metadata.json",
-          },
-          {
-            label: "APK",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/app.secpal-{versionCode}.apk",
-          },
-          {
-            label: "Checksummen",
-            href: "https://apk.secpal.app/android/releases/{versionCode}/SHA256SUMS.txt",
-          },
-        ],
-      },
-    ],
-    verificationTitle: "Technische Eckdaten",
-    verificationItems: [
-      {
-        label: "Android-Paketname",
-        value: "app.secpal",
-      },
-      {
-        label: "Signing SHA-256",
-        value: androidAppSigningCertificateSha256,
-      },
-    ],
-  },
-} as const satisfies Record<Locale, unknown>;
+  };
+}
+
+export const androidDistributionContent = {
+  en: buildAndroidDistributionContent(
+    "en",
+    androidDirectDownloadAvailable,
+    androidPublicPlayStoreAvailable
+  ),
+  de: buildAndroidDistributionContent(
+    "de",
+    androidDirectDownloadAvailable,
+    androidPublicPlayStoreAvailable
+  ),
+} satisfies Record<Locale, AndroidDistributionContent>;
 
 export function getAndroidDistributionContent(locale: Locale) {
   return androidDistributionContent[locale];

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -316,13 +316,24 @@ export function buildAndroidDistributionContent(
   if (locale === "de") {
     return {
       title: "SecPal für Android",
-      description:
-        "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur späteren öffentlichen Veröffentlichung im Play Store.",
+      description: publicPlayStoreAvailable
+        ? "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur öffentlichen Verfügbarkeit im Play Store."
+        : "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur späteren öffentlichen Veröffentlichung im Play Store.",
       eyebrow: "SecPal für Android",
       headline: "SecPal. Immer dabei.",
-      subline: directDownloadAvailable
-        ? "Die aktuelle Android-Version von SecPal kann direkt über secpal.app heruntergeladen werden. SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase. Eine öffentliche Veröffentlichung im Play Store folgt später."
-        : "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet. SecPal befindet sich in einer frühen 0.x-Entwicklungsphase. Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
+      subline: [
+        directDownloadAvailable
+          ? "Die aktuelle Android-Version von SecPal kann direkt über secpal.app heruntergeladen werden."
+          : "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet.",
+        directDownloadAvailable
+          ? "SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase."
+          : "SecPal befindet sich in einer frühen 0.x-Entwicklungsphase.",
+        publicPlayStoreAvailable
+          ? "SecPal ist auch öffentlich im Play Store verfügbar."
+          : directDownloadAvailable
+            ? "Eine öffentliche Veröffentlichung im Play Store folgt später."
+            : "Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
+      ].join(" "),
       badge: directDownloadAvailable
         ? "Direkter Download verfügbar"
         : "Direkter Download in Vorbereitung",
@@ -354,12 +365,15 @@ export function buildAndroidDistributionContent(
         },
         {
           label: "Play Store",
-          value: "Öffentliche Veröffentlichung später",
+          value: publicPlayStoreAvailable
+            ? "Öffentlich verfügbar"
+            : "Öffentliche Veröffentlichung später",
         },
       ],
       downloadTitle: "Download-Möglichkeiten",
-      downloadIntro:
-        "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der späteren öffentlichen Veröffentlichung im Play Store.",
+      downloadIntro: publicPlayStoreAvailable
+        ? "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der öffentlichen Verfügbarkeit im Play Store."
+        : "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der späteren öffentlichen Veröffentlichung im Play Store.",
       downloadOptions: [
         {
           badge: directDownloadAvailable ? "Verfügbar" : "In Vorbereitung",
@@ -417,13 +431,22 @@ export function buildAndroidDistributionContent(
 
   return {
     title: "SecPal for Android",
-    description:
-      "Information about the SecPal Android release, direct downloads from secpal.app, and the later public release on Google Play.",
+    description: publicPlayStoreAvailable
+      ? "Information about the SecPal Android release, direct downloads from secpal.app, and public availability on Google Play."
+      : "Information about the SecPal Android release, direct downloads from secpal.app, and the later public release on Google Play.",
     eyebrow: "SecPal for Android",
     headline: "SecPal in your pocket.",
-    subline: directDownloadAvailable
-      ? "The current SecPal Android release can be downloaded directly from secpal.app. SecPal remains in an early 0.x development phase. A public release on Google Play will follow later."
-      : "The first SecPal Android release is being prepared for direct download from secpal.app. SecPal remains in an early 0.x development phase. A public release on Google Play is planned for later.",
+    subline: [
+      directDownloadAvailable
+        ? "The current SecPal Android release can be downloaded directly from secpal.app."
+        : "The first SecPal Android release is being prepared for direct download from secpal.app.",
+      "SecPal remains in an early 0.x development phase.",
+      publicPlayStoreAvailable
+        ? "SecPal is also publicly available on Google Play."
+        : directDownloadAvailable
+          ? "A public release on Google Play will follow later."
+          : "A public release on Google Play is planned for later.",
+    ].join(" "),
     badge: directDownloadAvailable
       ? "Direct download available"
       : "Direct download in preparation",
@@ -455,12 +478,15 @@ export function buildAndroidDistributionContent(
       },
       {
         label: "Google Play",
-        value: "Public release later",
+        value: publicPlayStoreAvailable
+          ? "Publicly available"
+          : "Public release later",
       },
     ],
     downloadTitle: "Download options",
-    downloadIntro:
-      "Public Android distribution distinguishes between direct download from SecPal and the later public release on Google Play.",
+    downloadIntro: publicPlayStoreAvailable
+      ? "Public Android distribution distinguishes between direct download from SecPal and public availability on Google Play."
+      : "Public Android distribution distinguishes between direct download from SecPal and the later public release on Google Play.",
     downloadOptions: [
       {
         badge: directDownloadAvailable ? "Available" : "In preparation",

--- a/src/lib/android-distribution.ts
+++ b/src/lib/android-distribution.ts
@@ -136,16 +136,15 @@ export interface AndroidVersionedReleaseMetadata {
 
 interface AndroidDistributionCallToAction {
   label: string;
-  href: string | null;
+  href: string;
 }
 
 interface AndroidDistributionOption {
   badge: string;
   name: string;
   description: string;
-  href: string | null;
-  cta: string;
   kind: "primary" | "secondary";
+  action?: AndroidDistributionCallToAction;
   secondaryLink?: {
     label: string;
     href: string;
@@ -167,8 +166,8 @@ interface AndroidDistributionContent {
   headline: string;
   subline: string;
   badge: string;
-  heroPrimary: AndroidDistributionCallToAction;
-  heroSecondary: AndroidDistributionCallToAction;
+  heroPrimary: AndroidDistributionCallToAction | null;
+  heroSecondary: AndroidDistributionCallToAction | null;
   summaryTitle: string;
   summaryItems: {
     label: string;
@@ -260,12 +259,6 @@ export function buildAndroidDistributionContent(
   directDownloadAvailable: boolean,
   publicPlayStoreAvailable: boolean
 ): AndroidDistributionContent {
-  const directDownloadUrl = directDownloadAvailable
-    ? buildArtifactUrl(buildLatestArtifactPath())
-    : null;
-  const publicPlayStoreUrl = publicPlayStoreAvailable
-    ? androidPlayStoreUrl
-    : null;
   const endpointGroups: AndroidDistributionEndpointGroup[] =
     directDownloadAvailable
       ? [
@@ -323,32 +316,27 @@ export function buildAndroidDistributionContent(
       headline: "SecPal. Immer dabei.",
       subline: [
         directDownloadAvailable
-          ? "Die aktuelle Android-Version von SecPal kann direkt über secpal.app heruntergeladen werden."
+          ? "Die aktuelle Android-Version von SecPal steht direkt über secpal.app zum Download bereit."
           : "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet.",
         directDownloadAvailable
           ? "SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase."
           : "SecPal befindet sich in einer frühen 0.x-Entwicklungsphase.",
-        publicPlayStoreAvailable
-          ? "SecPal ist auch öffentlich im Play Store verfügbar."
-          : directDownloadAvailable
-            ? "Eine öffentliche Veröffentlichung im Play Store folgt später."
-            : "Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
       ].join(" "),
       badge: directDownloadAvailable
         ? "Direkter Download verfügbar"
         : "Direkter Download in Vorbereitung",
-      heroPrimary: {
-        label: directDownloadAvailable
-          ? "Android-Version herunterladen"
-          : "Android-Version in Vorbereitung",
-        href: directDownloadUrl,
-      },
-      heroSecondary: {
-        label: publicPlayStoreAvailable
-          ? "Im Play Store öffnen"
-          : "Play Store folgt später",
-        href: publicPlayStoreUrl,
-      },
+      heroPrimary: directDownloadAvailable
+        ? {
+            label: "Android-Version herunterladen",
+            href: buildArtifactUrl(buildLatestArtifactPath()),
+          }
+        : null,
+      heroSecondary: publicPlayStoreAvailable
+        ? {
+            label: "Im Play Store öffnen",
+            href: androidPlayStoreUrl,
+          }
+        : null,
       summaryTitle: "Kurzüberblick",
       summaryItems: [
         {
@@ -356,8 +344,8 @@ export function buildAndroidDistributionContent(
           value: "SecPal für Android",
         },
         {
-          label: "Öffentlicher Bezugsweg",
-          value: "Direkter Download über SecPal",
+          label: "Bereitstellung",
+          value: "Direkt über secpal.app",
         },
         {
           label: "Entwicklungsphase",
@@ -365,29 +353,25 @@ export function buildAndroidDistributionContent(
         },
         {
           label: "Play Store",
-          value: publicPlayStoreAvailable
-            ? "Öffentlich verfügbar"
-            : "Öffentliche Veröffentlichung später",
+          value: publicPlayStoreAvailable ? "Verfügbar" : "Geplant",
         },
       ],
-      downloadTitle: "Download-Möglichkeiten",
-      downloadIntro: publicPlayStoreAvailable
-        ? "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der öffentlichen Verfügbarkeit im Play Store."
-        : "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der späteren öffentlichen Veröffentlichung im Play Store.",
+      downloadTitle: "Bezugswege",
+      downloadIntro: "Aktuelle und geplante Bezugswege für SecPal auf Android.",
       downloadOptions: [
         {
           badge: directDownloadAvailable ? "Verfügbar" : "In Vorbereitung",
           name: "Direkter Download",
           description: directDownloadAvailable
-            ? "Die aktuelle Android-Version wird direkt über secpal.app bereitgestellt und kann anhand von Signatur und Prüfsumme überprüft werden."
-            : "Die erste öffentlich angebotene Android-Version wird über secpal.app bereitgestellt.",
-          href: directDownloadUrl,
-          cta: directDownloadAvailable
-            ? "APK herunterladen"
-            : "Download in Vorbereitung",
+            ? "Die aktuelle Android-Version steht direkt über secpal.app bereit. Signatur und Prüfsumme ermöglichen die Überprüfung des Pakets."
+            : "Die erste öffentliche Android-Version wird über secpal.app bereitgestellt.",
           kind: "primary",
           ...(directDownloadAvailable
             ? {
+                action: {
+                  label: "APK herunterladen",
+                  href: buildArtifactUrl(buildLatestArtifactPath()),
+                },
                 secondaryLink: {
                   label: "Manifest öffnen",
                   href: buildArtifactUrl(buildLatestMetadataPath()),
@@ -396,16 +380,20 @@ export function buildAndroidDistributionContent(
             : {}),
         },
         {
-          badge: publicPlayStoreAvailable ? "Öffentlich verfügbar" : "Später",
+          badge: publicPlayStoreAvailable ? "Verfügbar" : "Geplant",
           name: "Play Store",
           description: publicPlayStoreAvailable
             ? "SecPal ist zusätzlich öffentlich im Play Store verfügbar."
-            : "Eine öffentliche Veröffentlichung im Play Store ist für einen späteren Schritt vorgesehen.",
-          href: publicPlayStoreUrl,
-          cta: publicPlayStoreAvailable
-            ? "Im Play Store öffnen"
-            : "Noch nicht öffentlich verfügbar",
+            : "Eine öffentliche Veröffentlichung im Play Store ist als zusätzlicher Bezugsweg vorgesehen.",
           kind: "secondary",
+          ...(publicPlayStoreAvailable
+            ? {
+                action: {
+                  label: "Im Play Store öffnen",
+                  href: androidPlayStoreUrl,
+                },
+              }
+            : {}),
         },
       ],
       releaseNoticeTitle: "Hinweis zu frühen 0.x-Versionen",
@@ -438,30 +426,25 @@ export function buildAndroidDistributionContent(
     headline: "SecPal in your pocket.",
     subline: [
       directDownloadAvailable
-        ? "The current SecPal Android release can be downloaded directly from secpal.app."
+        ? "The current SecPal Android release is available for direct download from secpal.app."
         : "The first SecPal Android release is being prepared for direct download from secpal.app.",
       "SecPal remains in an early 0.x development phase.",
-      publicPlayStoreAvailable
-        ? "SecPal is also publicly available on Google Play."
-        : directDownloadAvailable
-          ? "A public release on Google Play will follow later."
-          : "A public release on Google Play is planned for later.",
     ].join(" "),
     badge: directDownloadAvailable
       ? "Direct download available"
       : "Direct download in preparation",
-    heroPrimary: {
-      label: directDownloadAvailable
-        ? "Download Android release"
-        : "Android release in preparation",
-      href: directDownloadUrl,
-    },
-    heroSecondary: {
-      label: publicPlayStoreAvailable
-        ? "Open Google Play"
-        : "Google Play release later",
-      href: publicPlayStoreUrl,
-    },
+    heroPrimary: directDownloadAvailable
+      ? {
+          label: "Download Android release",
+          href: buildArtifactUrl(buildLatestArtifactPath()),
+        }
+      : null,
+    heroSecondary: publicPlayStoreAvailable
+      ? {
+          label: "Open Google Play",
+          href: androidPlayStoreUrl,
+        }
+      : null,
     summaryTitle: "At a glance",
     summaryItems: [
       {
@@ -469,8 +452,8 @@ export function buildAndroidDistributionContent(
         value: "SecPal for Android",
       },
       {
-        label: "Public distribution",
-        value: "Direct download from SecPal",
+        label: "Distribution",
+        value: "Direct from secpal.app",
       },
       {
         label: "Development phase",
@@ -478,29 +461,26 @@ export function buildAndroidDistributionContent(
       },
       {
         label: "Google Play",
-        value: publicPlayStoreAvailable
-          ? "Publicly available"
-          : "Public release later",
+        value: publicPlayStoreAvailable ? "Available" : "Planned",
       },
     ],
-    downloadTitle: "Download options",
-    downloadIntro: publicPlayStoreAvailable
-      ? "Public Android distribution distinguishes between direct download from SecPal and public availability on Google Play."
-      : "Public Android distribution distinguishes between direct download from SecPal and the later public release on Google Play.",
+    downloadTitle: "Distribution",
+    downloadIntro:
+      "Current and planned distribution paths for SecPal on Android.",
     downloadOptions: [
       {
         badge: directDownloadAvailable ? "Available" : "In preparation",
         name: "Direct download",
         description: directDownloadAvailable
-          ? "The current Android release is provided directly through secpal.app and can be verified using its signature and checksum."
-          : "The first publicly offered Android release will be provided through secpal.app.",
-        href: directDownloadUrl,
-        cta: directDownloadAvailable
-          ? "Download APK"
-          : "Download in preparation",
+          ? "The current Android release is available directly through secpal.app. Its signature and checksum can be used to verify the package."
+          : "The first public Android release will be provided through secpal.app.",
         kind: "primary",
         ...(directDownloadAvailable
           ? {
+              action: {
+                label: "Download APK",
+                href: buildArtifactUrl(buildLatestArtifactPath()),
+              },
               secondaryLink: {
                 label: "Open manifest",
                 href: buildArtifactUrl(buildLatestMetadataPath()),
@@ -509,16 +489,20 @@ export function buildAndroidDistributionContent(
           : {}),
       },
       {
-        badge: publicPlayStoreAvailable ? "Publicly available" : "Later",
+        badge: publicPlayStoreAvailable ? "Available" : "Planned",
         name: "Google Play",
         description: publicPlayStoreAvailable
           ? "SecPal is also publicly available on Google Play."
-          : "A public release on Google Play is planned for a later step.",
-        href: publicPlayStoreUrl,
-        cta: publicPlayStoreAvailable
-          ? "Open Google Play"
-          : "Not publicly available yet",
+          : "A public release on Google Play is planned as an additional distribution path.",
         kind: "secondary",
+        ...(publicPlayStoreAvailable
+          ? {
+              action: {
+                label: "Open Google Play",
+                href: androidPlayStoreUrl,
+              },
+            }
+          : {}),
       },
     ],
     releaseNoticeTitle: "About early 0.x releases",

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -230,10 +230,10 @@ test("public Android content exposes exactly direct download and public Google P
       content.downloadOptions[1]?.name,
       locale === "de" ? "Play Store" : "Google Play"
     );
-    assert.equal(content.heroPrimary.href, null);
-    assert.equal(content.heroSecondary.href, null);
-    assert.equal(content.downloadOptions[0]?.href, null);
-    assert.equal(content.downloadOptions[1]?.href, null);
+    assert.equal(content.heroPrimary, null);
+    assert.equal(content.heroSecondary, null);
+    assert.ok(!("action" in content.downloadOptions[0]));
+    assert.ok(!("action" in content.downloadOptions[1]));
     assert.ok(!("secondaryLink" in content.downloadOptions[0]));
   }
 });
@@ -251,11 +251,11 @@ test("available direct downloads reuse the canonical latest alias builders", () 
     const directDownload = content.downloadOptions[0];
 
     assert.equal(
-      content.heroPrimary.href,
+      content.heroPrimary?.href,
       buildArtifactUrl(buildLatestArtifactPath())
     );
     assert.equal(
-      directDownload.href,
+      directDownload.action?.href,
       buildArtifactUrl(buildLatestArtifactPath())
     );
     assert.equal(
@@ -270,7 +270,8 @@ test("available direct downloads reuse the canonical latest alias builders", () 
         buildArtifactUrl(buildLatestChecksumPath()),
       ]
     );
-    assert.equal(content.heroSecondary.href, null);
+    assert.equal(content.heroSecondary, null);
+    assert.ok(!("action" in content.downloadOptions[1]));
   }
 });
 
@@ -279,30 +280,32 @@ test("public Google Play links are emitted only for public availability", () => 
     const unavailable = buildAndroidDistributionContent(locale, false, false);
     const available = buildAndroidDistributionContent(locale, false, true);
 
-    assert.equal(unavailable.heroSecondary.href, null);
-    assert.equal(unavailable.downloadOptions[1]?.href, null);
-    assert.equal(available.heroSecondary.href, androidPlayStoreUrl);
-    assert.equal(available.downloadOptions[1]?.href, androidPlayStoreUrl);
+    assert.equal(unavailable.heroSecondary, null);
+    assert.ok(!("action" in unavailable.downloadOptions[1]));
+    assert.equal(available.heroSecondary?.href, androidPlayStoreUrl);
+    assert.equal(
+      available.downloadOptions[1]?.action?.href,
+      androidPlayStoreUrl
+    );
   }
 });
 
-test("public Google Play availability updates all surrounding release copy", () => {
+test("public Google Play availability changes only concise status and real actions", () => {
   const expectations = {
     en: {
       description:
         "Information about the SecPal Android release, direct downloads from secpal.app, and public availability on Google Play.",
-      playSentence: "SecPal is also publicly available on Google Play.",
-      summary: "Publicly available",
-      intro:
-        "Public Android distribution distinguishes between direct download from SecPal and public availability on Google Play.",
+      summary: "Available",
+      intro: "Current and planned distribution paths for SecPal on Android.",
+      cardDescription: "SecPal is also publicly available on Google Play.",
     },
     de: {
       description:
         "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur öffentlichen Verfügbarkeit im Play Store.",
-      playSentence: "SecPal ist auch öffentlich im Play Store verfügbar.",
-      summary: "Öffentlich verfügbar",
-      intro:
-        "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der öffentlichen Verfügbarkeit im Play Store.",
+      summary: "Verfügbar",
+      intro: "Aktuelle und geplante Bezugswege für SecPal auf Android.",
+      cardDescription:
+        "SecPal ist zusätzlich öffentlich im Play Store verfügbar.",
     },
   };
 
@@ -316,33 +319,107 @@ test("public Google Play availability updates all surrounding release copy", () 
       const expectation = expectations[locale];
 
       assert.equal(content.description, expectation.description);
-      assert.ok(content.subline.endsWith(expectation.playSentence));
+      assert.ok(!content.subline.includes("Play"));
       assert.equal(content.summaryItems[3]?.value, expectation.summary);
       assert.equal(content.downloadIntro, expectation.intro);
+      assert.equal(
+        content.downloadOptions[1]?.description,
+        expectation.cardDescription
+      );
     }
   }
 });
 
-test("pending Google Play copy preserves the direct-download rollout phase", () => {
+test("hero, summary, and distribution copy follow the concise public hierarchy", () => {
   const expectations = {
     en: {
-      preparing: "A public release on Google Play is planned for later.",
-      available: "A public release on Google Play will follow later.",
+      preparing:
+        "The first SecPal Android release is being prepared for direct download from secpal.app. SecPal remains in an early 0.x development phase.",
+      available:
+        "The current SecPal Android release is available for direct download from secpal.app. SecPal remains in an early 0.x development phase.",
+      distributionLabel: "Distribution",
+      distributionValue: "Direct from secpal.app",
+      playStatus: "Planned",
+      sectionTitle: "Distribution",
+      sectionIntro:
+        "Current and planned distribution paths for SecPal on Android.",
+      directPreparing:
+        "The first public Android release will be provided through secpal.app.",
+      directAvailable:
+        "The current Android release is available directly through secpal.app. Its signature and checksum can be used to verify the package.",
+      playPreparing:
+        "A public release on Google Play is planned as an additional distribution path.",
     },
     de: {
       preparing:
-        "Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
+        "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet. SecPal befindet sich in einer frühen 0.x-Entwicklungsphase.",
       available:
-        "Eine öffentliche Veröffentlichung im Play Store folgt später.",
+        "Die aktuelle Android-Version von SecPal steht direkt über secpal.app zum Download bereit. SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase.",
+      distributionLabel: "Bereitstellung",
+      distributionValue: "Direkt über secpal.app",
+      playStatus: "Geplant",
+      sectionTitle: "Bezugswege",
+      sectionIntro: "Aktuelle und geplante Bezugswege für SecPal auf Android.",
+      directPreparing:
+        "Die erste öffentliche Android-Version wird über secpal.app bereitgestellt.",
+      directAvailable:
+        "Die aktuelle Android-Version steht direkt über secpal.app bereit. Signatur und Prüfsumme ermöglichen die Überprüfung des Pakets.",
+      playPreparing:
+        "Eine öffentliche Veröffentlichung im Play Store ist als zusätzlicher Bezugsweg vorgesehen.",
     },
   };
 
   for (const locale of ["en", "de"]) {
     const preparing = buildAndroidDistributionContent(locale, false, false);
     const available = buildAndroidDistributionContent(locale, true, false);
+    const expectation = expectations[locale];
 
-    assert.ok(preparing.subline.endsWith(expectations[locale].preparing));
-    assert.ok(available.subline.endsWith(expectations[locale].available));
+    assert.equal(preparing.subline, expectation.preparing);
+    assert.equal(available.subline, expectation.available);
+    assert.equal(
+      preparing.summaryItems[1]?.label,
+      expectation.distributionLabel
+    );
+    assert.equal(
+      preparing.summaryItems[1]?.value,
+      expectation.distributionValue
+    );
+    assert.equal(preparing.summaryItems[3]?.value, expectation.playStatus);
+    assert.equal(preparing.downloadTitle, expectation.sectionTitle);
+    assert.equal(preparing.downloadIntro, expectation.sectionIntro);
+    assert.equal(
+      preparing.downloadOptions[0]?.description,
+      expectation.directPreparing
+    );
+    assert.equal(
+      available.downloadOptions[0]?.description,
+      expectation.directAvailable
+    );
+    assert.equal(
+      preparing.downloadOptions[1]?.description,
+      expectation.playPreparing
+    );
+  }
+});
+
+test("public actions exist only when their public targets are available", () => {
+  for (const locale of ["en", "de"]) {
+    const unavailable = buildAndroidDistributionContent(locale, false, false);
+    const directOnly = buildAndroidDistributionContent(locale, true, false);
+    const allPublic = buildAndroidDistributionContent(locale, true, true);
+
+    assert.equal(unavailable.heroPrimary, null);
+    assert.equal(unavailable.heroSecondary, null);
+    assert.ok(unavailable.downloadOptions.every((option) => !option.action));
+
+    assert.ok(directOnly.heroPrimary);
+    assert.equal(directOnly.heroSecondary, null);
+    assert.ok(directOnly.downloadOptions[0]?.action);
+    assert.ok(!directOnly.downloadOptions[1]?.action);
+
+    assert.ok(allPublic.heroPrimary);
+    assert.ok(allPublic.heroSecondary);
+    assert.ok(allPublic.downloadOptions.every((option) => option.action));
   }
 });
 
@@ -371,7 +448,33 @@ test("public Android content contains no beta or restricted-testing language", (
   }
 });
 
-test("Android distribution surface conditionally renders accessible public actions", () => {
+test("unavailable public action labels are absent from the content model", () => {
+  const source = readFileSync(
+    new URL("../src/lib/android-distribution.ts", import.meta.url),
+    "utf8"
+  );
+  const removedActionLabels = [
+    "Android-Version in Vorbereitung",
+    "Play Store folgt später",
+    "Android release in preparation",
+    "Google Play release later",
+    "Download in Vorbereitung",
+    "Noch nicht öffentlich verfügbar",
+    "Download in preparation",
+    "Not publicly available yet",
+    "Öffentliche Veröffentlichung später",
+    "Public release later",
+  ];
+
+  for (const label of removedActionLabels) {
+    assert.ok(
+      !source.includes(`"${label}"`),
+      `content model must not contain the action label ${label}`
+    );
+  }
+});
+
+test("Android distribution surface renders only real, accessible public actions", () => {
   const component = readFileSync(
     new URL(
       "../src/components/AndroidDistributionSurface.astro",
@@ -381,9 +484,16 @@ test("Android distribution surface conditionally renders accessible public actio
   );
 
   assert.match(component, /\blg:grid-cols-2\b/);
-  assert.match(component, /aria-disabled="true"/);
-  assert.match(component, /content\.heroPrimary\.href\s*\?/);
-  assert.match(component, /content\.heroSecondary\.href\s*\?/);
+  assert.match(
+    component,
+    /content\.heroPrimary\s*\|\|\s*content\.heroSecondary/
+  );
+  assert.match(component, /option\.action/);
+  assert.match(component, /min-h-\[44px\]/);
+  assert.doesNotMatch(component, /aria-disabled/);
+  assert.doesNotMatch(component, /option\.href/);
+  assert.doesNotMatch(component, /\bmin-h-\[1\.5rem\]\b/);
   assert.match(component, /androidDirectDownloadAvailable\s*\?/);
+  assert.match(component, /locale === "de" \? "break-words" : null/);
   assert.doesNotMatch(component, /content\.betaNotice/);
 });

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -286,6 +286,66 @@ test("public Google Play links are emitted only for public availability", () => 
   }
 });
 
+test("public Google Play availability updates all surrounding release copy", () => {
+  const expectations = {
+    en: {
+      description:
+        "Information about the SecPal Android release, direct downloads from secpal.app, and public availability on Google Play.",
+      playSentence: "SecPal is also publicly available on Google Play.",
+      summary: "Publicly available",
+      intro:
+        "Public Android distribution distinguishes between direct download from SecPal and public availability on Google Play.",
+    },
+    de: {
+      description:
+        "Informationen zur Android-Version von SecPal, zum direkten Download über secpal.app und zur öffentlichen Verfügbarkeit im Play Store.",
+      playSentence: "SecPal ist auch öffentlich im Play Store verfügbar.",
+      summary: "Öffentlich verfügbar",
+      intro:
+        "Die öffentliche Android-Verteilung unterscheidet zwischen dem direkten Download über SecPal und der öffentlichen Verfügbarkeit im Play Store.",
+    },
+  };
+
+  for (const locale of ["en", "de"]) {
+    for (const directDownloadAvailable of [false, true]) {
+      const content = buildAndroidDistributionContent(
+        locale,
+        directDownloadAvailable,
+        true
+      );
+      const expectation = expectations[locale];
+
+      assert.equal(content.description, expectation.description);
+      assert.ok(content.subline.endsWith(expectation.playSentence));
+      assert.equal(content.summaryItems[3]?.value, expectation.summary);
+      assert.equal(content.downloadIntro, expectation.intro);
+    }
+  }
+});
+
+test("pending Google Play copy preserves the direct-download rollout phase", () => {
+  const expectations = {
+    en: {
+      preparing: "A public release on Google Play is planned for later.",
+      available: "A public release on Google Play will follow later.",
+    },
+    de: {
+      preparing:
+        "Eine öffentliche Veröffentlichung im Play Store ist für später vorgesehen.",
+      available:
+        "Eine öffentliche Veröffentlichung im Play Store folgt später.",
+    },
+  };
+
+  for (const locale of ["en", "de"]) {
+    const preparing = buildAndroidDistributionContent(locale, false, false);
+    const available = buildAndroidDistributionContent(locale, true, false);
+
+    assert.ok(preparing.subline.endsWith(expectations[locale].preparing));
+    assert.ok(available.subline.endsWith(expectations[locale].available));
+  }
+});
+
 test("public Android content contains no beta or restricted-testing language", () => {
   const publicContent = JSON.stringify(androidDistributionContent);
   const forbiddenPhrases = [

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -245,11 +245,15 @@ test("unavailable public Android content does not expose public download or stor
   assert.ok(!publicContent.includes(androidPlayStoreUrl));
 });
 
-test("available direct downloads reuse the canonical latest alias builders", () => {
+test("direct distribution names SecPal while links use the canonical artifact host", () => {
   for (const locale of ["en", "de"]) {
     const content = buildAndroidDistributionContent(locale, true, false);
     const directDownload = content.downloadOptions[0];
 
+    assert.equal(
+      content.summaryItems[1]?.value,
+      locale === "de" ? "Direkt über secpal.app" : "Direct from secpal.app"
+    );
     assert.equal(
       content.heroPrimary?.href,
       buildArtifactUrl(buildLatestArtifactPath())

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -242,7 +242,7 @@ test("unavailable public Android content does not expose public download or stor
   const publicContent = JSON.stringify(androidDistributionContent);
 
   assert.doesNotMatch(publicContent, /https:\/\/apk\.secpal\.app/);
-  assert.doesNotMatch(publicContent, new RegExp(androidPlayStoreUrl));
+  assert.ok(!publicContent.includes(androidPlayStoreUrl));
 });
 
 test("available direct downloads reuse the canonical latest alias builders", () => {

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -2,15 +2,22 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  androidDirectDownloadAvailable,
   androidArtifactHost,
+  androidDistributionContent,
   androidPlayStoreUrl,
+  androidPublicPlayStoreAvailable,
+  androidReleaseTracks,
   buildArtifactUrl,
+  buildAndroidDistributionContent,
   buildChannelAliasMetadataPath,
   buildLatestArtifactPath,
   buildLatestChecksumPath,
+  buildLatestMetadataPath,
   buildTrackArtifactPath,
   buildTrackChecksumPath,
   buildTrackMetadataPath,
@@ -196,24 +203,127 @@ test("versioned Android artifact routes explain pending release availability", a
   );
 });
 
-test("android distribution content points Play Store CTAs at the app listing", async () => {
-  const { androidDistributionContent } =
-    await import("../src/lib/android-distribution.ts");
+test("public Android status is independent from internal release tracks", () => {
+  const source = readFileSync(
+    new URL("../src/lib/android-distribution.ts", import.meta.url),
+    "utf8"
+  );
 
-  assert.equal(
-    androidDistributionContent.en.heroPrimary.href,
-    androidPlayStoreUrl
+  assert.equal(androidDirectDownloadAvailable, false);
+  assert.equal(androidPublicPlayStoreAvailable, false);
+  assert.deepEqual(androidReleaseTracks, ["stable", "beta"]);
+  assert.doesNotMatch(source, /androidStableDownloadAvailable/);
+  assert.doesNotMatch(source, /androidBetaDownloadAvailable/);
+});
+
+test("public Android content exposes exactly direct download and public Google Play", () => {
+  for (const locale of ["en", "de"]) {
+    const content = androidDistributionContent[locale];
+
+    assert.equal(content.summaryItems.length, 4);
+    assert.equal(content.downloadOptions.length, 2);
+    assert.equal(
+      content.downloadOptions[0]?.name,
+      locale === "de" ? "Direkter Download" : "Direct download"
+    );
+    assert.equal(
+      content.downloadOptions[1]?.name,
+      locale === "de" ? "Play Store" : "Google Play"
+    );
+    assert.equal(content.heroPrimary.href, null);
+    assert.equal(content.heroSecondary.href, null);
+    assert.equal(content.downloadOptions[0]?.href, null);
+    assert.equal(content.downloadOptions[1]?.href, null);
+    assert.ok(!("secondaryLink" in content.downloadOptions[0]));
+  }
+});
+
+test("unavailable public Android content does not expose public download or store URLs", () => {
+  const publicContent = JSON.stringify(androidDistributionContent);
+
+  assert.doesNotMatch(publicContent, /https:\/\/apk\.secpal\.app/);
+  assert.doesNotMatch(publicContent, new RegExp(androidPlayStoreUrl));
+});
+
+test("available direct downloads reuse the canonical latest alias builders", () => {
+  for (const locale of ["en", "de"]) {
+    const content = buildAndroidDistributionContent(locale, true, false);
+    const directDownload = content.downloadOptions[0];
+
+    assert.equal(
+      content.heroPrimary.href,
+      buildArtifactUrl(buildLatestArtifactPath())
+    );
+    assert.equal(
+      directDownload.href,
+      buildArtifactUrl(buildLatestArtifactPath())
+    );
+    assert.equal(
+      directDownload.secondaryLink?.href,
+      buildArtifactUrl(buildLatestMetadataPath())
+    );
+    assert.deepEqual(
+      content.endpointGroups[0]?.entries.map((entry) => entry.href),
+      [
+        buildArtifactUrl(buildLatestMetadataPath()),
+        buildArtifactUrl(buildLatestArtifactPath()),
+        buildArtifactUrl(buildLatestChecksumPath()),
+      ]
+    );
+    assert.equal(content.heroSecondary.href, null);
+  }
+});
+
+test("public Google Play links are emitted only for public availability", () => {
+  for (const locale of ["en", "de"]) {
+    const unavailable = buildAndroidDistributionContent(locale, false, false);
+    const available = buildAndroidDistributionContent(locale, false, true);
+
+    assert.equal(unavailable.heroSecondary.href, null);
+    assert.equal(unavailable.downloadOptions[1]?.href, null);
+    assert.equal(available.heroSecondary.href, androidPlayStoreUrl);
+    assert.equal(available.downloadOptions[1]?.href, androidPlayStoreUrl);
+  }
+});
+
+test("public Android content contains no beta or restricted-testing language", () => {
+  const publicContent = JSON.stringify(androidDistributionContent);
+  const forbiddenPhrases = [
+    "Beta-Version",
+    "Beta-Kanal",
+    "Beta-Download",
+    "Beta folgt",
+    "Beta verfügbar",
+    "Beta version",
+    "Beta channel",
+    "Beta download",
+    "Internal Testing",
+    "interner Test",
+    "closed testing",
+    "geschlossener Test",
+  ];
+
+  for (const phrase of forbiddenPhrases) {
+    assert.ok(
+      !publicContent.includes(phrase),
+      `public Android content must not contain ${phrase}`
+    );
+  }
+});
+
+test("Android distribution surface conditionally renders accessible public actions", () => {
+  const component = readFileSync(
+    new URL(
+      "../src/components/AndroidDistributionSurface.astro",
+      import.meta.url
+    ),
+    "utf8"
   );
-  assert.equal(
-    androidDistributionContent.de.heroPrimary.href,
-    androidPlayStoreUrl
-  );
-  assert.equal(
-    androidDistributionContent.en.downloadOptions[0]?.href,
-    androidPlayStoreUrl
-  );
-  assert.equal(
-    androidDistributionContent.de.downloadOptions[0]?.href,
-    androidPlayStoreUrl
-  );
+
+  assert.match(component, /\blg:grid-cols-2\b/);
+  assert.match(component, /aria-disabled="true"/);
+  assert.match(component, /content\.heroPrimary\.href\s*\?/);
+  assert.match(component, /content\.heroSecondary\.href\s*\?/);
+  assert.match(component, /androidDirectDownloadAvailable\s*\?/);
+  assert.doesNotMatch(component, /content\.betaNotice/);
 });

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -282,6 +282,14 @@ test("public Google Play links are emitted only for public availability", () => 
 
     assert.equal(unavailable.heroSecondary, null);
     assert.ok(!("action" in unavailable.downloadOptions[1]));
+    assert.equal(available.heroPrimary, null);
+    assert.ok(!available.downloadOptions[0]?.action);
+    assert.equal(
+      available.badge,
+      locale === "de"
+        ? "Direkter Download in Vorbereitung"
+        : "Direct download in preparation"
+    );
     assert.equal(available.heroSecondary?.href, androidPlayStoreUrl);
     assert.equal(
       available.downloadOptions[1]?.action?.href,
@@ -493,7 +501,8 @@ test("Android distribution surface renders only real, accessible public actions"
   assert.doesNotMatch(component, /aria-disabled/);
   assert.doesNotMatch(component, /option\.href/);
   assert.doesNotMatch(component, /\bmin-h-\[1\.5rem\]\b/);
-  assert.match(component, /androidDirectDownloadAvailable\s*\?/);
+  assert.match(component, /content\.endpointGroups\.length\s*>\s*0/);
+  assert.doesNotMatch(component, /androidDirectDownloadAvailable/);
   assert.match(component, /locale === "de" \? "break-words" : null/);
   assert.doesNotMatch(component, /content\.betaNotice/);
 });

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -200,7 +200,8 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   assert.match(component, /<section\b[^>]*class="[^"]*\bmin-w-0\b[^"]*"[^>]*>/);
   // technical endpoints stay at the bottom of the page when a public download exists.
   assert.match(component, TECHNICAL_DETAILS_HEADING_PATTERN);
-  assert.match(component, /androidDirectDownloadAvailable\s*\?/);
+  assert.match(component, /content\.endpointGroups\.length\s*>\s*0/);
+  assert.doesNotMatch(component, /androidDirectDownloadAvailable/);
   // individual endpoint links keep long machine paths wrapped on the rendered href element
   assert.match(component, ENDPOINT_LINK_PARAGRAPH_PATTERN);
   // verification items keep correct definition-list semantics for label/value pairs.

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -198,8 +198,9 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   assert.match(component, ARTICLE_WITH_MIN_W_0_PATTERN);
   // section endpoint groups have min-w-0 to prevent flex overflow
   assert.match(component, /<section\b[^>]*class="[^"]*\bmin-w-0\b[^"]*"[^>]*>/);
-  // technical endpoints stay at the bottom of the page but remain visible by default.
+  // technical endpoints stay at the bottom of the page when a public download exists.
   assert.match(component, TECHNICAL_DETAILS_HEADING_PATTERN);
+  assert.match(component, /androidDirectDownloadAvailable\s*\?/);
   // individual endpoint links keep long machine paths wrapped on the rendered href element
   assert.match(component, ENDPOINT_LINK_PARAGRAPH_PATTERN);
   // verification items keep correct definition-list semantics for label/value pairs.
@@ -234,7 +235,7 @@ test("long German roadmap and Android labels wrap without changing English typog
   );
   assert.ok(
     androidDistributionContent.de.downloadOptions.some(
-      (option) => option.name === "Direktdownload"
+      (option) => option.name === "Direkter Download"
     )
   );
   assert.match(


### PR DESCRIPTION
## Problem and evidence

The public Android page described Google Play as already available and exposed stable and beta as public download choices. That did not match the current release state: no public APK artifact is available, and the Google Play listing is not publicly released.

The public page therefore needed a status model that distinguishes only:

- direct public downloads from SecPal
- a public Google Play release

Internal stable and beta tracks remain part of the release infrastructure, but they must not affect or appear in the public distribution status.

## Change

- replace the public stable/beta availability flags with independent direct-download and public-Google-Play states
- keep both public states disabled until the corresponding public release exists
- make direct download the primary public distribution path and position Google Play as a later public release
- reduce the public distribution surface to exactly two cards and remove visible beta and restricted-testing content
- render APK, manifest, checksum, and Google Play links only when their public status is enabled
- keep package and signing information visible while hiding unavailable technical download endpoints
- retain internal stable/beta tracks, metadata routes, versioned builders, and signing models
- preserve the German-only card-heading wrapping regression fix
- update Android distribution and mobile-layout regression coverage
- document the public distribution change in the Unreleased changelog

## Validation

- `npm test` — 49 tests passed
- `npm run typecheck` — no errors, warnings, or hints
- `npm run build`
- `./scripts/preflight.sh`
- `git diff --check`
- REUSE, ESLint, domain-policy, static-build, and commit-signature checks passed
- browser matrix covering English and German, eight required viewport sizes, light and dark modes, and 100% and 125% base font sizes for both unavailable and direct-download-available states

## Draft readiness

- GitHub CI and the required final self-review in the pull request view are still pending.
- The push preflight passed but reported a review-size warning: 842 changed lines compared with the local 600-line guideline. The diff remains one Android distribution topic, but reviewability should be confirmed before marking the pull request ready.
- No public APK artifact or public Google Play release exists yet, so both production availability states intentionally remain `false`.
