### PR TITLE
Refine Android distribution page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- refined the public Android page with a content-sized desktop hero, calmer
+  mobile signing-fingerprint typography, and a cooler early-release notice
 - made direct SecPal downloads the primary public Android distribution path,
   positioned the public Google Play release as a later step, removed visible
   beta distribution while retaining the internal track infrastructure, and

--- a/src/components/AndroidDistributionSurface.astro
+++ b/src/components/AndroidDistributionSurface.astro
@@ -24,8 +24,8 @@ const content = getAndroidDistributionContent(locale);
     class:list={[
       "relative isolate flex items-center overflow-hidden border-b border-gray-200 dark:border-white/10",
       overlayHeader
-        ? "min-h-screen pt-[var(--secpal-nav-height)]"
-        : "min-h-[calc(100svh-var(--secpal-nav-height))]",
+        ? "min-h-screen pt-[var(--secpal-nav-height)] lg:min-h-0"
+        : "min-h-[calc(100svh-var(--secpal-nav-height))] lg:min-h-0",
       inheritHeroBackground
         ? null
         : "bg-linear-to-br from-sky-50 via-white to-indigo-50 dark:from-gray-900 dark:via-gray-900 dark:to-slate-900",
@@ -43,7 +43,7 @@ const content = getAndroidDistributionContent(locale);
     </div>
 
     <div
-      class="mx-auto grid w-full max-w-7xl gap-12 px-6 py-20 lg:grid-cols-[minmax(0,1fr)_22rem] lg:px-8 lg:py-28"
+      class="mx-auto grid w-full max-w-7xl gap-12 px-6 py-20 lg:grid-cols-[minmax(0,1fr)_22rem] lg:px-8 lg:py-16 xl:py-20"
     >
       <div class="max-w-3xl">
         <p
@@ -177,7 +177,7 @@ const content = getAndroidDistributionContent(locale);
         }
       </div>
       <div
-        class="mt-8 rounded-3xl border border-amber-200 bg-amber-50 px-6 py-5 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100"
+        class="mt-8 rounded-3xl border border-indigo-200 bg-indigo-50 px-6 py-5 text-indigo-950 dark:border-indigo-400/20 dark:bg-indigo-400/10 dark:text-indigo-100"
       >
         <p class="text-sm font-semibold">{content.releaseNoticeTitle}</p>
         <p class="mt-2 text-sm/7">{content.releaseNoticeBody}</p>
@@ -202,7 +202,7 @@ const content = getAndroidDistributionContent(locale);
                 <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">
                   {item.label}
                 </dt>
-                <dd class="mt-1 break-all font-mono text-sm text-gray-900 dark:text-gray-100">
+                <dd class="mt-1 break-all font-mono text-xs/5 text-gray-900 sm:text-sm/6 dark:text-gray-100">
                   {item.value}
                 </dd>
               </div>

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -349,6 +349,9 @@ test("hero, summary, and distribution copy follow the concise public hierarchy",
         "The first SecPal Android release is being prepared for direct download from secpal.app. SecPal remains in an early 0.x development phase.",
       available:
         "The current SecPal Android release is available for direct download from secpal.app. SecPal remains in an early 0.x development phase.",
+      releaseNoticeTitle: "About early 0.x releases",
+      releaseNoticeBody:
+        "Early 0.x releases are under active development. Features and workflows may change in later releases.",
       distributionLabel: "Distribution",
       distributionValue: "Direct from secpal.app",
       playStatus: "Planned",
@@ -367,6 +370,9 @@ test("hero, summary, and distribution copy follow the concise public hierarchy",
         "Die erste Android-Version von SecPal wird für den direkten Download über secpal.app vorbereitet. SecPal befindet sich in einer frühen 0.x-Entwicklungsphase.",
       available:
         "Die aktuelle Android-Version von SecPal steht direkt über secpal.app zum Download bereit. SecPal befindet sich weiterhin in einer frühen 0.x-Entwicklungsphase.",
+      releaseNoticeTitle: "Hinweis zu frühen 0.x-Versionen",
+      releaseNoticeBody:
+        "Frühe 0.x-Versionen befinden sich in aktiver Entwicklung. Funktionen und Abläufe können sich mit weiteren Versionen verändern.",
       distributionLabel: "Bereitstellung",
       distributionValue: "Direkt über secpal.app",
       playStatus: "Geplant",
@@ -388,6 +394,8 @@ test("hero, summary, and distribution copy follow the concise public hierarchy",
 
     assert.equal(preparing.subline, expectation.preparing);
     assert.equal(available.subline, expectation.available);
+    assert.equal(preparing.releaseNoticeTitle, expectation.releaseNoticeTitle);
+    assert.equal(preparing.releaseNoticeBody, expectation.releaseNoticeBody);
     assert.equal(
       preparing.summaryItems[1]?.label,
       expectation.distributionLabel
@@ -500,7 +508,9 @@ test("Android distribution surface renders only real, accessible public actions"
     component,
     /content\.heroPrimary\s*\|\|\s*content\.heroSecondary/
   );
-  assert.match(component, /option\.action/);
+  assert.match(component, /option\.action\s*\|\|\s*option\.secondaryLink/);
+  assert.match(component, /\{option\.action\s*\?/);
+  assert.match(component, /\{option\.secondaryLink\s*\?/);
   assert.match(component, /min-h-\[44px\]/);
   assert.doesNotMatch(component, /aria-disabled/);
   assert.doesNotMatch(component, /option\.href/);
@@ -509,4 +519,70 @@ test("Android distribution surface renders only real, accessible public actions"
   assert.doesNotMatch(component, /androidDirectDownloadAvailable/);
   assert.match(component, /locale === "de" \? "break-words" : null/);
   assert.doesNotMatch(component, /content\.betaNotice/);
+});
+
+test("Android hero becomes content-sized at lg without tightening mobile", () => {
+  const component = readFileSync(
+    new URL(
+      "../src/components/AndroidDistributionSurface.astro",
+      import.meta.url
+    ),
+    "utf8"
+  );
+  const heroVariants = component.match(
+    /overlayHeader\s*\?\s*"([^"]+)"\s*:\s*"([^"]+)"/
+  );
+  const heroGrid = component.match(
+    /<div\s+class="([^"]*lg:grid-cols-\[minmax\(0,1fr\)_22rem\][^"]*)"\s*>/
+  );
+
+  assert.ok(heroVariants, "both conditional hero variants must remain present");
+  assert.ok(
+    heroGrid,
+    "the responsive two-column hero grid must remain present"
+  );
+
+  const overlayHeroClasses = new Set(heroVariants[1].split(/\s+/));
+  const standardHeroClasses = new Set(heroVariants[2].split(/\s+/));
+  const heroGridClasses = new Set(heroGrid[1].split(/\s+/));
+
+  assert.ok(overlayHeroClasses.has("min-h-screen"));
+  assert.ok(
+    overlayHeroClasses.has("pt-[var(--secpal-nav-height)]"),
+    "overlay hero must retain navigation clearance"
+  );
+  assert.ok(
+    standardHeroClasses.has("min-h-[calc(100svh-var(--secpal-nav-height))]")
+  );
+  assert.ok(overlayHeroClasses.has("lg:min-h-0"));
+  assert.ok(standardHeroClasses.has("lg:min-h-0"));
+  assert.ok(heroGridClasses.has("py-20"));
+  assert.ok(heroGridClasses.has("lg:py-16"));
+  assert.ok(heroGridClasses.has("xl:py-20"));
+  assert.ok(!heroGridClasses.has("lg:py-28"));
+  assert.ok(heroGridClasses.has("lg:grid-cols-[minmax(0,1fr)_22rem]"));
+});
+
+test("early 0.x notice uses calm light and dark SecPal colors", () => {
+  const component = readFileSync(
+    new URL(
+      "../src/components/AndroidDistributionSurface.astro",
+      import.meta.url
+    ),
+    "utf8"
+  );
+  const notice = component.match(
+    /<div\s+class="([^"]*)"\s*>\s*<p[^>]*>\{content\.releaseNoticeTitle\}<\/p>/
+  );
+
+  assert.ok(notice, "release notice container must remain present");
+  const noticeClasses = notice[1];
+  assert.match(noticeClasses, /\bborder-indigo-200\b/);
+  assert.match(noticeClasses, /\bbg-indigo-50\b/);
+  assert.match(noticeClasses, /\btext-indigo-950\b/);
+  assert.match(noticeClasses, /\bdark:border-indigo-400\/20\b/);
+  assert.match(noticeClasses, /\bdark:bg-indigo-400\/10\b/);
+  assert.match(noticeClasses, /\bdark:text-indigo-100\b/);
+  assert.doesNotMatch(noticeClasses, /\b(?:border|bg|text)-amber-/);
+  assert.match(component, /<p[^>]*>\{content\.releaseNoticeBody\}<\/p>/);
 });

--- a/tests/android-distribution.test.mjs
+++ b/tests/android-distribution.test.mjs
@@ -34,6 +34,9 @@ import { GET as getBetaMetadata } from "../src/pages/android/beta/latest.json.ts
 import { GET as getVersionedArtifact } from "../src/pages/android/releases/{versionCode}/app.secpal-{versionCode}.apk.ts";
 import { GET as getVersionedChecksum } from "../src/pages/android/releases/{versionCode}/SHA256SUMS.txt.ts";
 
+const classTokens = (classNames) =>
+  new Set(classNames.trim().split(/\s+/).filter(Boolean));
+
 test("buildVersionedMetadataDocument returns stable versioned Android release URLs", () => {
   const version = "123456789";
   const siteUrl = new URL("https://secpal.app");
@@ -530,10 +533,10 @@ test("Android hero becomes content-sized at lg without tightening mobile", () =>
     "utf8"
   );
   const heroVariants = component.match(
-    /overlayHeader\s*\?\s*"([^"]+)"\s*:\s*"([^"]+)"/
+    /overlayHeader\s*\?\s*(["'`])([^"'`]+)\1\s*:\s*(["'`])([^"'`]+)\3/
   );
   const heroGrid = component.match(
-    /<div\s+class="([^"]*lg:grid-cols-\[minmax\(0,1fr\)_22rem\][^"]*)"\s*>/
+    /<div\b[^>]*\bclass=(["'])([^"']*lg:grid-cols-\[minmax\(0,1fr\)_22rem\][^"']*)\1[^>]*>/
   );
 
   assert.ok(heroVariants, "both conditional hero variants must remain present");
@@ -542,9 +545,9 @@ test("Android hero becomes content-sized at lg without tightening mobile", () =>
     "the responsive two-column hero grid must remain present"
   );
 
-  const overlayHeroClasses = new Set(heroVariants[1].split(/\s+/));
-  const standardHeroClasses = new Set(heroVariants[2].split(/\s+/));
-  const heroGridClasses = new Set(heroGrid[1].split(/\s+/));
+  const overlayHeroClasses = classTokens(heroVariants[2]);
+  const standardHeroClasses = classTokens(heroVariants[4]);
+  const heroGridClasses = classTokens(heroGrid[2]);
 
   assert.ok(overlayHeroClasses.has("min-h-screen"));
   assert.ok(
@@ -572,7 +575,7 @@ test("early 0.x notice uses calm light and dark SecPal colors", () => {
     "utf8"
   );
   const notice = component.match(
-    /<div\s+class="([^"]*)"\s*>\s*<p[^>]*>\{content\.releaseNoticeTitle\}<\/p>/
+    /<div\b[^>]*\bclass="([^"]*)"[^>]*>\s*<p[^>]*>\{content\.releaseNoticeTitle\}<\/p>/
   );
 
   assert.ok(notice, "release notice container must remain present");

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -9,6 +9,9 @@ import { de } from "../src/i18n/de.ts";
 import { en } from "../src/i18n/en.ts";
 import { androidDistributionContent } from "../src/lib/android-distribution.ts";
 
+const classTokens = (classNames) =>
+  new Set(classNames.trim().split(/\s+/).filter(Boolean));
+
 test("global layout accounts for mobile safe-area insets", () => {
   const css = readFileSync(
     new URL("../src/styles/global.css", import.meta.url),
@@ -194,7 +197,7 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   const TECHNICAL_DETAILS_HEADING_PATTERN =
     /<h3\b[^>]*>\s*\{content\.technicalDetailsTitle\}\s*<\/h3>/;
   const verificationItem = component.match(
-    /content\.verificationItems\.map\(\(item\) => \(\s*<div class="([^"]*)">[\s\S]*?<dd class="([^"]*)">\s*\{item\.value\}\s*<\/dd>/
+    /content\.verificationItems\.map\(\(item\) => \(\s*<div\b[^>]*\bclass="([^"]*)"[^>]*>[\s\S]*?<dd\b[^>]*\bclass="([^"]*)"[^>]*>\s*\{item\.value\}\s*<\/dd>/
   );
 
   // download and rollout cards keep min-w-0 to prevent overflow
@@ -214,8 +217,8 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
   );
   assert.ok(verificationItem, "verification item markup must remain present");
 
-  const verificationItemClasses = new Set(verificationItem[1].split(/\s+/));
-  const verificationValueClasses = new Set(verificationItem[2].split(/\s+/));
+  const verificationItemClasses = classTokens(verificationItem[1]);
+  const verificationValueClasses = classTokens(verificationItem[2]);
   const forbiddenClasses = [
     "overflow-x-auto",
     "whitespace-nowrap",

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -193,6 +193,9 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
     /<p\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b[^"]*"[^>]*>\s*\{\s*entry\.href\s*\}\s*<\/p>/;
   const TECHNICAL_DETAILS_HEADING_PATTERN =
     /<h3\b[^>]*>\s*\{content\.technicalDetailsTitle\}\s*<\/h3>/;
+  const verificationItem = component.match(
+    /content\.verificationItems\.map\(\(item\) => \(\s*<div class="([^"]*)">[\s\S]*?<dd class="([^"]*)">\s*\{item\.value\}\s*<\/dd>/
+  );
 
   // download and rollout cards keep min-w-0 to prevent overflow
   assert.match(component, ARTICLE_WITH_MIN_W_0_PATTERN);
@@ -209,11 +212,26 @@ test("android distribution cards wrap long visible machine paths on mobile", () 
     component,
     /<dl\b[^>]*class="[^"]*\bgrid\b[^"]*\bsm:grid-cols-2\b[^"]*"[^>]*>[\s\S]*<dt\b[\s\S]*<dd\b[\s\S]*<\/dl>/
   );
-  // verification items also keep machine-readable values on break-all mono elements.
-  assert.match(
-    component,
-    /<dd\b[^>]*class="[^"]*\bbreak-all\b[^"]*\bfont-mono\b[^"]*"[^>]*>\s*\{\s*item\.value\s*\}\s*<\/dd>/
-  );
+  assert.ok(verificationItem, "verification item markup must remain present");
+
+  const verificationItemClasses = new Set(verificationItem[1].split(/\s+/));
+  const verificationValueClasses = new Set(verificationItem[2].split(/\s+/));
+  const forbiddenClasses = [
+    "overflow-x-auto",
+    "whitespace-nowrap",
+    "truncate",
+    "text-ellipsis",
+  ];
+
+  assert.ok(verificationItemClasses.has("min-w-0"));
+  assert.ok(verificationValueClasses.has("break-all"));
+  assert.ok(verificationValueClasses.has("font-mono"));
+  assert.ok(verificationValueClasses.has("text-xs/5"));
+  assert.ok(verificationValueClasses.has("sm:text-sm/6"));
+  for (const className of forbiddenClasses) {
+    assert.ok(!verificationItemClasses.has(className));
+    assert.ok(!verificationValueClasses.has(className));
+  }
 });
 
 test("long German roadmap and Android labels wrap without changing English typography", () => {


### PR DESCRIPTION
## Summary

Refines the public Android distribution page without changing its release, content, or action model.

## Problem and evidence

- The hero enforced a viewport-sized minimum height on desktop even when no public download action was available, leaving substantial empty space before the distribution section.
- The full signing SHA-256 fingerprint wrapped densely on narrow screens at the existing mobile text size.
- The early-release product information used amber warning colors although it is explanatory status information rather than an alert.

## Changes

- Makes both hero variants content-sized from `lg` while preserving mobile and tablet minimum heights, overlay-header clearance, the background treatment, and the two-column layout (`src/components/AndroidDistributionSurface.astro:24`, `src/components/AndroidDistributionSurface.astro:45`).
- Uses smaller, controlled mobile monospace typography for package and signing values while preserving definition-list semantics, `break-all`, and the complete fingerprint (`src/components/AndroidDistributionSurface.astro:198`).
- Replaces the amber early-release notice with calm indigo light and dark treatments without changing its content (`src/components/AndroidDistributionSurface.astro:179`).
- Extends Android distribution and mobile regression coverage, including real-action guards, responsive hero behavior, release-notice text and colors, and scoped technical-value assertions (`tests/android-distribution.test.mjs:497`, `tests/mobile-safe-area.test.mjs:179`).

## Validation

- `npm test` — 55 passing tests
- `./scripts/preflight.sh` — formatting, REUSE, domain policy, Astro typecheck, ESLint, static build, commit signatures, and PR-size check passed
- `git diff --check`
- Browser matrix for German and English at 320×568, 360×640, 390×844, 412×915, 430×932, 768×1024, 1024×768, 1280×800, 1440×900, and 1920×1080; light and dark mode; normal and 125% base font size; both the current unavailable public state and a temporary direct-download state. No clipping, horizontal overflow, or console errors observed.

## Readiness

No in-scope code dependency blocks review. Hosted checks are running; the pull request remains a draft pending their completion and the final PR-view self-review.
