### PR TITLE
Refocus the public website privacy notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LicenseRef-TailwindPlus` is the repo's SPDX reference for Tailwind
   Plus-derived components
 - replaced the repo-local `markdownlint-cli2` pre-commit and preflight path with pinned `markdownlint-cli@0.49.0` usage and removed the stale `cli2` file references from export/licensing metadata
-- expanded the public privacy notice so it now covers the SecPal Android app, beta distribution, Google Play / third-party store context, and app-data deletion contact paths in addition to the website itself
+- refocused the localized privacy notice on the public website, direct download
+  infrastructure, DNS services, local display preference, and email contact;
+  removed product-internal app and beta-processing descriptions; and prevented
+  GitHub links from transmitting the referring SecPal page
 - refocused the public Android landing page on end users: stable and beta are now presented as simple download choices, rollout methods are explained without pretending to be separate APK channels, and the deeper machine-readable endpoints are tucked behind secondary technical details
 - corrected the provider-neutral governance baseline so `AGENTS.md` and the Copilot mirror now advertise the workflow overlay, describe the existing `npm test` suite accurately, track Astro 7 instead of Astro 6, and pin the shared reusable quality workflows plus their `governance-ref` inputs to the reviewed `.github` SHA for reproducible validation
 - refactored `mobile-safe-area` test assertions: extracted complex inline regex literals to named constants and restored the coupled `break-all`+`{line}` assertion so endpoint-line paragraph failures remain diagnosable without weakening test coverage

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -40,6 +40,7 @@ const t = useTranslations(locale);
           >
           <a
             href="https://github.com/SecPal"
+            referrerpolicy="no-referrer"
             class="rounded-sm text-sm/6 font-semibold text-white hover:text-gray-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
             >{t.cta.buttonSecondary} <span aria-hidden="true">→</span></a
           >

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,6 +39,7 @@ const year = new Date().getFullYear();
       </a>
       <a
         href="https://github.com/SecPal"
+        referrerpolicy="no-referrer"
         class="text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white"
       >
         <span class="sr-only">{t.footer.links.github}</span>

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -25,8 +25,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         Diese Datenschutzerklärung gilt für die öffentliche Website secpal.app,
-        die über apk.secpal.app bereitgestellten Downloadressourcen sowie die
-        direkte Kontaktaufnahme mit SecPal.
+        die über apk.secpal.app bereitgestellten Downloadressourcen, die über
+        Cloudflare bereitgestellten autoritativen DNS-Dienste sowie die direkte
+        Kontaktaufnahme mit SecPal.
       </p>
       <p class="mt-4">
         Sie beschreibt nicht die Verarbeitung personenbezogener Daten innerhalb

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -12,7 +12,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, die Domain- und DNS-Infrastruktur sowie die direkte Kontaktaufnahme per E-Mail."
+  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
   updatedLabel="Stand"
   updatedAt="24. Juli 2026"
 >
@@ -105,9 +105,11 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         SecPal speichert dabei keine individuellen IP-Adressen, User-Agents oder
         Crawlerinformationen und erstellt keine Besucher-, Referrer-, Länder-,
         Geräte- oder Downloadstatistiken. Die flüchtige technische Verarbeitung
-        während der Verbindung bleibt davon unberührt. Infrastrukturbetreiber
-        können technisch erforderliche Betriebs- oder Sicherheitsdaten in
-        eigener Verantwortung verarbeiten.
+        während der Verbindung bleibt davon unberührt. Unabhängig von der durch
+        SecPal deaktivierten regulären Protokollierung können die eingesetzten
+        Dienstleister technisch erforderliche Betriebs- und
+        Sicherheitsverarbeitungen nach den jeweils geltenden vertraglichen und
+        gesetzlichen Rahmenbedingungen durchführen.
       </p>
     </div>
 
@@ -115,11 +117,11 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        5. Domainverwaltung und DNS
+        5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Die Domainverwaltung und die autoritativen DNS-Dienste erfolgen über
-        Cloudflare. Die Web-DNS-Einträge sind DNS-only und beantworten
+        Die autoritativen DNS-Dienste für secpal.app werden über Cloudflare
+        bereitgestellt. Die Web-DNS-Einträge sind DNS-only und beantworten
         DNS-Abfragen mit der tatsächlichen Hetzner-Origin-IP. Der reguläre HTTP-
         und HTTPS-Verkehr läuft direkt zu Hetzner.
       </p>
@@ -279,8 +281,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
             >Cloudflare, Inc.:</strong
           >
           {" "}
-          Domainverwaltung und autoritative DNS-Dienste. Wegen der DNS-only-Konfiguration
-          erhält Cloudflare nicht den regulären HTTP- oder HTTPS-Verkehr.
+          autoritative DNS-Dienste. Wegen der DNS-only-Konfiguration erhält Cloudflare
+          nicht den regulären HTTP- oder HTTPS-Verkehr.
         </li>
         <li>
           <strong class="font-semibold text-gray-900 dark:text-white"

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -7,25 +7,42 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Datenschutz | SecPal"
-  description="Datenschutzhinweise für secpal.app, die SecPal-Android-App, Beta-Verteilungen und direkte E-Mail-Kontakte mit SecPal."
+  description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung beschreibt, welche personenbezogenen Daten beim Besuch von secpal.app, bei der Nutzung der SecPal-Android-App, bei Android-Beta-Verteilungen sowie bei direktem E-Mail-Kontakt mit SecPal verarbeitet werden."
+  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, die Domain- und DNS-Infrastruktur sowie die direkte Kontaktaufnahme per E-Mail."
   updatedLabel="Stand"
-  updatedAt="28. Juni 2026"
+  updatedAt="24. Juli 2026"
 >
   <section class="space-y-8">
     <div>
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        1. Verantwortlicher
+        1. Geltungsbereich
       </h2>
       <p class="mt-6">
-        Verantwortlich für die Datenverarbeitung auf dieser Website ist:
+        Diese Datenschutzerklärung gilt für die öffentliche Website secpal.app,
+        die über apk.secpal.app bereitgestellten Downloadressourcen sowie die
+        direkte Kontaktaufnahme mit SecPal.
       </p>
+      <p class="mt-4">
+        Sie beschreibt nicht die Verarbeitung personenbezogener Daten innerhalb
+        einer installierten oder betriebenen SecPal-Instanz. Für solche
+        Verarbeitungen ist die Stelle verantwortlich, die den Betrieb und die
+        Zwecke der jeweiligen Instanz bestimmt.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        2. Verantwortlicher
+      </h2>
+      <p class="mt-6">Verantwortlicher im Sinne der DSGVO ist:</p>
       <div
         class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
       >
@@ -33,6 +50,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         <p class="mt-2">Holger Schmermbeck</p>
         <p class="mt-2">Enno-Arends-Str. 4</p>
         <p class="mt-2">26571 Juist</p>
+        <p class="mt-2">Deutschland</p>
       </div>
       <p class="mt-4">
         Kontakt per E-Mail:{" "}
@@ -48,119 +66,234 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        2. Zugriffsdaten und Hosting
+        3. Technische Bereitstellung und Hosting
       </h2>
       <p class="mt-6">
-        Beim Aufruf dieser Website werden technisch erforderliche Daten
-        verarbeitet, damit die Seite ausgeliefert und sicher betrieben werden
-        kann.
+        Beim Aufruf der Website oder einer Downloadressource übermittelt der
+        Browser technisch notwendige Verbindungs- und Anfragedaten. Dazu gehören
+        insbesondere die IP-Adresse, der angeforderte Host und die angeforderte
+        Ressource, Verbindungs- und Protokolldaten sowie technisch übermittelte
+        HTTP-Header.
       </p>
-      <ul
-        role="list"
-        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
-      >
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Verarbeitete Daten:</strong
-            > IP-Adresse, Datum und Uhrzeit des Abrufs, angeforderte URL, Referrer,
-            Browsertyp und Betriebssystem.</span
-          >
-        </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Zweck:</strong
-            > Bereitstellung der Website, Fehleranalyse, Missbrauchserkennung und
-            Absicherung des technischen Betriebs.</span
-          >
-        </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Rechtsgrundlage:</strong
-            > Art. 6 Abs. 1 lit. f DSGVO auf Basis des berechtigten Interesses an
-            einem sicheren und funktionsfähigen Webauftritt.</span
-          >
-        </li>
-      </ul>
-      <p class="mt-8">Das Hosting dieser Website erfolgt bei Hetzner.</p>
+      <p class="mt-4">
+        Diese Daten werden für die Dauer der Verbindung flüchtig verarbeitet,
+        damit die angeforderte Website oder Datei übertragen werden kann. Das
+        Hosting von secpal.app und apk.secpal.app erfolgt über die Hetzner
+        Online GmbH.
+      </p>
+      <p class="mt-4">
+        Zwecke der Verarbeitung sind die Auslieferung der angeforderten Inhalte,
+        ein stabiler und sicherer Transport sowie der Betrieb der
+        Hostinginfrastruktur. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO.
+        Das berechtigte Interesse liegt in der sicheren und funktionsfähigen
+        Bereitstellung dieser Inhalte.
+      </p>
     </div>
 
     <div>
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        3. Android-App, Beta-Verteilungen und Update-Bereitstellung
+        4. Keine reguläre Zugriffsprotokollierung
       </h2>
       <p class="mt-6">
-        SecPal wird auch als native Android-App mit dem Paketnamen
-        {" "}
-        <strong class="font-semibold text-gray-900 dark:text-white"
-          >app.secpal</strong
-        >
-        {" "}
-        bereitgestellt. Die Verteilung erfolgt über den Google Play Store oder über
-        SecPal-Download-URLs. Unabhängig vom Verteilungsweg bleibt die signierte App
-        identisch.
+        SecPal führt für secpal.app und apk.secpal.app keine regulären
+        Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne Seiten- und
+        Downloadabrufe werden von SecPal nicht dauerhaft protokolliert.
       </p>
+      <p class="mt-4">
+        SecPal speichert dabei keine individuellen IP-Adressen, User-Agents oder
+        Crawlerinformationen und erstellt keine Besucher-, Referrer-, Länder-,
+        Geräte- oder Downloadstatistiken. Die flüchtige technische Verarbeitung
+        während der Verbindung bleibt davon unberührt. Infrastrukturbetreiber
+        können technisch erforderliche Betriebs- oder Sicherheitsdaten in
+        eigener Verantwortung verarbeiten.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        5. Domainverwaltung und DNS
+      </h2>
+      <p class="mt-6">
+        Die Domainverwaltung und die autoritativen DNS-Dienste erfolgen über
+        Cloudflare. Die Web-DNS-Einträge sind DNS-only und beantworten
+        DNS-Abfragen mit der tatsächlichen Hetzner-Origin-IP. Der reguläre HTTP-
+        und HTTPS-Verkehr läuft direkt zu Hetzner.
+      </p>
+      <p class="mt-4">
+        Cloudflare wird für diese Hosts nicht als Reverse Proxy, CDN, WAF oder
+        HTTP-Analyseplattform eingesetzt. Cloudflare erhält daher nicht den
+        regulären Seiten- oder Downloadverkehr.
+      </p>
+      <p class="mt-4">
+        Im Rahmen der DNS-Auflösung kann Cloudflare technisch notwendige
+        DNS-Abfragedaten verarbeiten. Zweck ist die zuverlässige und sichere
+        Erreichbarkeit der Domains. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f
+        DSGVO; das berechtigte Interesse liegt in einer stabilen und sicheren
+        Domainauflösung.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        6. Öffentliche Downloadressourcen
+      </h2>
+      <p class="mt-6">
+        apk.secpal.app kann APK-Dateien, Manifeste, Veröffentlichungsmetadaten
+        und Prüfsummen bereitstellen. Der Abruf erfordert dieselbe flüchtige
+        technische Verbindungsverarbeitung wie ein normaler Websiteabruf.
+      </p>
+      <p class="mt-4">
+        SecPal führt keine Downloadprotokolle oder individuellen Downloadzähler.
+        Aus dem Abruf erhält secpal.app keine Informationen über die spätere
+        Installation oder Verwendung der heruntergeladenen Anwendung.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        7. Lokale Darstellungspräferenz
+      </h2>
+      <p class="mt-6">
+        Wenn eine Person den Hell- oder Dunkelmodus manuell auswählt, speichert
+        die Website den Wert{" "}
+        <code class="break-all">light</code> oder{" "}
+        <code class="break-all">dark</code> unter dem Schlüssel{" "}
+        <code class="break-all">theme</code> im lokalen Speicher des Browsers. Ohne
+        eine manuelle Auswahl orientiert sich die Darstellung an der Systemeinstellung.
+      </p>
+      <p class="mt-4">
+        Die Einstellung verbleibt im Browser und wird weder an SecPal noch an
+        einen externen Anbieter übermittelt. Sie bleibt gespeichert, bis sie
+        geändert oder der lokale Browserspeicher gelöscht wird.
+      </p>
+      <p class="mt-4">
+        Die Speicherung ist erforderlich, um den ausdrücklich gewählten
+        Darstellungsmodus bei späteren Seitenaufrufen bereitzustellen. Sie
+        erfolgt auf Grundlage von § 25 Abs. 2 Nr. 2 TDDDG und erfordert keine
+        Einwilligung.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        8. Keine Webanalyse oder Besucherprofilbildung
+      </h2>
+      <p class="mt-6">
+        SecPal setzt auf secpal.app und apk.secpal.app keine Webanalyse-,
+        Marketing- oder Nutzertrackingdienste ein. Es werden keine
+        Besucherprofile erstellt und keine optionalen Analyse- oder
+        Marketing-Cookies gesetzt.
+      </p>
+      <p class="mt-4">
+        Da keine optionalen Trackingtechnologien verwendet werden, ist kein
+        Einwilligungsbanner für solche Zwecke eingebunden.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        9. Kontaktaufnahme per E-Mail
+      </h2>
+      <p class="mt-6">
+        Die E-Mail-Kommunikation wird technisch über Uberspace bereitgestellt.
+        Uberspace wird von Jonas Pasche in Mainz betrieben.
+      </p>
+      <p class="mt-4">
+        Verarbeitet werden können die Absenderadresse, der Name, falls
+        angegeben, der Betreff, der Nachrichteninhalt, der
+        Kommunikationszeitpunkt, Anhänge sowie technisch notwendige
+        E-Mail-Metadaten. Zweck ist ausschließlich die Bearbeitung der Anfrage
+        und die dafür erforderliche Kommunikation.
+      </p>
+      <p class="mt-4">
+        Art. 6 Abs. 1 lit. b DSGVO gilt, wenn eine Person durch ihre Anfrage
+        vorvertragliche Maßnahmen anfordert oder die Kommunikation einen Vertrag
+        betrifft. In sonstigen Fällen gilt Art. 6 Abs. 1 lit. f DSGVO. Das
+        berechtigte Interesse liegt in der Bearbeitung eingehender Anfragen und
+        Sicherheitsmeldungen.
+      </p>
+      <p class="mt-4">
+        Nach abschließender Bearbeitung löscht SecPal die Nachricht. Sie wird
+        nicht für Marketing, Newsletter, Besucheranalyse oder CRM-Profile
+        weiterverwendet. Zwingende gesetzliche Aufbewahrungspflichten bleiben
+        vorbehalten. Technisch notwendige Vorgänge in Sicherungs-, Zustell- oder
+        Warteschlangensystemen des E-Mail-Anbieters können davon abweichen.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        10. Externe Links
+      </h2>
+      <p class="mt-6">
+        Diese Website enthält Links zu externen Angeboten, insbesondere zu
+        GitHub. Inhalte dieser Anbieter werden nicht in secpal.app eingebettet.
+        Beim bloßen Aufruf der Website wird daher keine Verbindung zu GitHub
+        hergestellt.
+      </p>
+      <p class="mt-4">
+        Erst beim Auswählen eines externen Links verlässt die Person secpal.app,
+        und der Browser stellt eine Verbindung zum jeweiligen Anbieter her. Für
+        die Verarbeitung auf dem externen Angebot ist der jeweilige Anbieter
+        verantwortlich.
+      </p>
+      <p class="mt-4">
+        Bei Links zum SecPal-Auftritt auf GitHub unterdrückt SecPal die
+        Übermittlung der zuvor besuchten Seite als HTTP-Referrer.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        11. Empfänger und Dienstleister
+      </h2>
       <ul
         role="list"
         class="mt-8 max-w-3xl space-y-6 text-gray-600 dark:text-gray-400"
       >
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Verarbeitete Daten:</strong
-            > je nach Nutzung insbesondere Kontodaten, von Nutzerinnen und Nutzern
-            eingegebene Einsatz- und Organisationsdaten, technische Geräte- und App-Daten,
-            Protokolldaten, Version- und Update-Informationen sowie bei Managed-Device-
-            oder Device-Owner-Szenarien erforderliche Provisioning- oder Bootstrap-Informationen.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Hetzner Online GmbH:</strong
           >
+          {" "}
+          Hosting und Auslieferung der Website und der Downloadressourcen.
         </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Zweck:</strong
-            > Bereitstellung der App, Authentifizierung, Bereitstellung von Funktionen,
-            sichere technische Auslieferung von Installations- und Update-Informationen,
-            Fehleranalyse, Missbrauchserkennung und Systemsicherheit.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Cloudflare, Inc.:</strong
           >
+          {" "}
+          Domainverwaltung und autoritative DNS-Dienste. Wegen der DNS-only-Konfiguration
+          erhält Cloudflare nicht den regulären HTTP- oder HTTPS-Verkehr.
         </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Rechtsgrundlagen:</strong
-            > Art. 6 Abs. 1 lit. b DSGVO für die Bereitstellung vereinbarter App-Funktionen
-            und vorvertraglicher oder vertraglicher Leistungen; Art. 6 Abs. 1 lit.
-            f DSGVO für den sicheren Betrieb, die Abwehr von Missbrauch, die technische
-            Integrität der Verteilung sowie die Stabilität der verbundenen Systeme.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Uberspace, betrieben von Jonas Pasche:</strong
           >
+          {" "}
+          technische E-Mail-Kommunikation.
         </li>
       </ul>
-      <p class="mt-8">
-        Für geschlossene oder offene Beta-Phasen gelten dieselben Grundsätze.
-        Beta-Versionen können zusätzlich technische Diagnosedaten und
-        Fehlerkontexte verarbeiten, soweit dies zur Stabilisierung und sicheren
-        Bereitstellung der Vorabversion erforderlich ist.
+      <p class="mt-6">
+        GitHub ist beim bloßen Seitenaufruf kein Empfänger personenbezogener
+        Daten. Eine Verbindung entsteht erst durch das Auswählen eines externen
+        GitHub-Links.
       </p>
     </div>
 
@@ -168,26 +301,19 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        4. Google Play Store und Drittplattformen
+        12. Drittlandübermittlung bei Cloudflare
       </h2>
       <p class="mt-6">
-        Wenn die SecPal-Android-App über den Google Play Store oder andere
-        Drittplattformen bereitgestellt wird, können diese Plattformen im
-        Zusammenhang mit Listing, Download, Installation, Lizenzierung,
-        Abrechnung, Update-Auslieferung oder Missbrauchsprävention eigene
-        personenbezogene Daten verarbeiten.
+        Cloudflare ist ein Anbieter mit Sitz in den USA und globaler
+        Infrastruktur. Im Rahmen der DNS-Dienste kann eine Verarbeitung
+        außerhalb des Europäischen Wirtschaftsraums nicht vollständig
+        ausgeschlossen werden.
       </p>
       <p class="mt-4">
-        Diese Verarbeitungen erfolgen grundsätzlich in der Verantwortlichkeit
-        der jeweiligen Plattformbetreiber. Für die Datenverarbeitung durch
-        Google gelten ergänzend die Datenschutz- und Nutzungsbedingungen von
-        Google.
-      </p>
-      <p class="mt-4">
-        Soweit wir über solche Plattformen Beta- oder Release-Programme
-        organisieren, verarbeiten wir die dort erforderlichen Informationen nur,
-        soweit dies für Bereitstellung, Support, Release-Kommunikation oder
-        Sicherheit notwendig ist.
+        Für Übermittlungen in die USA kann das EU-US Data Privacy Framework
+        genutzt werden, solange die Zertifizierung wirksam ist. Ergänzend
+        beziehungsweise für andere relevante Drittlandübermittlungen sieht
+        Cloudflare Standardvertragsklauseln vor.
       </p>
     </div>
 
@@ -195,17 +321,17 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        5. Kontaktaufnahme per E-Mail
+        13. Bereitstellung der Daten
       </h2>
       <p class="mt-6">
-        Wenn Sie per E-Mail Kontakt aufnehmen, verarbeiten wir die von Ihnen
-        übermittelten Angaben, um Ihre Anfrage zu beantworten und die weitere
-        Kommunikation zu dokumentieren.
+        Die Verarbeitung der Verbindungsdaten ist technisch erforderlich, um die
+        Website oder Downloadressourcen auszuliefern. Ohne diese Verarbeitung
+        kann der angeforderte Inhalt nicht übertragen werden.
       </p>
       <p class="mt-4">
-        Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO, soweit es um
-        vorvertragliche Maßnahmen oder die Bearbeitung einer konkreten Anfrage
-        geht, andernfalls Art. 6 Abs. 1 lit. f DSGVO.
+        Die Kontaktaufnahme per E-Mail ist freiwillig. Ohne eine erreichbare
+        Absenderadresse und ausreichende Angaben kann eine Anfrage
+        möglicherweise nicht beantwortet werden.
       </p>
     </div>
 
@@ -213,12 +339,19 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        6. Keine Cookies und kein Tracking auf dieser Website
+        14. Speicherdauer
       </h2>
       <p class="mt-6">
-        Auf dieser Website werden derzeit keine Analyse-, Tracking- oder
-        Marketing-Cookies eingesetzt. Es wird auch kein Cookie-Banner für
-        optionale Tracking-Zwecke verwendet.
+        SecPal speichert keine individuellen Website- oder Downloadzugriffe in
+        regulären Webserverlogs. Die Theme-Einstellung bleibt ausschließlich im
+        Browser, bis sie geändert oder der lokale Browserspeicher gelöscht wird.
+      </p>
+      <p class="mt-4">
+        E-Mails werden nach abschließender Bearbeitung gelöscht, sofern keine
+        gesetzliche Pflicht oder ein konkreter rechtlicher Grund für eine
+        längere Aufbewahrung besteht. Für technisch erforderliche Verarbeitungen
+        der Dienstleister gelten deren jeweilige betriebliche und rechtliche
+        Anforderungen; SecPal nennt hierfür keine unbelegte feste Frist.
       </p>
     </div>
 
@@ -226,51 +359,37 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        7. Speicherdauer
+        15. Rechte betroffener Personen
       </h2>
       <p class="mt-6">
-        Server-Logdaten werden nur so lange gespeichert, wie dies zur
-        technischen Bereitstellung, Fehleranalyse und Sicherheitsüberwachung
-        erforderlich ist.
+        Soweit die jeweiligen gesetzlichen Voraussetzungen vorliegen, bestehen
+        Rechte auf Auskunft, Berichtigung, Löschung, Einschränkung der
+        Verarbeitung und Datenübertragbarkeit. Gegen Verarbeitungen auf
+        Grundlage von Art. 6 Abs. 1 lit. f DSGVO besteht außerdem ein
+        Widerspruchsrecht.
       </p>
       <p class="mt-4">
-        Daten aus E-Mails werden gelöscht, sobald die jeweilige Anfrage
-        abgeschlossen ist, sofern keine gesetzlichen Aufbewahrungspflichten
-        entgegenstehen.
+        Betroffene Personen können sich zudem bei einer
+        Datenschutzaufsichtsbehörde beschweren. Zuständig ist insbesondere:
       </p>
-      <p class="mt-4">
-        Daten aus der Nutzung der Android-App oder aus Beta-Verteilungen werden
-        nur so lange gespeichert, wie dies für die Bereitstellung der jeweiligen
-        Funktion, die Sicherheitsüberwachung, Support, Fehleranalyse,
-        Release-Verwaltung oder gesetzliche Aufbewahrungspflichten erforderlich
-        ist.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      <div
+        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
       >
-        8. Rechte der betroffenen Personen
-      </h2>
-      <p class="mt-6">
-        Ihnen stehen nach Maßgabe der DSGVO insbesondere Rechte auf Auskunft,
-        Berichtigung, Löschung, Einschränkung der Verarbeitung,
-        Datenübertragbarkeit sowie Widerspruch gegen die Verarbeitung zu.
-      </p>
+        <p class="font-semibold text-gray-900 dark:text-white">
+          Der Landesbeauftragte für den Datenschutz Niedersachsen
+        </p>
+        <p class="mt-2">Prinzenstraße 5</p>
+        <p class="mt-2">30159 Hannover</p>
+      </div>
       <p class="mt-4">
-        Außerdem haben Sie das Recht, sich bei einer Datenschutzaufsichtsbehörde
-        zu beschweren.
-      </p>
-      <p class="mt-4">
-        Wenn Sie ein Konto für SecPal nutzen oder personenbezogene Daten aus der
-        App löschen lassen möchten, können Sie sich unter{" "}
+        Anfragen zu Betroffenenrechten können an{" "}
         <a
           href="mailto:hello@secpal.app"
           class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
           >hello@secpal.app</a
         >
-        {" "}an uns wenden.
+        {" "}
+        gerichtet werden.
       </p>
     </div>
 
@@ -278,12 +397,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        9. Änderungen dieser Datenschutzerklärung
+        16. Änderungen der Datenschutzerklärung
       </h2>
       <p class="mt-6">
-        Wir passen diese Datenschutzerklärung an, wenn sich die Website, die
-        Android-App, die tatsächlichen Datenverarbeitungen, die Beta- oder
-        Release-Prozesse oder die rechtlichen Anforderungen ändern.
+        SecPal aktualisiert diese Datenschutzerklärung, wenn sich die Website,
+        die Download-Infrastruktur, die eingesetzten Dienstleister oder die
+        rechtlichen Anforderungen ändern.
       </p>
     </div>
   </section>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -7,25 +7,42 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Privacy Notice | SecPal"
-  description="Privacy notice for secpal.app, the SecPal Android app, beta distribution, and direct email contact with SecPal."
+  description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice explains which personal data may be processed when you visit secpal.app, use the SecPal Android app, take part in Android beta distribution, or contact SecPal by email."
+  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the domain and DNS infrastructure, and direct contact by email."
   updatedLabel="Last updated"
-  updatedAt="June 28, 2026"
+  updatedAt="July 24, 2026"
 >
   <section class="space-y-8">
     <div>
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        1. Controller
+        1. Scope
       </h2>
       <p class="mt-6">
-        The controller responsible for data processing on this website is:
+        This privacy notice applies to the public secpal.app website, download
+        resources provided through apk.secpal.app, and direct contact with
+        SecPal.
       </p>
+      <p class="mt-4">
+        It does not describe the processing of personal data within an installed
+        or operated SecPal instance. Such processing is the responsibility of
+        the entity that determines the operation and purposes of the respective
+        instance.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        2. Controller
+      </h2>
+      <p class="mt-6">The controller within the meaning of the GDPR is:</p>
       <div
         class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
       >
@@ -49,116 +66,226 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        2. Access data and hosting
+        3. Technical delivery and hosting
       </h2>
       <p class="mt-6">
-        When you visit this website, technically necessary data is processed so
-        the site can be delivered and operated securely.
+        When the website or a download resource is requested, the browser sends
+        technically necessary connection and request data. This includes, in
+        particular, the IP address, the requested host and resource, connection
+        and protocol data, and technically transmitted HTTP headers.
       </p>
-      <ul
-        role="list"
-        class="mt-8 max-w-xl space-y-6 text-gray-600 dark:text-gray-400"
-      >
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Processed data:</strong
-            > IP address, date and time of access, requested URL, referrer, browser
-            type, and operating system.</span
-          >
-        </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Purpose:</strong
-            > delivery of the website, error analysis, abuse detection, and safeguarding
-            technical operations.</span
-          >
-        </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Legal basis:</strong
-            > Art. 6(1)(f) GDPR based on the legitimate interest in operating a secure
-            and functional website.</span
-          >
-        </li>
-      </ul>
-      <p class="mt-8">This website is hosted by Hetzner.</p>
+      <p class="mt-4">
+        This data is processed transiently for the duration of the connection so
+        that the requested website or file can be transmitted. secpal.app and
+        apk.secpal.app are hosted through Hetzner Online GmbH.
+      </p>
+      <p class="mt-4">
+        The purposes are to deliver the requested content, provide stable and
+        secure transport, and operate the hosting infrastructure. The legal
+        basis is Article 6(1)(f) GDPR. The legitimate interest is the secure and
+        functional provision of this content.
+      </p>
     </div>
 
     <div>
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        3. Android app, beta distribution, and update delivery
+        4. No regular access logging
       </h2>
       <p class="mt-6">
-        SecPal is also provided as a native Android app with the package name
-        {" "}
-        <strong class="font-semibold text-gray-900 dark:text-white"
-          >app.secpal</strong
-        >.{" "}
-        Distribution takes place through the Google Play Store or through SecPal download
-        URLs. The signed app package remains the same regardless of the distribution
-        path.
+        SecPal keeps no regular web server access or error logs for secpal.app
+        and apk.secpal.app. Individual page and download requests are not
+        permanently logged by SecPal.
       </p>
+      <p class="mt-4">
+        SecPal does not store individual IP addresses, user agents, or crawler
+        information and does not use such requests to produce visitor, referrer,
+        country, device, or download statistics. This does not affect the
+        transient technical processing during the connection. Infrastructure
+        operators may process technically necessary operational or security data
+        under their own responsibility.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        5. Domain management and DNS
+      </h2>
+      <p class="mt-6">
+        Domain management and authoritative DNS services are provided through
+        Cloudflare. The web DNS records are DNS-only and answer DNS queries with
+        the actual Hetzner origin IP address. Regular HTTP and HTTPS traffic
+        goes directly to Hetzner.
+      </p>
+      <p class="mt-4">
+        Cloudflare is not used for these hosts as a Reverse Proxy, CDN, WAF, or
+        HTTP analytics platform. Cloudflare therefore does not receive regular
+        page or download traffic.
+      </p>
+      <p class="mt-4">
+        Cloudflare may process technically necessary DNS query data as part of
+        DNS resolution. The purpose is reliable and secure domain availability.
+        The legal basis is Article 6(1)(f) GDPR; the legitimate interest is
+        stable and secure domain resolution.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        6. Public download resources
+      </h2>
+      <p class="mt-6">
+        apk.secpal.app may provide APK files, manifests, release metadata, and
+        checksums. A request requires the same transient technical connection
+        processing as a regular website request.
+      </p>
+      <p class="mt-4">
+        SecPal keeps no download logs or individual download counters. A request
+        does not provide secpal.app with information about the later
+        installation or use of the downloaded software.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        7. Local display preference
+      </h2>
+      <p class="mt-6">
+        If a person manually selects light or dark mode, the website stores the
+        value <code class="break-all">light</code> or{" "}
+        <code class="break-all">dark</code> under the key{" "}
+        <code class="break-all">theme</code> in the browser's local storage. Without
+        a manual selection, the display follows the operating-system preference.
+      </p>
+      <p class="mt-4">
+        The setting remains in the browser and is not transmitted to SecPal or
+        an external provider. It remains stored until it is changed or the
+        browser's local storage is cleared.
+      </p>
+      <p class="mt-4">
+        The storage is necessary to provide the display mode expressly selected
+        by the user. It is based on Section 25(2)(2) TDDDG and does not require
+        consent.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        8. No web analytics or visitor profiling
+      </h2>
+      <p class="mt-6">
+        SecPal does not use web analytics, marketing, or user-tracking services
+        on secpal.app or apk.secpal.app. No visitor profiles are created, and no
+        optional analytics or marketing cookies are set.
+      </p>
+      <p class="mt-4">
+        Because no optional tracking technologies are used, no consent banner
+        for these purposes is included.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        9. Contact by email
+      </h2>
+      <p class="mt-6">
+        Email communication is technically provided through Uberspace. Uberspace
+        is operated by Jonas Pasche in Mainz, Germany.
+      </p>
+      <p class="mt-4">
+        The data processed may include the sender address, name if provided,
+        subject, message content, time of communication, attachments, and
+        technically necessary email metadata. The sole purpose is to process the
+        request and conduct the communication required for it.
+      </p>
+      <p class="mt-4">
+        Article 6(1)(b) GDPR applies when a person requests pre-contractual
+        steps through their inquiry or when the communication concerns a
+        contract. In all other cases, Article 6(1)(f) GDPR applies. The
+        legitimate interest is processing incoming inquiries and security
+        reports.
+      </p>
+      <p class="mt-4">
+        SecPal deletes the message after the request has been finally processed.
+        It is not reused for marketing, newsletters, visitor analytics, or CRM
+        profiles. Mandatory statutory retention obligations remain unaffected.
+        Technically necessary processes in the email provider's backup,
+        delivery, or queue systems may differ.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        10. External links
+      </h2>
+      <p class="mt-6">
+        This website contains links to external services, especially GitHub.
+        Content from these providers is not embedded in secpal.app. Merely
+        visiting the website therefore does not establish a connection to
+        GitHub.
+      </p>
+      <p class="mt-4">
+        Only when a person selects an external link do they leave secpal.app and
+        the browser establishes a connection to the respective provider. The
+        respective provider is responsible for processing on the external
+        service.
+      </p>
+      <p class="mt-4">
+        For links to SecPal's presence on GitHub, SecPal suppresses transmission
+        of the previously visited page as the HTTP referrer.
+      </p>
+    </div>
+
+    <div>
+      <h2
+        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      >
+        11. Recipients and service providers
+      </h2>
       <ul
         role="list"
         class="mt-8 max-w-3xl space-y-6 text-gray-600 dark:text-gray-400"
       >
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Processed data:</strong
-            > depending on use, this may include account data, operations and organizational
-            data entered by users, technical device and app data, log data, version
-            and update information, and, for managed-device or Device Owner scenarios,
-            required provisioning or bootstrap information.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Hetzner Online GmbH:</strong
           >
+          {" "}
+          hosting and delivery of the website and download resources.
         </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Purpose:</strong
-            > app delivery, authentication, provision of app features, secure technical
-            delivery of installation and update information, error analysis, abuse
-            detection, and system security.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Cloudflare, Inc.:</strong
           >
+          {" "}
+          domain management and authoritative DNS services. Because the configuration
+          is DNS-only, Cloudflare does not receive regular HTTP or HTTPS traffic.
         </li>
-        <li class="flex gap-x-3">
-          <span
-            class="mt-1 size-2 flex-none rounded-full bg-indigo-600 dark:bg-indigo-400"
-          ></span>
-          <span
-            ><strong class="font-semibold text-gray-900 dark:text-white"
-              >Legal bases:</strong
-            > Art. 6(1)(b) GDPR for providing agreed app functionality and pre-contractual
-            or contractual services; Art. 6(1)(f) GDPR for secure operation, abuse
-            prevention, distribution integrity, and the stability of connected systems.</span
+        <li>
+          <strong class="font-semibold text-gray-900 dark:text-white"
+            >Uberspace, operated by Jonas Pasche:</strong
           >
+          {" "}
+          technical email communication.
         </li>
       </ul>
-      <p class="mt-8">
-        The same principles apply to closed and open beta phases. Beta versions
-        may additionally process technical diagnostic data and error context
-        where this is required to stabilize and securely provide the pre-release
-        version.
+      <p class="mt-6">
+        GitHub is not a recipient of personal data merely because a person
+        visits the website. A connection is only established when an external
+        GitHub link is selected.
       </p>
     </div>
 
@@ -166,23 +293,18 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        4. Google Play Store and third-party platforms
+        12. International transfers involving Cloudflare
       </h2>
       <p class="mt-6">
-        If the SecPal Android app is distributed through the Google Play Store
-        or other third-party platforms, those platforms may process personal
-        data in connection with listing, download, installation, licensing,
-        billing, update delivery, or abuse prevention.
+        Cloudflare is a provider based in the United States with global
+        infrastructure. Processing outside the European Economic Area cannot be
+        completely ruled out in connection with the DNS services.
       </p>
       <p class="mt-4">
-        Such processing is generally carried out under the responsibility of the
-        respective platform operator. For Google's processing, Google's own
-        privacy and terms documents also apply.
-      </p>
-      <p class="mt-4">
-        Where we organize beta or release programs through such platforms, we
-        only process the information required there for release management,
-        support, release communication, or security to the extent necessary.
+        The EU-US Data Privacy Framework may be used for transfers to the United
+        States for as long as the certification remains effective. In addition,
+        or for other relevant international transfers, Cloudflare provides for
+        Standard Contractual Clauses.
       </p>
     </div>
 
@@ -190,16 +312,16 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        5. Contact by email
+        13. Provision of data
       </h2>
       <p class="mt-6">
-        If you contact us by email, we process the information you send so we
-        can answer your request and document the related communication.
+        Processing connection data is technically necessary to deliver the
+        website or download resources. Without this processing, the requested
+        content cannot be transmitted.
       </p>
       <p class="mt-4">
-        The legal basis is Art. 6(1)(b) GDPR where your request relates to
-        pre-contractual steps or a specific inquiry, otherwise Art. 6(1)(f)
-        GDPR.
+        Contact by email is voluntary. Without a reachable sender address and
+        sufficient information, it may not be possible to answer an inquiry.
       </p>
     </div>
 
@@ -207,12 +329,19 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        6. No cookies and no tracking on this website
+        14. Storage periods
       </h2>
       <p class="mt-6">
-        This website currently does not use analytics, tracking, or marketing
-        cookies. There is also no consent banner for optional tracking at this
-        time.
+        SecPal does not store individual website or download requests in regular
+        web server logs. The theme setting remains solely in the browser until
+        it is changed or the browser's local storage is cleared.
+      </p>
+      <p class="mt-4">
+        Emails are deleted after final processing unless a statutory obligation
+        or a specific legal reason requires longer retention. The service
+        providers' respective operational and legal requirements apply to
+        technically necessary processing; SecPal does not state an unsupported
+        fixed period for such processing.
       </p>
     </div>
 
@@ -220,47 +349,35 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        7. Storage duration
+        15. Data subject rights
       </h2>
       <p class="mt-6">
-        Server log data is stored only for as long as necessary for technical
-        delivery, error analysis, and security monitoring.
+        Where the relevant statutory requirements are met, data subjects have
+        rights of access, rectification, erasure, restriction of processing, and
+        data portability. They also have a right to object to processing based
+        on Article 6(1)(f) GDPR.
       </p>
       <p class="mt-4">
-        Data from emails is deleted once the relevant request has been
-        completed, unless statutory retention obligations require otherwise.
+        Data subjects may also lodge a complaint with a data protection
+        supervisory authority. The competent authority includes:
       </p>
-      <p class="mt-4">
-        Data from use of the Android app or beta distribution is stored only as
-        long as necessary for the relevant feature, security monitoring,
-        support, error analysis, release management, or statutory retention
-        duties.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+      <div
+        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
       >
-        8. Data subject rights
-      </h2>
-      <p class="mt-6">
-        Under the GDPR, you may have rights of access, rectification, erasure,
-        restriction of processing, data portability, and objection to
-        processing.
-      </p>
+        <p class="font-semibold text-gray-900 dark:text-white">
+          The State Commissioner for Data Protection of Lower Saxony
+        </p>
+        <p class="mt-2">Prinzenstraße 5</p>
+        <p class="mt-2">30159 Hannover</p>
+        <p class="mt-2">Germany</p>
+      </div>
       <p class="mt-4">
-        You also have the right to lodge a complaint with a supervisory
-        authority.
-      </p>
-      <p class="mt-4">
-        If you use a SecPal account or want personal data associated with the
-        app to be deleted, you can contact us at{" "}
+        Requests concerning data subject rights may be sent to{" "}
         <a
           href="mailto:hello@secpal.app"
           class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
           >hello@secpal.app</a
-        >.
+        >{"."}
       </p>
     </div>
 
@@ -268,12 +385,11 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        9. Changes to this notice
+        16. Changes to this privacy notice
       </h2>
       <p class="mt-6">
-        We update this privacy notice whenever the website, the Android app, the
-        actual data processing activities, the beta or release processes, or the
-        legal requirements change.
+        SecPal updates this privacy notice when the website, download
+        infrastructure, service providers, or legal requirements change.
       </p>
     </div>
   </section>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -12,7 +12,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the domain and DNS infrastructure, and direct contact by email."
+  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
   updatedLabel="Last updated"
   updatedAt="July 24, 2026"
 >
@@ -102,9 +102,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         SecPal does not store individual IP addresses, user agents, or crawler
         information and does not use such requests to produce visitor, referrer,
         country, device, or download statistics. This does not affect the
-        transient technical processing during the connection. Infrastructure
-        operators may process technically necessary operational or security data
-        under their own responsibility.
+        transient technical processing during the connection. Independently of
+        the regular logging disabled by SecPal, the service providers may carry
+        out technically necessary operational and security processing under the
+        applicable contractual and legal frameworks.
       </p>
     </div>
 
@@ -112,10 +113,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <h2
         class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
       >
-        5. Domain management and DNS
+        5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Domain management and authoritative DNS services are provided through
+        Authoritative DNS services for secpal.app are provided through
         Cloudflare. The web DNS records are DNS-only and answer DNS queries with
         the actual Hetzner origin IP address. Regular HTTP and HTTPS traffic
         goes directly to Hetzner.
@@ -271,8 +272,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
             >Cloudflare, Inc.:</strong
           >
           {" "}
-          domain management and authoritative DNS services. Because the configuration
-          is DNS-only, Cloudflare does not receive regular HTTP or HTTPS traffic.
+          authoritative DNS services. Because the configuration is DNS-only, Cloudflare
+          does not receive regular HTTP or HTTPS traffic.
         </li>
         <li>
           <strong class="font-semibold text-gray-900 dark:text-white"

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -25,8 +25,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         This privacy notice applies to the public secpal.app website, download
-        resources provided through apk.secpal.app, and direct contact with
-        SecPal.
+        resources provided through apk.secpal.app, authoritative DNS services
+        provided through Cloudflare, and direct contact with SecPal.
       </p>
       <p class="mt-4">
         It does not describe the processing of personal data within an installed

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -102,6 +102,17 @@ test("localized privacy pages retain their shell metadata and aligned sections",
   assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
 });
 
+test("the formal scope includes authoritative DNS services", () => {
+  assert.match(
+    compactPages.de,
+    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*autoritativen DNS-Dienste[^<]*<\/p>/
+  );
+  assert.match(
+    compactPages.en,
+    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*authoritative DNS services[^<]*<\/p>/
+  );
+});
+
 test("section extraction rejects headings that contain markup", () => {
   const headingWithMarkup = "<h2>1. Scope <em>note</em></h2>";
 

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import test from "node:test";
+
+const readSource = (path) =>
+  readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+const pages = {
+  de: readSource("src/pages/de/privacy.astro"),
+  en: readSource("src/pages/en/privacy.astro"),
+};
+const compactPages = Object.fromEntries(
+  Object.entries(pages).map(([locale, source]) => [
+    locale,
+    source.replace(/\s+/g, " "),
+  ])
+);
+
+const expectedShellProps = {
+  de: [
+    'title="Datenschutz | SecPal"',
+    'description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
+    'canonicalPath="/de/privacy/"',
+    'currentPath="/privacy"',
+    'eyebrow="Rechtliches"',
+    'headline="Datenschutzerklärung"',
+    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, die Domain- und DNS-Infrastruktur sowie die direkte Kontaktaufnahme per E-Mail."',
+    'updatedLabel="Stand"',
+    'updatedAt="24. Juli 2026"',
+  ],
+  en: [
+    'title="Privacy Notice | SecPal"',
+    'description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."',
+    'canonicalPath="/en/privacy/"',
+    'currentPath="/privacy"',
+    'eyebrow="Legal"',
+    'headline="Privacy Notice"',
+    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the domain and DNS infrastructure, and direct contact by email."',
+    'updatedLabel="Last updated"',
+    'updatedAt="July 24, 2026"',
+  ],
+};
+
+const expectedSections = {
+  de: [
+    "Geltungsbereich",
+    "Verantwortlicher",
+    "Technische Bereitstellung und Hosting",
+    "Keine reguläre Zugriffsprotokollierung",
+    "Domainverwaltung und DNS",
+    "Öffentliche Downloadressourcen",
+    "Lokale Darstellungspräferenz",
+    "Keine Webanalyse oder Besucherprofilbildung",
+    "Kontaktaufnahme per E-Mail",
+    "Externe Links",
+    "Empfänger und Dienstleister",
+    "Drittlandübermittlung bei Cloudflare",
+    "Bereitstellung der Daten",
+    "Speicherdauer",
+    "Rechte betroffener Personen",
+    "Änderungen der Datenschutzerklärung",
+  ],
+  en: [
+    "Scope",
+    "Controller",
+    "Technical delivery and hosting",
+    "No regular access logging",
+    "Domain management and DNS",
+    "Public download resources",
+    "Local display preference",
+    "No web analytics or visitor profiling",
+    "Contact by email",
+    "External links",
+    "Recipients and service providers",
+    "International transfers involving Cloudflare",
+    "Provision of data",
+    "Storage periods",
+    "Data subject rights",
+    "Changes to this privacy notice",
+  ],
+};
+
+const extractSectionNames = (source) =>
+  [...source.matchAll(/<h2\b[^>]*>([\s\S]*?)<\/h2>/g)].map((match) =>
+    match[1]
+      .replace(/<[^>]+>/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .replace(/^\d+\.\s*/, "")
+  );
+
+test("localized privacy pages retain their shell metadata and aligned sections", () => {
+  for (const [locale, source] of Object.entries(pages)) {
+    assert.match(source, /import LegalPageShell from/);
+    for (const property of expectedShellProps[locale]) {
+      assert.ok(
+        source.includes(property),
+        `${locale} privacy page must retain ${property}`
+      );
+    }
+  }
+  assert.deepEqual(extractSectionNames(pages.de), expectedSections.de);
+  assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
+});
+
+test("the controller is identified with SecPal before Holger Schmermbeck", () => {
+  assert.match(
+    compactPages.de,
+    /<p class="mt-6">Verantwortlicher im Sinne der DSGVO ist:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
+  );
+  assert.match(
+    compactPages.en,
+    /<p class="mt-6">The controller within the meaning of the GDPR is:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
+  );
+
+  for (const source of Object.values(pages)) {
+    assert.match(source, /Enno-Arends-Str\. 4/);
+    assert.match(source, /26571 Juist/);
+    assert.match(source, /hello@secpal\.app/);
+    assert.doesNotMatch(
+      source,
+      /Datenschutzbeauftragter|Data Protection Officer/i
+    );
+  }
+});
+
+test("hosting, transient delivery, and disabled regular logging are precise", () => {
+  assert.match(compactPages.de, /Hetzner Online GmbH/);
+  assert.match(compactPages.en, /Hetzner Online GmbH/);
+  assert.match(compactPages.de, /flüchtig|Dauer der Verbindung/);
+  assert.match(compactPages.en, /transient|duration of the connection/);
+  assert.match(compactPages.de, /IP-Adresse/);
+  assert.match(compactPages.en, /IP address/);
+  assert.match(
+    compactPages.de,
+    /keine individuellen IP-Adressen, User-Agents oder Crawlerinformationen/
+  );
+  assert.match(
+    compactPages.en,
+    /does not store individual IP addresses, user agents, or crawler information/
+  );
+  assert.match(
+    compactPages.de,
+    /keine regulären Webserver-Zugriffs- oder Fehlerprotokolle/
+  );
+  assert.match(compactPages.en, /no regular web server access or error logs/);
+  assert.match(compactPages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
+  assert.match(compactPages.en, /Article 6\(1\)\(f\) GDPR/);
+  assert.doesNotMatch(compactPages.de, /keinerlei Daten verarbeitet/i);
+  assert.doesNotMatch(compactPages.en, /no data (?:is|are) processed/i);
+});
+
+test("Cloudflare is limited to authoritative DNS and transfer safeguards", () => {
+  for (const source of Object.values(compactPages)) {
+    assert.match(source, /Cloudflare/);
+    assert.match(source, /DNS-only/);
+    assert.match(source, /Hetzner/);
+    assert.match(source, /Reverse Proxy/i);
+    assert.match(source, /\bWAF\b/);
+    assert.match(source, /Data Privacy Framework/);
+    assert.match(
+      source,
+      /Standardvertragsklauseln|Standard Contractual Clauses/
+    );
+  }
+  assert.match(compactPages.de, /autoritative DNS-Dienste/);
+  assert.match(compactPages.en, /authoritative DNS services/);
+  assert.match(
+    compactPages.de,
+    /HTTP- und HTTPS-Verkehr[^.]*direkt[^.]*Hetzner/
+  );
+  assert.match(
+    compactPages.en,
+    /HTTP and HTTPS traffic[^.]*directly[^.]*Hetzner/
+  );
+});
+
+test("recipient labels preserve a visible space after the colon", () => {
+  const recipientLabels = {
+    de: [
+      "Hetzner Online GmbH:",
+      "Cloudflare, Inc.:",
+      "Uberspace, betrieben von Jonas Pasche:",
+    ],
+    en: [
+      "Hetzner Online GmbH:",
+      "Cloudflare, Inc.:",
+      "Uberspace, operated by Jonas Pasche:",
+    ],
+  };
+
+  for (const [locale, labels] of Object.entries(recipientLabels)) {
+    for (const label of labels) {
+      assert.ok(
+        compactPages[locale].includes(`${label}</strong > {" "}`),
+        `${locale} recipient label "${label}" must retain explicit spacing`
+      );
+    }
+  }
+});
+
+test("inline email links preserve surrounding spaces and punctuation", () => {
+  assert.match(
+    compactPages.de,
+    /Anfragen zu Betroffenenrechten können an\{" "\} <a[^>]*href="mailto:hello@secpal\.app"[^>]*>hello@secpal\.app<\/a\s*> \{" "\} gerichtet werden\./
+  );
+  assert.match(
+    compactPages.en,
+    /Requests concerning data subject rights may be sent to\{" "\} <a[^>]*href="mailto:hello@secpal\.app"[^>]*>hello@secpal\.app<\/a\s*>\{"\."\}/
+  );
+});
+
+test("email processing and deletion are documented for Uberspace", () => {
+  for (const source of Object.values(pages)) {
+    assert.match(source, /Uberspace/);
+    assert.match(source, /Jonas Pasche/);
+    assert.match(source, /hello@secpal\.app/);
+  }
+  assert.match(pages.de, /Nachrichteninhalt/);
+  assert.match(pages.en, /message content/);
+  assert.match(pages.de, /Anhänge/);
+  assert.match(pages.en, /attachments/);
+  assert.match(pages.de, /Art\. 6 Abs\. 1 lit\. b DSGVO/);
+  assert.match(pages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
+  assert.match(pages.en, /Article 6\(1\)\(b\) GDPR/);
+  assert.match(pages.en, /Article 6\(1\)\(f\) GDPR/);
+  assert.match(pages.de, /nach abschließender Bearbeitung/);
+  assert.match(
+    pages.en,
+    /after (?:the request has been finally processed|final processing)/
+  );
+});
+
+test("the local theme preference is the only documented browser storage", () => {
+  for (const source of Object.values(pages)) {
+    assert.match(source, /<code[^>]*>theme<\/code>/);
+    assert.match(source, /<code[^>]*>light<\/code>/);
+    assert.match(source, /<code[^>]*>dark<\/code>/);
+  }
+  assert.match(compactPages.de, /lokalen Speicher des Browsers/);
+  assert.match(compactPages.en, /browser's local storage/);
+  assert.match(compactPages.de, /§ 25 Abs\. 2 Nr\. 2 TDDDG/);
+  assert.match(compactPages.en, /Section 25\(2\)\(2\) TDDDG/);
+  assert.match(
+    compactPages.de,
+    /weder an SecPal noch an einen externen Anbieter übermittelt/
+  );
+  assert.match(
+    compactPages.en,
+    /not transmitted to SecPal or an external provider/
+  );
+});
+
+test("the pages exclude web analytics, tracking, and visitor profiles", () => {
+  assert.match(
+    compactPages.de,
+    /keine Webanalyse-, Marketing- oder Nutzertrackingdienste/
+  );
+  assert.match(
+    compactPages.en,
+    /does not use web analytics, marketing, or user-tracking services/
+  );
+  assert.match(compactPages.de, /keine Besucherprofile/);
+  assert.match(compactPages.en, /No visitor profiles/);
+  assert.match(
+    compactPages.de,
+    /keine optionalen Analyse- oder Marketing-Cookies/
+  );
+  assert.match(compactPages.en, /no optional analytics or marketing cookies/);
+});
+
+test("external GitHub navigation is click-only and suppresses the referrer", () => {
+  assert.match(compactPages.de, /externen Angeboten/);
+  assert.match(compactPages.en, /external services/);
+  assert.match(
+    compactPages.de,
+    /Inhalte dieser Anbieter werden nicht in secpal\.app eingebettet/
+  );
+  assert.match(
+    compactPages.en,
+    /Content from these providers is not embedded in secpal\.app/
+  );
+  assert.match(compactPages.de, /Erst beim Auswählen eines externen Links/);
+  assert.match(compactPages.en, /Only when a person selects an external link/);
+  assert.match(compactPages.de, /jeweilige Anbieter verantwortlich/);
+  assert.match(compactPages.en, /respective provider is responsible/);
+  assert.match(compactPages.de, /HTTP-Referrer/);
+  assert.match(compactPages.en, /HTTP referrer/);
+});
+
+test("every visible SecPal GitHub link suppresses the referrer", () => {
+  const sourceFiles = readdirSync(new URL("../src", import.meta.url), {
+    recursive: true,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".astro"))
+    .map(
+      (entry) => new URL(entry.name, new URL(`${entry.parentPath}/`, "file:"))
+    );
+  let linkCount = 0;
+
+  for (const path of sourceFiles) {
+    const source = readFileSync(path, "utf8");
+    const githubAnchors =
+      source.match(
+        /<a\b(?=[^>]*href="https:\/\/github\.com\/SecPal")[^>]*>/g
+      ) ?? [];
+
+    linkCount += githubAnchors.length;
+    for (const anchor of githubAnchors) {
+      assert.match(
+        anchor,
+        /\breferrerpolicy="no-referrer"/,
+        `${path.pathname} contains an unhardened GitHub link`
+      );
+      assert.doesNotMatch(anchor, /\btarget="_blank"/);
+    }
+  }
+
+  assert.equal(linkCount, 2);
+});
+
+test("superseded app and beta topics are absent from both privacy pages", () => {
+  const forbidden =
+    /\b(?:Beta|beta distribution|Google Play|Play Store|Device Owner|Managed Device|Provisioning|Bootstrap|Push|Benutzerkonto|user account|Beschäftigtendaten|employee data|SaaS|GoAccess|App-Daten löschen|delete app data)\b/i;
+
+  for (const [locale, source] of Object.entries(pages)) {
+    assert.doesNotMatch(
+      source,
+      forbidden,
+      `${locale} privacy page contains superseded product-internal content`
+    );
+  }
+});

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -27,7 +27,7 @@ const expectedShellProps = {
     'currentPath="/privacy"',
     'eyebrow="Rechtliches"',
     'headline="Datenschutzerklärung"',
-    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, die Domain- und DNS-Infrastruktur sowie die direkte Kontaktaufnahme per E-Mail."',
+    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
     'updatedLabel="Stand"',
     'updatedAt="24. Juli 2026"',
   ],
@@ -38,7 +38,7 @@ const expectedShellProps = {
     'currentPath="/privacy"',
     'eyebrow="Legal"',
     'headline="Privacy Notice"',
-    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the domain and DNS infrastructure, and direct contact by email."',
+    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
     'updatedLabel="Last updated"',
     'updatedAt="July 24, 2026"',
   ],
@@ -50,7 +50,7 @@ const expectedSections = {
     "Verantwortlicher",
     "Technische Bereitstellung und Hosting",
     "Keine reguläre Zugriffsprotokollierung",
-    "Domainverwaltung und DNS",
+    "Domain Name System (DNS)",
     "Öffentliche Downloadressourcen",
     "Lokale Darstellungspräferenz",
     "Keine Webanalyse oder Besucherprofilbildung",
@@ -68,7 +68,7 @@ const expectedSections = {
     "Controller",
     "Technical delivery and hosting",
     "No regular access logging",
-    "Domain management and DNS",
+    "Domain Name System (DNS)",
     "Public download resources",
     "Local display preference",
     "No web analytics or visitor profiling",
@@ -84,8 +84,8 @@ const expectedSections = {
 };
 
 const extractSectionNames = (source) =>
-  [...source.matchAll(/<h2\b[^>]*>\s*\d+\.\s*([^<]+?)\s*<\/h2>/g)].map(
-    (match) => match[1].replace(/\s+/g, " ").trim()
+  [...source.matchAll(/<h2\b[^>]*>\s*(?:\d+\.\s*)?([^<]+?)\s*<\/h2>/g)].map(
+    ([, heading]) => heading.replace(/\s+/g, " ").trim()
   );
 
 test("localized privacy pages retain their shell metadata and aligned sections", () => {
@@ -151,6 +151,16 @@ test("hosting, transient delivery, and disabled regular logging are precise", ()
   assert.match(compactPages.en, /no regular web server access or error logs/);
   assert.match(compactPages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
   assert.match(compactPages.en, /Article 6\(1\)\(f\) GDPR/);
+  assert.match(
+    compactPages.de,
+    /Unabhängig von der durch SecPal deaktivierten regulären Protokollierung/
+  );
+  assert.match(
+    compactPages.en,
+    /Independently of the regular logging disabled by SecPal/
+  );
+  assert.doesNotMatch(compactPages.de, /in eigener Verantwortung/);
+  assert.doesNotMatch(compactPages.en, /under their own responsibility/);
   assert.doesNotMatch(compactPages.de, /keinerlei Daten verarbeitet/i);
   assert.doesNotMatch(compactPages.en, /no data (?:is|are) processed/i);
 });
@@ -170,6 +180,8 @@ test("Cloudflare is limited to authoritative DNS and transfer safeguards", () =>
   }
   assert.match(compactPages.de, /autoritative DNS-Dienste/);
   assert.match(compactPages.en, /authoritative DNS services/);
+  assert.doesNotMatch(compactPages.de, /Domainverwaltung/);
+  assert.doesNotMatch(compactPages.en, /domain management/i);
   assert.match(
     compactPages.de,
     /HTTP- und HTTPS-Verkehr[^.]*direkt[^.]*Hetzner/

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -84,12 +84,8 @@ const expectedSections = {
 };
 
 const extractSectionNames = (source) =>
-  [...source.matchAll(/<h2\b[^>]*>([\s\S]*?)<\/h2>/g)].map((match) =>
-    match[1]
-      .replace(/<[^>]+>/g, "")
-      .replace(/\s+/g, " ")
-      .trim()
-      .replace(/^\d+\.\s*/, "")
+  [...source.matchAll(/<h2\b[^>]*>\s*\d+\.\s*([^<]+?)\s*<\/h2>/g)].map(
+    (match) => match[1].replace(/\s+/g, " ").trim()
   );
 
 test("localized privacy pages retain their shell metadata and aligned sections", () => {
@@ -104,6 +100,12 @@ test("localized privacy pages retain their shell metadata and aligned sections",
   }
   assert.deepEqual(extractSectionNames(pages.de), expectedSections.de);
   assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
+});
+
+test("section extraction rejects headings that contain markup", () => {
+  const headingWithMarkup = "<h2>1. Scope <em>note</em></h2>";
+
+  assert.deepEqual(extractSectionNames(headingWithMarkup), []);
 });
 
 test("the controller is identified with SecPal before Holger Schmermbeck", () => {


### PR DESCRIPTION
## Problem and evidence

The localized privacy notice had expanded beyond the confirmed scope of the public website. It described Android application, beta-distribution, and Google Play processing that does not belong in the privacy notice for `secpal.app` and `apk.secpal.app`. The confirmed infrastructure instead requires precise disclosure of transient connection processing, disabled regular SecPal web-server logging, Hetzner hosting, Cloudflare DNS-only operation, the local theme preference, and direct email handling through Uberspace. The visible links to the SecPal GitHub organization also did not explicitly suppress the referring SecPal page.

## Change

- replace the German and English privacy pages with aligned 16-section notices limited to the public website, download resources, DNS infrastructure, local display preference, external links, and direct email contact
- identify the controller using the existing SecPal and Holger Schmermbeck contact details while excluding processing inside installed or operated SecPal instances
- distinguish transient delivery processing from regular access logging and document the confirmed roles of Hetzner, Cloudflare, and Uberspace
- add `referrerpolicy="no-referrer"` to every visible `https://github.com/SecPal` link without changing link behavior or presentation
- add focused regression coverage for metadata, section parity, controller details, infrastructure disclosures, prohibited legacy topics, rendered inline spacing, and GitHub referrer hardening
- replace the contradictory Unreleased changelog entry

## Validation

- `npm test` — 67 tests passed
- `npm run format:check`
- `npm run lint`
- `npm run check` — 0 errors, 0 warnings, 0 hints
- `npm run build` — static privacy routes generated successfully
- `./scripts/preflight.sh` — passed, including REUSE, domain policy, signed-commit, lint, typecheck, and build checks
- `git diff --check`
- prohibited legacy-content and required infrastructure-term searches
- rendered HTML checks for email-link spacing and punctuation in both locales
- browser matrix for `/de/privacy/` and `/en/privacy/` at 320×568, 360×640, 412×915, 768×1024, and 1440×900 in light and dark modes; no horizontal overflow, clipping, console errors, or unexpected layout changes were found
- GitHub navigation request inspection confirmed that no SecPal `Referer` header is sent

## Draft readiness

No known in-scope content or implementation issue remains. This PR stays in draft until GitHub checks complete and the required final self-review in the PR view finds zero issues.

The synchronized bilingual legal text, its focused regression tests, and the associated referrer hardening form one reviewable privacy change but exceed the repository's 600-line limit. The repository's large-PR override is therefore required for this PR.