### PR TITLE
Remove retired development host

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, `dev.secpal.app` for this repo's live staging/development host, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,9 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- made the retired-domain regression scan tolerate tracked files deleted from
-  the working tree, so local validation no longer fails with an unrelated
-  missing-file error before deletions are staged
+- made retired-domain validation tolerate tracked files deleted from the
+  working tree and reject mixed-case hostnames, so local validation remains
+  usable during removals without allowing case-based policy bypasses
 - prevented long German roadmap and Android download labels from causing
   horizontal page overflow when the browser base font size is enlarged
 - aligned the mobile menu's visual and keyboard order and moved focus to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- made the retired-domain regression scan tolerate tracked files deleted from
+  the working tree, so local validation no longer fails with an unrelated
+  missing-file error before deletions are staged
 - prevented long German roadmap and Android download labels from causing
   horizontal page overflow when the browser base font size is enlarged
 - aligned the mobile menu's visual and keyboard order and moved focus to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refocused the localized homepage hero on clear, practice-led language for
   German security service providers, with one in-page action and a concise
   development status
+- retired the former live development host without replacement, removed its
+  build and deployment-check configuration, and made the public site the
+  default metadata origin
 - grouped GitHub Actions Dependabot updates under the stable `github-actions` identifier, so future workflow bump PRs use a predictable group-based title/branch instead of opaque reusable-workflow path slugs
 - refreshed the English and German roadmap copy so shift planning is the current focus, OWKS is the next milestone, and completed passkey, onboarding, and Android distribution work is no longer shown as in progress
 - replaced the stub `LICENSES/LicenseRef-TailwindPlus.txt` summary with the
@@ -95,14 +98,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added a repo-local `.preflight-exclude` baseline for generated lockfiles and license texts, so dependency bump PRs no longer fail the shared PR size check on `package-lock.json` churn alone
 - fixed mobile overflow and right-shift in `src/components/Hero.astro` so the hero headline, subline, and CTAs remain properly aligned on narrow viewports
 - upgraded `astro` to the first major release that officially carries patched `esbuild` support and kept the remaining npm audit remediations aligned through the lockfile plus targeted overrides (`brace-expansion`, `defu`), so the website toolchain findings no longer require out-of-range transitive overrides
-- neutral locale entry routes on `/` and `/android` now redirect German browser locales to `/de/...` and all other locales to `/en/...`, so `secpal.app` and `dev.secpal.app` no longer force the English Android page when the browser prefers German
+- neutral locale entry routes on `/` and `/android` now redirect German browser locales to `/de/...` and all other locales to `/en/...`, so `secpal.app` no longer forces the English Android page when the browser prefers German
 - added safe-area-aware body padding together with `viewport-fit=cover` and wrapping rules for Android machine-readable cards so text and content blocks no longer sit too close to the mobile screen edge or overflow on devices with asymmetric viewport insets
 
 ## [0.0.1] - 2026-03-31
 
 ### Changed
 
-- corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and the Android application identifier stays Android-only; explicitly documented `dev.secpal.app` as the live staging/development host for this repository (a subdomain of `secpal.app`)
+- corrected repo-local domain guidance and validation so `secpal.app` is described only as the public website and real-email domain, while `api.secpal.dev` and `app.secpal.dev` remain the active API/PWA hosts and the Android application identifier stays Android-only
 - Six occurrences of four hard-coded English accessibility strings in `Nav.astro` (`"Open main menu"`, `"Close menu"`, `"Toggle dark mode"`, `"Mobile navigation"`) are now locale-aware via translation keys so screen readers on `/de` no longer announce mixed-language labels
 - Feature card 2 description reworded in both `de.ts` and `en.ts` to break the identical sentence opening shared with card 1; the meaning is preserved while the three cards now read as clearly distinct items when scanned vertically
 - `.github/copilot-instructions.md` now requires a branch hygiene check before any write action so website work never starts on local `main` and dirty non-`main` branches must be assessed before continuing
@@ -133,7 +136,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The social preview build step now relies on a declared local `sharp` dependency instead of an implicit transitive install, so `npm run build` remains stable when upstream package trees change
 - Social preview badge backgrounds in the top label now use a conservative per-locale text-width estimate including letter spacing and tuned padding, so both the English and German badge copy stay fully inside the tinted pill without the English badge growing unnecessarily long
 - Social preview logo placement is now slightly smaller and lower inside the circular stage, so the shield sits more naturally within the round frame instead of touching the upper visual boundary
-- Default website builds from the live repository checkout now derive canonical and social preview origins from `https://dev.secpal.app`, so the dev host no longer emits production `canonical`, `og:url`, or preview image URLs unless `SECPAL_SITE_URL` explicitly targets production
+- Default website builds now derive canonical and social preview origins from
+  the configured site URL, so alternate builds do not emit production
+  `canonical`, `og:url`, or preview image URLs unless `SECPAL_SITE_URL`
+  explicitly targets production
 - Social preview assets are now regenerated from the canonical `logo-dark-512.png` brand asset for dark preview cards before every build, so the final OG/Twitter cards use the original SecPal logo instead of a manually reconstructed or wrong-contrast variant while still emitting absolute image URLs from the active build domain
 - `astro.config.mjs` now filters Astro's known false-positive `UNUSED_EXTERNAL_IMPORT` warning for `@astrojs/internal-helpers/remote`, and the site now tracks `astro@6.1.1`, so local builds finish without upstream warning noise
 - `package.json` now pins `typescript` to the `5.9.x` support range used by `@typescript-eslint`, and npm overrides now lift vulnerable transitive `brace-expansion`, `picomatch`, and `yaml` packages to patched releases so linting and `npm audit` both run cleanly
@@ -149,7 +155,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `package-lock.json` now resolves `flatted` to `3.4.2` and `h3` to `1.15.10`, removing the known npm audit findings without changing declared package ranges
-- Deployment checks and README guidance now point to the real live development host `dev.secpal.app` instead of the old `secpal.dev` assumption, while keeping server-side locale negotiation documented only for production
+- Deployment checks and README guidance now distinguish development behavior
+  from server-side locale negotiation, which remains documented only for
+  production
 - Shared links now emit complete Open Graph and Twitter Card metadata from the shared base layout, so localized pages consistently expose the correct title, description, locale, and `1200x630` preview image to messenger and social crawlers
 - The neutral `/` entry page now exposes the same preview metadata before redirecting to `/en/`, so root links still unfurl with the correct SecPal card when crawlers do not fully evaluate redirects
 - German landing and legal pages now point social preview metadata at a dedicated German Open Graph image instead of reusing the English preview card
@@ -162,7 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hero now presents `SecPal – A guard’s best friend` as a compact eyebrow tagline above the main positioning headline
 - Footer no longer claims "All rights reserved" on the public site, avoiding a misleading rights statement for the AGPL-published project
 - Landing page now leads with the SecPal product name, removes the duplicated hero view, and reframes the homepage as a focused coming-soon preview while the product is still under active construction
-- Alternate deployment builds now derive canonical and hreflang URLs from `SECPAL_SITE_URL` so `dev.secpal.app` no longer points metadata at production
+- Alternate deployment builds now derive canonical and hreflang URLs from
+  `SECPAL_SITE_URL` so their metadata does not point at production
 - Dark mode toggle: added `is:inline` to ensure the script runs after DOM is ready
 - Language switcher: `getLocalizedPath` now produces trailing-slash URLs (`/de/`, `/en/`) matching Astro's canonical page paths
 - Footer links and Nav language switcher now always produce canonical trailing-slash URLs for non-root paths (e.g. `/en/privacy/` instead of `/en/privacy`) — `getLocalizedPath` normalized to always append trailing slash for non-root routes, so no unnecessary redirects occur

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ This repository contains the public static site for [secpal.app](https://secpal.
 Use only the approved SecPal domains in content, configuration, and examples:
 
 - `secpal.app` for the public website and real email addresses
-- `dev.secpal.app` as the live staging/development host for this repository (subdomain of `secpal.app`)
 - `api.secpal.dev` for the API and `app.secpal.dev` for the PWA/frontend
 - `secpal.dev` for development, staging, testing, and examples
 - `app.secpal` only as the Android application identifier

--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ npm install
 npm run dev    # http://localhost:4321
 ```
 
-For alternate deployments you can override the generated site base URL at build time:
-
-```bash
-SECPAL_SITE_URL=https://dev.secpal.app npm run build
-```
+For controlled alternate deployments, set `SECPAL_SITE_URL` to the deployment
+origin before running the build.
 
 ### Available commands
 
@@ -68,9 +65,8 @@ Run the preflight script before every push:
 
 ## Stable release workflow
 
-`dev.secpal.app` can continue to use the live repository checkout. `secpal.app`
-is deployed separately from `/home/secpal/www/secpal.app/current`, so the public
-site is independent from the working tree on the VPS.
+`secpal.app` is deployed from `/home/secpal/www/secpal.app/current`, so the
+public site is independent from the working tree on the VPS.
 
 ### Promote a stable release
 
@@ -107,9 +103,9 @@ bash ./scripts/check-stable.sh
 
 The health-check helper verifies the `current` and `previous` release links,
 checks that the localized static files and `RELEASE.txt` exist, validates the
-Nginx configuration, and confirms that `secpal.app`, `www.secpal.app`, and the
-live development host `dev.secpal.app` behave as expected over HTTPS,
-including the language-based root redirect on `secpal.app`.
+Nginx configuration, and confirms that `secpal.app` and `www.secpal.app`
+behave as expected over HTTPS, including the language-based root redirect on
+`secpal.app`.
 
 If the shell session cannot read the live TLS material and also cannot use
 passwordless `sudo`, you can skip only the `nginx -t` step explicitly:
@@ -140,12 +136,6 @@ All user-facing strings live in `src/i18n/en.ts` and `src/i18n/de.ts`. Both file
 In production, the root route `/` is redirected at the web-server (Nginx)
 layer. `Accept-Language` requests preferring German resolve to `/de/`, while
 all other requests fall back to `/en/`.
-
-The live development host runs directly on `https://dev.secpal.app`. There, the
-localized pages are served under `/en/` and `/de/`, while the neutral entry
-routes under `/` and `/android` redirect browsers to the locale-specific pages
-based on the browser language and still expose the correct social preview
-metadata.
 
 ## License
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import { createLogger } from "vite";
 
-const siteUrl = process.env.SECPAL_SITE_URL ?? "https://dev.secpal.app";
+const siteUrl = process.env.SECPAL_SITE_URL ?? "https://secpal.app";
 const astroInternalHelpersWarning =
   '"matchHostname", "matchPathname", "matchPort" and "matchProtocol" are imported from external module "@astrojs/internal-helpers/remote" but never used in "node_modules/astro/dist/assets/utils/index.js"';
 const viteLogger = createLogger();

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,7 +16,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, www.secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev, dev.secpal.app"
+echo "Allowed: secpal.app, www.secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
 echo "Changelog site: changelog.secpal.app"
@@ -51,10 +51,10 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 
 # Allowlist approach: flag any secpal.* domain not matching an approved pattern.
 # Approved or temporarily tolerated here: secpal.app, www.secpal.app, secpal.dev (including
-# api/app subdomains), apk.secpal.app, dev.secpal.app, and deprecated-but-allowed api.secpal.app.
+# api/app subdomains), apk.secpal.app, and deprecated-but-allowed api.secpal.app.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])dev\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
     grep -E 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -108,7 +108,6 @@ else
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"
-    echo "  - dev.secpal.app: live staging/development host for this repository"
     echo "  - changelog.secpal.app: public changelog site"
     echo "  - app.secpal: Android application identifier only"
     echo "  - DEPRECATED as web hosts: api.secpal.app"

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -25,7 +25,7 @@ echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
 echo ""
 
-matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
+matches=$(grep -r -n -i -E "secpal\.[A-Za-z0-9][A-Za-z0-9.-]*" \
     --include="*.md" \
     --include="*.yaml" \
     --include="*.yml" \
@@ -54,11 +54,11 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api/app subdomains), apk.secpal.app, and deprecated-but-allowed api.secpal.app.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
-    grep -E 'secpal\.' || true)
+    grep -Evi '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
+    grep -Ei 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
-    grep -E 'api\.secpal\.app' | \
+    grep -Ei 'api\.secpal\.app' | \
     grep -v -- "appId" | \
     grep -v -- "applicationId" | \
     grep -v -- "package name" | \

--- a/scripts/check-stable.sh
+++ b/scripts/check-stable.sh
@@ -7,8 +7,6 @@ set -euo pipefail
 DEFAULT_DEPLOY_ROOT="/home/secpal/www/secpal.app"
 PRIMARY_URL="${SECPAL_PRIMARY_URL:-https://secpal.app}"
 PRIMARY_WWW_URL="${SECPAL_PRIMARY_WWW_URL:-https://www.secpal.app}"
-DEV_URL="${SECPAL_DEV_URL:-https://dev.secpal.app}"
-DEV_WWW_URL="${SECPAL_DEV_WWW_URL:-}"
 SKIP_NGINX_VALIDATION="${SECPAL_SKIP_NGINX_VALIDATION:-0}"
 NGINX_BIN="${NGINX_BIN:-$(command -v nginx 2>/dev/null || true)}"
 
@@ -32,8 +30,6 @@ Options:
 Environment overrides:
   SECPAL_PRIMARY_URL        Default: https://secpal.app
   SECPAL_PRIMARY_WWW_URL    Default: https://www.secpal.app
-  SECPAL_DEV_URL            Default: https://dev.secpal.app
-  SECPAL_DEV_WWW_URL        Optional dev alias to verify
     SECPAL_SKIP_NGINX_VALIDATION  Set to 1 to skip `nginx -t`
 
 Examples:
@@ -132,24 +128,6 @@ assert_http_ok() {
     log "Verified HTTP 200: $url"
 }
 
-assert_http_ok_on_host() {
-    local url="$1"
-    local expected_origin="$2"
-    local result status_code effective_url
-
-    result="$(curl --silent --show-error --connect-timeout 10 --max-time 30 \
-        --location --output /dev/null \
-        --write-out '%{http_code} %{url_effective}' "$url")" \
-        || fail "curl failed for $url: connection or timeout error"
-    status_code="${result%% *}"
-    effective_url="${result#* }"
-    [[ "$status_code" == "200" ]] || fail "Expected HTTP 200 for $url, got $status_code"
-    [[ "$effective_url" == "$expected_origin"* ]] \
-        || fail "Effective URL $effective_url is not under expected origin $expected_origin"
-
-    log "Verified HTTP 200: $url"
-}
-
 validate_nginx_config() {
     if [[ "$SKIP_NGINX_VALIDATION" == "1" ]]; then
         log "Skipping nginx validation because SECPAL_SKIP_NGINX_VALIDATION=1"
@@ -220,12 +198,5 @@ assert_locale_redirect "$PRIMARY_URL/" "en-US,en;q=0.9,de;q=0.8" "$PRIMARY_URL/e
 assert_http_ok "$PRIMARY_URL/en/"
 assert_http_ok "$PRIMARY_URL/de/"
 assert_redirect "$PRIMARY_WWW_URL/en/" "$PRIMARY_URL/en/"
-assert_http_ok_on_host "$DEV_URL/" "$DEV_URL"
-assert_http_ok_on_host "$DEV_URL/en/" "$DEV_URL"
-assert_http_ok_on_host "$DEV_URL/de/" "$DEV_URL"
-
-if [[ -n "$DEV_WWW_URL" ]]; then
-    assert_redirect "$DEV_WWW_URL/en/" "$DEV_URL/en/"
-fi
 
 log "Stable deployment health check passed"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,7 +26,7 @@ const {
   socialImagePath,
   socialImageAlt,
 } = Astro.props;
-const siteUrl = Astro.site ?? new URL("https://dev.secpal.app");
+const siteUrl = Astro.site ?? new URL("https://secpal.app");
 const canonicalUrl = canonicalPath
   ? new URL(canonicalPath, siteUrl).toString()
   : undefined;

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const repositoryRoot = new URL("../", import.meta.url);
+const retiredDomain = ["dev", "secpal", "app"].join(".");
+
+const repositoryFiles = execFileSync(
+  "git",
+  ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+  {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }
+)
+  .split("\0")
+  .filter(Boolean);
+
+test("the retired development domain is absent from the repository", () => {
+  const matchingFiles = repositoryFiles.filter((path) =>
+    readFileSync(new URL(path, repositoryRoot)).includes(retiredDomain)
+  );
+
+  assert.deepEqual(matchingFiles, []);
+});

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -3,27 +3,63 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 const repositoryRoot = new URL("../", import.meta.url);
 const retiredDomain = ["dev", "secpal", "app"].join(".");
 
-const repositoryFiles = execFileSync(
-  "git",
-  ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
-  {
-    cwd: repositoryRoot,
-    encoding: "utf8",
-  }
-)
-  .split("\0")
-  .filter(Boolean);
+function findMatchingFiles(root) {
+  const repositoryFiles = execFileSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+    {
+      cwd: root,
+      encoding: "utf8",
+    }
+  )
+    .split("\0")
+    .filter(Boolean);
+
+  return repositoryFiles.filter((path) => {
+    try {
+      return readFileSync(new URL(path, root)).includes(retiredDomain);
+    } catch (error) {
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return false;
+      }
+
+      throw error;
+    }
+  });
+}
 
 test("the retired development domain is absent from the repository", () => {
-  const matchingFiles = repositoryFiles.filter((path) =>
-    readFileSync(new URL(path, repositoryRoot)).includes(retiredDomain)
-  );
+  const matchingFiles = findMatchingFiles(repositoryRoot);
 
   assert.deepEqual(matchingFiles, []);
+});
+
+test("the repository scan ignores tracked files deleted from the worktree", (t) => {
+  const temporaryRepository = mkdtempSync(
+    join(tmpdir(), "secpal-retired-domain-")
+  );
+  t.after(() => rmSync(temporaryRepository, { recursive: true, force: true }));
+
+  execFileSync("git", ["init", "--quiet"], { cwd: temporaryRepository });
+  const deletedPath = join(temporaryRepository, "deleted.txt");
+  writeFileSync(deletedPath, "temporary test fixture");
+  execFileSync("git", ["add", "deleted.txt"], { cwd: temporaryRepository });
+  rmSync(deletedPath);
+
+  const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
+  assert.deepEqual(findMatchingFiles(temporaryRoot), []);
 });

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -26,7 +26,9 @@ function findMatchingFiles(root) {
 
   return repositoryFiles.filter((path) => {
     try {
-      return readFileSync(new URL(path, root)).includes(retiredDomain);
+      return readFileSync(new URL(path, root), "utf8")
+        .toLowerCase()
+        .includes(retiredDomain);
     } catch (error) {
       if (
         error &&
@@ -62,4 +64,20 @@ test("the repository scan ignores tracked files deleted from the worktree", (t) 
 
   const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
   assert.deepEqual(findMatchingFiles(temporaryRoot), []);
+});
+
+test("the repository scan rejects mixed-case retired domains", (t) => {
+  const temporaryRepository = mkdtempSync(
+    join(tmpdir(), "secpal-retired-domain-")
+  );
+  t.after(() => rmSync(temporaryRepository, { recursive: true, force: true }));
+
+  execFileSync("git", ["init", "--quiet"], { cwd: temporaryRepository });
+  writeFileSync(
+    join(temporaryRepository, "mixed-case.txt"),
+    ["DEV", "SECPAL", "APP"].join(".")
+  );
+
+  const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
+  assert.deepEqual(findMatchingFiles(temporaryRoot), ["mixed-case.txt"]);
 });


### PR DESCRIPTION
## Summary

- retire the former live development host without replacement
- use the public website as the default canonical and social-metadata origin
- remove host-specific domain-policy, documentation, and deployment-check paths
- prevent the retired hostname from reappearing in repository files

## Validation

- `npm test`
- `npm run format:check`
- `npm run lint`
- `npm run check`
- `npm run build`
- `shellcheck scripts/check-domains.sh scripts/check-stable.sh`
- `reuse lint`
- `./scripts/preflight.sh`
- `git diff --check`

Closes #240
