### PR TITLE
docs(privacy): cover changelog host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- extended the localized privacy notice to cover changelog.secpal.app under the
+  same confirmed Hetzner hosting, Cloudflare DNS-only, disabled logging,
+  local-theme, and no-tracking conditions as the other public SecPal hosts
 - refined the public Android page with a content-sized desktop hero, calmer
   mobile signing-fingerprint typography, and a cooler early-release notice
 - made direct SecPal downloads the primary public Android distribution path,

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -7,14 +7,14 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Datenschutz | SecPal"
-  description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
+  description="Datenschutzhinweise für secpal.app, changelog.secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
+  intro="Diese Datenschutzerklärung betrifft die öffentlichen Websites secpal.app und changelog.secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
   updatedLabel="Stand"
-  updatedAt="24. Juli 2026"
+  updatedAt="25. Juli 2026"
 >
   <section class="space-y-8">
     <div>
@@ -24,10 +24,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         1. Geltungsbereich
       </h2>
       <p class="mt-6">
-        Diese Datenschutzerklärung gilt für die öffentliche Website secpal.app,
-        die über apk.secpal.app bereitgestellten Downloadressourcen, die über
-        Cloudflare bereitgestellten autoritativen DNS-Dienste sowie die direkte
-        Kontaktaufnahme mit SecPal.
+        Diese Datenschutzerklärung gilt für die öffentlichen Websites secpal.app
+        und changelog.secpal.app, die über apk.secpal.app bereitgestellten
+        Downloadressourcen, die über Cloudflare bereitgestellten autoritativen
+        DNS-Dienste sowie die direkte Kontaktaufnahme mit SecPal.
       </p>
       <p class="mt-4">
         Sie beschreibt nicht die Verarbeitung personenbezogener Daten innerhalb
@@ -79,8 +79,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <p class="mt-4">
         Diese Daten werden für die Dauer der Verbindung flüchtig verarbeitet,
         damit die angeforderte Website oder Datei übertragen werden kann. Das
-        Hosting von secpal.app und apk.secpal.app erfolgt über die Hetzner
-        Online GmbH.
+        Hosting von secpal.app, changelog.secpal.app und apk.secpal.app erfolgt
+        über die Hetzner Online GmbH.
       </p>
       <p class="mt-4">
         Zwecke der Verarbeitung sind die Auslieferung der angeforderten Inhalte,
@@ -98,9 +98,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         4. Keine reguläre Zugriffsprotokollierung
       </h2>
       <p class="mt-6">
-        SecPal führt für secpal.app und apk.secpal.app keine regulären
-        Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne Seiten- und
-        Downloadabrufe werden von SecPal nicht dauerhaft protokolliert.
+        SecPal führt für secpal.app, changelog.secpal.app und apk.secpal.app
+        keine regulären Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne
+        Seiten- und Downloadabrufe werden von SecPal nicht dauerhaft
+        protokolliert.
       </p>
       <p class="mt-4">
         SecPal speichert dabei keine individuellen IP-Adressen, User-Agents oder
@@ -121,10 +122,11 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Die autoritativen DNS-Dienste für secpal.app werden über Cloudflare
-        bereitgestellt. Die Web-DNS-Einträge sind DNS-only und beantworten
-        DNS-Abfragen mit der tatsächlichen Hetzner-Origin-IP. Der reguläre HTTP-
-        und HTTPS-Verkehr läuft direkt zu Hetzner.
+        Die autoritativen DNS-Dienste für secpal.app, changelog.secpal.app und
+        apk.secpal.app werden über Cloudflare bereitgestellt. Die Web-DNS-
+        Einträge sind DNS-only und beantworten DNS-Abfragen mit der
+        tatsächlichen Hetzner-Origin-IP. Der reguläre HTTP- und HTTPS-Verkehr
+        dieser Hosts läuft direkt zu Hetzner.
       </p>
       <p class="mt-4">
         Cloudflare wird für diese Hosts nicht als Reverse Proxy, CDN, WAF oder
@@ -165,8 +167,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         7. Lokale Darstellungspräferenz
       </h2>
       <p class="mt-6">
-        Wenn eine Person den Hell- oder Dunkelmodus manuell auswählt, speichert
-        die Website den Wert{" "}
+        Auf secpal.app und changelog.secpal.app kann eine Person den Hell- oder
+        Dunkelmodus manuell auswählen. Die jeweilige Website speichert den Wert{
+          " "
+        }
         <code class="break-all">light</code> oder{" "}
         <code class="break-all">dark</code> unter dem Schlüssel{" "}
         <code class="break-all">theme</code> im lokalen Speicher des Browsers. Ohne
@@ -192,9 +196,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         8. Keine Webanalyse oder Besucherprofilbildung
       </h2>
       <p class="mt-6">
-        SecPal setzt auf secpal.app und apk.secpal.app keine Webanalyse-,
-        Marketing- oder Nutzertrackingdienste ein. Es werden keine
-        Besucherprofile erstellt und keine optionalen Analyse- oder
+        SecPal setzt auf secpal.app, changelog.secpal.app und apk.secpal.app
+        keine Webanalyse-, Marketing- oder Nutzertrackingdienste ein. Es werden
+        keine Besucherprofile erstellt und keine optionalen Analyse- oder
         Marketing-Cookies gesetzt.
       </p>
       <p class="mt-4">
@@ -243,16 +247,16 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         10. Externe Links
       </h2>
       <p class="mt-6">
-        Diese Website enthält Links zu externen Angeboten, insbesondere zu
-        GitHub. Inhalte dieser Anbieter werden nicht in secpal.app eingebettet.
-        Beim bloßen Aufruf der Website wird daher keine Verbindung zu GitHub
-        hergestellt.
+        Die erfassten Websites enthalten Links zu externen Angeboten,
+        insbesondere zu GitHub. Inhalte dieser Anbieter werden nicht
+        eingebettet. Beim bloßen Aufruf einer erfassten Website wird daher keine
+        Verbindung zu GitHub hergestellt.
       </p>
       <p class="mt-4">
-        Erst beim Auswählen eines externen Links verlässt die Person secpal.app,
-        und der Browser stellt eine Verbindung zum jeweiligen Anbieter her. Für
-        die Verarbeitung auf dem externen Angebot ist der jeweilige Anbieter
-        verantwortlich.
+        Erst beim Auswählen eines externen Links verlässt die Person die
+        jeweilige Website, und der Browser stellt eine Verbindung zum jeweiligen
+        Anbieter her. Für die Verarbeitung auf dem externen Angebot ist der
+        jeweilige Anbieter verantwortlich.
       </p>
       <p class="mt-4">
         Bei Links zum SecPal-Auftritt auf GitHub unterdrückt SecPal die
@@ -275,7 +279,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
             >Hetzner Online GmbH:</strong
           >
           {" "}
-          Hosting und Auslieferung der Website und der Downloadressourcen.
+          Hosting und Auslieferung der öffentlichen Websites und der Downloadressourcen.
         </li>
         <li>
           <strong class="font-semibold text-gray-900 dark:text-white"
@@ -345,9 +349,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         14. Speicherdauer
       </h2>
       <p class="mt-6">
-        SecPal speichert keine individuellen Website- oder Downloadzugriffe in
-        regulären Webserverlogs. Die Theme-Einstellung bleibt ausschließlich im
-        Browser, bis sie geändert oder der lokale Browserspeicher gelöscht wird.
+        SecPal speichert keine individuellen Website- oder Downloadzugriffe für
+        secpal.app, changelog.secpal.app oder apk.secpal.app in regulären
+        Webserverlogs. Die Theme-Einstellung bleibt ausschließlich im Browser,
+        bis sie geändert oder der lokale Browserspeicher gelöscht wird.
       </p>
       <p class="mt-4">
         E-Mails werden nach abschließender Bearbeitung gelöscht, sofern keine

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -7,14 +7,14 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Privacy Notice | SecPal"
-  description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."
+  description="Privacy notice for secpal.app, changelog.secpal.app, apk.secpal.app, and direct contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
+  intro="This privacy notice concerns the public secpal.app and changelog.secpal.app websites, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
   updatedLabel="Last updated"
-  updatedAt="July 24, 2026"
+  updatedAt="July 25, 2026"
 >
   <section class="space-y-8">
     <div>
@@ -24,9 +24,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         1. Scope
       </h2>
       <p class="mt-6">
-        This privacy notice applies to the public secpal.app website, download
-        resources provided through apk.secpal.app, authoritative DNS services
-        provided through Cloudflare, and direct contact with SecPal.
+        This privacy notice applies to the public secpal.app and
+        changelog.secpal.app websites, download resources provided through
+        apk.secpal.app, authoritative DNS services provided through Cloudflare,
+        and direct contact with SecPal.
       </p>
       <p class="mt-4">
         It does not describe the processing of personal data within an installed
@@ -76,8 +77,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </p>
       <p class="mt-4">
         This data is processed transiently for the duration of the connection so
-        that the requested website or file can be transmitted. secpal.app and
-        apk.secpal.app are hosted through Hetzner Online GmbH.
+        that the requested website or file can be transmitted. secpal.app,
+        changelog.secpal.app, and apk.secpal.app are hosted through Hetzner
+        Online GmbH.
       </p>
       <p class="mt-4">
         The purposes are to deliver the requested content, provide stable and
@@ -94,9 +96,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         4. No regular access logging
       </h2>
       <p class="mt-6">
-        SecPal keeps no regular web server access or error logs for secpal.app
-        and apk.secpal.app. Individual page and download requests are not
-        permanently logged by SecPal.
+        SecPal keeps no regular web server access or error logs for secpal.app,
+        changelog.secpal.app, and apk.secpal.app. Individual page and download
+        requests are not permanently logged by SecPal.
       </p>
       <p class="mt-4">
         SecPal does not store individual IP addresses, user agents, or crawler
@@ -116,10 +118,11 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Authoritative DNS services for secpal.app are provided through
-        Cloudflare. The web DNS records are DNS-only and answer DNS queries with
-        the actual Hetzner origin IP address. Regular HTTP and HTTPS traffic
-        goes directly to Hetzner.
+        Authoritative DNS services for secpal.app, changelog.secpal.app, and
+        apk.secpal.app are provided through Cloudflare. The web DNS records are
+        DNS-only and answer DNS queries with the actual Hetzner origin IP
+        address. Regular HTTP and HTTPS traffic for these hosts goes directly to
+        Hetzner.
       </p>
       <p class="mt-4">
         Cloudflare is not used for these hosts as a Reverse Proxy, CDN, WAF, or
@@ -159,8 +162,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         7. Local display preference
       </h2>
       <p class="mt-6">
-        If a person manually selects light or dark mode, the website stores the
-        value <code class="break-all">light</code> or{" "}
+        On secpal.app and changelog.secpal.app, a person can manually select
+        light or dark mode. The respective website stores the value <code
+          class="break-all">light</code
+        > or{" "}
         <code class="break-all">dark</code> under the key{" "}
         <code class="break-all">theme</code> in the browser's local storage. Without
         a manual selection, the display follows the operating-system preference.
@@ -185,8 +190,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         SecPal does not use web analytics, marketing, or user-tracking services
-        on secpal.app or apk.secpal.app. No visitor profiles are created, and no
-        optional analytics or marketing cookies are set.
+        on secpal.app, changelog.secpal.app, or apk.secpal.app. No visitor
+        profiles are created, and no optional analytics or marketing cookies are
+        set.
       </p>
       <p class="mt-4">
         Because no optional tracking technologies are used, no consent banner
@@ -233,16 +239,15 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         10. External links
       </h2>
       <p class="mt-6">
-        This website contains links to external services, especially GitHub.
-        Content from these providers is not embedded in secpal.app. Merely
-        visiting the website therefore does not establish a connection to
-        GitHub.
+        The covered websites contain links to external services, especially
+        GitHub. Content from these providers is not embedded. Merely visiting a
+        covered website therefore does not establish a connection to GitHub.
       </p>
       <p class="mt-4">
-        Only when a person selects an external link do they leave secpal.app and
-        the browser establishes a connection to the respective provider. The
-        respective provider is responsible for processing on the external
-        service.
+        Only when a person selects an external link do they leave the respective
+        website and the browser establishes a connection to the respective
+        provider. The respective provider is responsible for processing on the
+        external service.
       </p>
       <p class="mt-4">
         For links to SecPal's presence on GitHub, SecPal suppresses transmission
@@ -265,7 +270,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
             >Hetzner Online GmbH:</strong
           >
           {" "}
-          hosting and delivery of the website and download resources.
+          hosting and delivery of the public websites and download resources.
         </li>
         <li>
           <strong class="font-semibold text-gray-900 dark:text-white"
@@ -333,9 +338,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         14. Storage periods
       </h2>
       <p class="mt-6">
-        SecPal does not store individual website or download requests in regular
-        web server logs. The theme setting remains solely in the browser until
-        it is changed or the browser's local storage is cleared.
+        SecPal does not store individual website or download requests for
+        secpal.app, changelog.secpal.app, or apk.secpal.app in regular web
+        server logs. The theme setting remains solely in the browser until it is
+        changed or the browser's local storage is cleared.
       </p>
       <p class="mt-4">
         Emails are deleted after final processing unless a statutory obligation

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -103,18 +103,13 @@ test("localized privacy pages retain their shell metadata and aligned sections",
 });
 
 test("the formal scope covers all public hosts and authoritative DNS services", () => {
-  for (const source of Object.values(pages)) {
-    assert.match(source, /secpal\.app/);
-    assert.match(source, /changelog\.secpal\.app/);
-    assert.match(source, /apk\.secpal\.app/);
-  }
   assert.match(
     compactPages.de,
-    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*autoritativen DNS-Dienste[^<]*<\/p>/
+    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*changelog\.secpal\.app[^<]*apk\.secpal\.app[^<]*autoritativen DNS-Dienste[^<]*<\/p>/
   );
   assert.match(
     compactPages.en,
-    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*authoritative DNS services[^<]*<\/p>/
+    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*changelog\.secpal\.app[^<]*apk\.secpal\.app[^<]*authoritative DNS services[^<]*<\/p>/
   );
 });
 

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -22,25 +22,25 @@ const compactPages = Object.fromEntries(
 const expectedShellProps = {
   de: [
     'title="Datenschutz | SecPal"',
-    'description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
+    'description="Datenschutzhinweise für secpal.app, changelog.secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
     'canonicalPath="/de/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Rechtliches"',
     'headline="Datenschutzerklärung"',
-    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
+    'intro="Diese Datenschutzerklärung betrifft die öffentlichen Websites secpal.app und changelog.secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
     'updatedLabel="Stand"',
-    'updatedAt="24. Juli 2026"',
+    'updatedAt="25. Juli 2026"',
   ],
   en: [
     'title="Privacy Notice | SecPal"',
-    'description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."',
+    'description="Privacy notice for secpal.app, changelog.secpal.app, apk.secpal.app, and direct contact with SecPal."',
     'canonicalPath="/en/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Legal"',
     'headline="Privacy Notice"',
-    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
+    'intro="This privacy notice concerns the public secpal.app and changelog.secpal.app websites, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
     'updatedLabel="Last updated"',
-    'updatedAt="July 24, 2026"',
+    'updatedAt="July 25, 2026"',
   ],
 };
 
@@ -102,7 +102,12 @@ test("localized privacy pages retain their shell metadata and aligned sections",
   assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
 });
 
-test("the formal scope includes authoritative DNS services", () => {
+test("the formal scope covers all public hosts and authoritative DNS services", () => {
+  for (const source of Object.values(pages)) {
+    assert.match(source, /secpal\.app/);
+    assert.match(source, /changelog\.secpal\.app/);
+    assert.match(source, /apk\.secpal\.app/);
+  }
   assert.match(
     compactPages.de,
     /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*autoritativen DNS-Dienste[^<]*<\/p>/
@@ -141,8 +146,14 @@ test("the controller is identified with SecPal before Holger Schmermbeck", () =>
 });
 
 test("hosting, transient delivery, and disabled regular logging are precise", () => {
-  assert.match(compactPages.de, /Hetzner Online GmbH/);
-  assert.match(compactPages.en, /Hetzner Online GmbH/);
+  assert.match(
+    compactPages.de,
+    /Hosting von secpal\.app, changelog\.secpal\.app und apk\.secpal\.app erfolgt über die Hetzner Online GmbH/
+  );
+  assert.match(
+    compactPages.en,
+    /secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app are hosted through Hetzner Online GmbH/
+  );
   assert.match(compactPages.de, /flüchtig|Dauer der Verbindung/);
   assert.match(compactPages.en, /transient|duration of the connection/);
   assert.match(compactPages.de, /IP-Adresse/);
@@ -160,6 +171,14 @@ test("hosting, transient delivery, and disabled regular logging are precise", ()
     /keine regulären Webserver-Zugriffs- oder Fehlerprotokolle/
   );
   assert.match(compactPages.en, /no regular web server access or error logs/);
+  assert.match(
+    compactPages.de,
+    /für secpal\.app, changelog\.secpal\.app und apk\.secpal\.app keine regulären/
+  );
+  assert.match(
+    compactPages.en,
+    /for secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app/
+  );
   assert.match(compactPages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
   assert.match(compactPages.en, /Article 6\(1\)\(f\) GDPR/);
   assert.match(
@@ -181,6 +200,7 @@ test("Cloudflare is limited to authoritative DNS and transfer safeguards", () =>
     assert.match(source, /Cloudflare/);
     assert.match(source, /DNS-only/);
     assert.match(source, /Hetzner/);
+    assert.match(source, /changelog\.secpal\.app/);
     assert.match(source, /Reverse Proxy/i);
     assert.match(source, /\bWAF\b/);
     assert.match(source, /Data Privacy Framework/);
@@ -260,13 +280,15 @@ test("email processing and deletion are documented for Uberspace", () => {
 });
 
 test("the local theme preference is the only documented browser storage", () => {
-  for (const source of Object.values(pages)) {
-    assert.match(source, /<code[^>]*>theme<\/code>/);
-    assert.match(source, /<code[^>]*>light<\/code>/);
-    assert.match(source, /<code[^>]*>dark<\/code>/);
+  for (const source of Object.values(compactPages)) {
+    assert.match(source, /<code[^>]*>theme<\/code\s*>/);
+    assert.match(source, /<code[^>]*>light<\/code\s*>/);
+    assert.match(source, /<code[^>]*>dark<\/code\s*>/);
   }
   assert.match(compactPages.de, /lokalen Speicher des Browsers/);
   assert.match(compactPages.en, /browser's local storage/);
+  assert.match(compactPages.de, /secpal\.app und changelog\.secpal\.app/);
+  assert.match(compactPages.en, /secpal\.app and changelog\.secpal\.app/);
   assert.match(compactPages.de, /§ 25 Abs\. 2 Nr\. 2 TDDDG/);
   assert.match(compactPages.en, /Section 25\(2\)\(2\) TDDDG/);
   assert.match(
@@ -295,6 +317,12 @@ test("the pages exclude web analytics, tracking, and visitor profiles", () => {
     /keine optionalen Analyse- oder Marketing-Cookies/
   );
   assert.match(compactPages.en, /no optional analytics or marketing cookies/);
+  for (const source of Object.values(compactPages)) {
+    assert.match(
+      source,
+      /secpal\.app, changelog\.secpal\.app und apk\.secpal\.app|secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app/
+    );
+  }
 });
 
 test("external GitHub navigation is click-only and suppresses the referrer", () => {
@@ -302,12 +330,9 @@ test("external GitHub navigation is click-only and suppresses the referrer", () 
   assert.match(compactPages.en, /external services/);
   assert.match(
     compactPages.de,
-    /Inhalte dieser Anbieter werden nicht in secpal\.app eingebettet/
+    /Inhalte dieser Anbieter werden nicht eingebettet/
   );
-  assert.match(
-    compactPages.en,
-    /Content from these providers is not embedded in secpal\.app/
-  );
+  assert.match(compactPages.en, /Content from these providers is not embedded/);
   assert.match(compactPages.de, /Erst beim Auswählen eines externen Links/);
   assert.match(compactPages.en, /Only when a person selects an external link/);
   assert.match(compactPages.de, /jeweilige Anbieter verantwortlich/);


### PR DESCRIPTION
## Problem and evidence

The localized privacy notices named `secpal.app` and `apk.secpal.app`, but did
not explicitly cover the public `changelog.secpal.app` host. As a result, the
scope, Hetzner hosting, DNS-only Cloudflare use, logging, local theme storage,
and no-tracking statements did not consistently describe all public SecPal
hosts.

## Change

- add `changelog.secpal.app` to the German and English metadata, introductions,
  scope, hosting, access-logging, DNS, storage, and no-tracking statements
- limit the local `theme` preference disclosure to `secpal.app` and
  `changelog.secpal.app`; keep download resources exclusive to `apk.secpal.app`
- retain the controller wording and section order, and make external-link
  wording apply to the covered websites
- extend privacy-page regression coverage for host scope, Hetzner hosting,
  disabled access/error logging, DNS-only delivery, local theme storage, and
  no-tracking assertions

## Validation run

- `npm test` (72 tests passed)
- `npm run format:check`
- `npm run lint`
- `npm run check` (0 errors, 0 warnings, 0 hints)
- `npm run build`
- `./scripts/preflight.sh` (including REUSE and domain-policy checks)
- `git diff --check`
- requested host-coverage, prohibited DNS-term, and retired-content scans

## Readiness

The pull request remains a draft because the requested manual browser review at
the specified viewport sizes in light and dark mode has not been performed in
this environment: no Chromium or Chrome executable is available. The static
build includes both privacy routes and the generated output was checked.
