### PR TITLE
fix(site): remove retired changelog host

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Node dependencies with `npm ci` where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added a public roadmap page at `/roadmap/`, localized as `/en/roadmap/` and `/de/roadmap/`
 - documented current roadmap focus (shift planning), the next planned step (online guard tour system), and longer-term direction (contract management and service instruction configurator)
 - added a Node regression test that keeps the English and German roadmap copy aligned with the current shift-planning focus and the next OWKS milestone
-- linked the roadmap page to the full changelog at `changelog.secpal.app`
 - added roadmap navigation link to desktop and mobile menus, and roadmap paths to the sitemap
 - added the public Android distribution surface on `secpal.app/android`, including localized human-facing landing pages, stable machine-readable latest and versioned release JSON endpoints, navigation/sitemap discovery, and explicit `apk.secpal.app` host documentation for the single-package Android rollout architecture
 - added a concrete Android release metadata template endpoint at `apk.secpal.app/android/releases/{versionCode}/metadata.json` plus shared versioned metadata helpers, so release automation and documentation can reference one stable machine-readable contract before APK hosting is wired up
@@ -32,9 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- extended the localized privacy notice to cover changelog.secpal.app under the
-  same confirmed Hetzner hosting, Cloudflare DNS-only, disabled logging,
-  local-theme, and no-tracking conditions as the other public SecPal hosts
+- removed retired standalone changelog links, privacy scope, domain-policy
+  allowance, and active documentation before release
 - refined the public Android page with a content-sized desktop hero, calmer
   mobile signing-fingerprint typography, and a cooler early-release notice
 - made direct SecPal downloads the primary public Android distribution path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - removed retired standalone changelog links, privacy scope, domain-policy
-  allowance, and active documentation before release
+  allowance, and active documentation before release, and hardened the domain
+  check against mixed allowed, forbidden, and retired host references
 - refined the public Android page with a content-sized desktop hero, calmer
   mobile signing-fingerprint typography, and a cooler early-release notice
 - made direct SecPal downloads the primary public Android distribution path,

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,10 +16,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, www.secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, www.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
-echo "Changelog site: changelog.secpal.app"
 echo "Identifier-only: app.secpal (Android application ID)"
 echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
@@ -54,7 +53,7 @@ matches=$(grep -r -n -i -E "secpal\.[A-Za-z0-9][A-Za-z0-9.-]*" \
 # api/app subdomains), apk.secpal.app, and deprecated-but-allowed api.secpal.app.
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Evi '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
+    grep -Evi '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
     grep -Ei 'secpal\.' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
@@ -108,7 +107,6 @@ else
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"
     echo "  - secpal.dev: development, staging, testing, examples"
-    echo "  - changelog.secpal.app: public changelog site"
     echo "  - app.secpal: Android application identifier only"
     echo "  - DEPRECATED as web hosts: api.secpal.app"
     echo "  - FORBIDDEN: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example"

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -48,13 +48,21 @@ matches=$(grep -r -n -i -E "secpal\.[A-Za-z0-9][A-Za-z0-9.-]*" \
     grep -v -- '- "secpal\.' | \
     grep -v -- '^[[:space:]]*- \[' || true)
 
-# Allowlist approach: flag any secpal.* domain not matching an approved pattern.
-# Approved or temporarily tolerated here: secpal.app, www.secpal.app, secpal.dev (including
-# api/app subdomains), apk.secpal.app, and deprecated-but-allowed api.secpal.app.
-# This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
-violations=$(printf '%s\n' "$matches" | \
-    grep -Evi '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])secpal\.app\.git($|[^A-Za-z0-9._-]|\.$)|(^|[^A-Za-z0-9.-])www\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' |
-    grep -Ei 'secpal\.' || true)
+# Extract each SecPal domain separately so an allowed host cannot hide a
+# forbidden host elsewhere on the same line.
+domains=$(printf '%s\n' "$matches" | \
+    grep -Eio '([*A-Za-z0-9-]+\.)*secpal\.[A-Za-z0-9][A-Za-z0-9.-]*' || true)
+
+# Allowlist approach: flag any extracted domain not matching an approved pattern.
+# Approved or temporarily tolerated here: secpal.app, www.secpal.app, secpal.dev
+# (including api/app subdomains), apk.secpal.app, the app.secpal Android
+# identifier, and deprecated-but-allowed api.secpal.app.
+violations=$(printf '%s\n' "$domains" | \
+    grep -Evi '^(secpal\.app(\.git)?|www\.secpal\.app|apk\.secpal\.app|(\*\.)?([A-Za-z0-9-]+\.)*secpal\.dev|api\.secpal\.app|app\.secpal)\.?$' |
+    grep -Evi '^changelog\.secpal\.app\.?$' || true)
+
+retired_web_hosts=$(printf '%s\n' "$domains" | \
+    grep -Ei '^changelog\.secpal\.app\.?$' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -Ei 'api\.secpal\.app' | \
@@ -84,7 +92,7 @@ deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -v -- 'must not appear as active web hosts' | \
     grep -v -- 'not treated as a deployable web domain' || true)
 
-if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then
+if [[ -z "$violations" && -z "$retired_web_hosts" && -z "$deprecated_web_hosts" ]]; then
     echo -e "${GREEN}✅ Domain Policy Check PASSED${NC}"
     echo "All domain usage matches the approved SecPal split"
     exit 0
@@ -94,6 +102,11 @@ else
     if [[ -n "$violations" ]]; then
         echo "Found forbidden domains:"
         echo "$violations"
+        echo ""
+    fi
+    if [[ -n "$retired_web_hosts" ]]; then
+        echo "Found retired web hosts:"
+        echo "$retired_web_hosts"
         echo ""
     fi
     if [[ -n "$deprecated_web_hosts" ]]; then

--- a/src/components/Roadmap.astro
+++ b/src/components/Roadmap.astro
@@ -161,24 +161,5 @@ const phases: { key: Phase; accent: string; badge: string; dot: string }[] = [
         }
       </dl>
     </div>
-
-    <!-- Changelog link -->
-    <div class="mt-20 border-t border-gray-200 pt-10 dark:border-white/10">
-      <p class="text-sm/6 font-semibold text-gray-900 dark:text-white">
-        {r.changelog.label}
-      </p>
-      <p class="mt-2 text-sm/6 text-gray-600 dark:text-gray-400">
-        {r.changelog.description}
-      </p>
-      <p class="mt-4">
-        <a
-          href={r.changelog.href}
-          class="text-sm/6 font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          {r.changelog.link}
-          <span aria-hidden="true">→</span>
-        </a>
-      </p>
-    </div>
   </div>
 </div>

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -188,13 +188,6 @@ export const de: Translations = {
         },
       ],
     },
-    changelog: {
-      label: "Was ausgeliefert wurde",
-      description:
-        "Jedes ausgelieferte Feature und jeden Fix dokumentiert changelog.secpal.app — die vollständige Versionshistorie über API, Web-App und Android.",
-      link: "Zum Changelog",
-      href: "https://changelog.secpal.app",
-    },
   },
   footer: {
     rights: "",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -186,13 +186,6 @@ export const en = {
         },
       ],
     },
-    changelog: {
-      label: "What has shipped",
-      description:
-        "Every released feature and fix is documented at changelog.secpal.app — the full history of what has shipped across API, web app, and Android.",
-      link: "Read the changelog",
-      href: "https://changelog.secpal.app",
-    },
   },
   footer: {
     rights: "",

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Datenschutz | SecPal"
-  description="Datenschutzhinweise für secpal.app, changelog.secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
+  description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung betrifft die öffentlichen Websites secpal.app und changelog.secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
+  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
   updatedLabel="Stand"
   updatedAt="25. Juli 2026"
 >
@@ -24,10 +24,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         1. Geltungsbereich
       </h2>
       <p class="mt-6">
-        Diese Datenschutzerklärung gilt für die öffentlichen Websites secpal.app
-        und changelog.secpal.app, die über apk.secpal.app bereitgestellten
-        Downloadressourcen, die über Cloudflare bereitgestellten autoritativen
-        DNS-Dienste sowie die direkte Kontaktaufnahme mit SecPal.
+        Diese Datenschutzerklärung gilt für die öffentliche Website secpal.app,
+        die über apk.secpal.app bereitgestellten Downloadressourcen, die über
+        Cloudflare bereitgestellten autoritativen DNS-Dienste sowie die direkte
+        Kontaktaufnahme mit SecPal.
       </p>
       <p class="mt-4">
         Sie beschreibt nicht die Verarbeitung personenbezogener Daten innerhalb
@@ -79,8 +79,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       <p class="mt-4">
         Diese Daten werden für die Dauer der Verbindung flüchtig verarbeitet,
         damit die angeforderte Website oder Datei übertragen werden kann. Das
-        Hosting von secpal.app, changelog.secpal.app und apk.secpal.app erfolgt
-        über die Hetzner Online GmbH.
+        Hosting von secpal.app und apk.secpal.app erfolgt über die Hetzner
+        Online GmbH.
       </p>
       <p class="mt-4">
         Zwecke der Verarbeitung sind die Auslieferung der angeforderten Inhalte,
@@ -98,10 +98,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         4. Keine reguläre Zugriffsprotokollierung
       </h2>
       <p class="mt-6">
-        SecPal führt für secpal.app, changelog.secpal.app und apk.secpal.app
-        keine regulären Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne
-        Seiten- und Downloadabrufe werden von SecPal nicht dauerhaft
-        protokolliert.
+        SecPal führt für secpal.app und apk.secpal.app keine regulären
+        Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne Seiten- und
+        Downloadabrufe werden von SecPal nicht dauerhaft protokolliert.
       </p>
       <p class="mt-4">
         SecPal speichert dabei keine individuellen IP-Adressen, User-Agents oder
@@ -122,11 +121,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Die autoritativen DNS-Dienste für secpal.app, changelog.secpal.app und
-        apk.secpal.app werden über Cloudflare bereitgestellt. Die Web-DNS-
-        Einträge sind DNS-only und beantworten DNS-Abfragen mit der
-        tatsächlichen Hetzner-Origin-IP. Der reguläre HTTP- und HTTPS-Verkehr
-        dieser Hosts läuft direkt zu Hetzner.
+        Die autoritativen DNS-Dienste für secpal.app und apk.secpal.app werden
+        über Cloudflare bereitgestellt. Die Web-DNS-Einträge sind DNS-only und
+        beantworten DNS-Abfragen mit der tatsächlichen Hetzner-Origin-IP. Der
+        reguläre HTTP- und HTTPS-Verkehr dieser Hosts läuft direkt zu Hetzner.
       </p>
       <p class="mt-4">
         Cloudflare wird für diese Hosts nicht als Reverse Proxy, CDN, WAF oder
@@ -167,10 +165,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         7. Lokale Darstellungspräferenz
       </h2>
       <p class="mt-6">
-        Auf secpal.app und changelog.secpal.app kann eine Person den Hell- oder
-        Dunkelmodus manuell auswählen. Die jeweilige Website speichert den Wert{
-          " "
-        }
+        Auf secpal.app kann eine Person den Hell- oder Dunkelmodus manuell
+        auswählen. Die Website speichert den Wert{" "}
         <code class="break-all">light</code> oder{" "}
         <code class="break-all">dark</code> unter dem Schlüssel{" "}
         <code class="break-all">theme</code> im lokalen Speicher des Browsers. Ohne
@@ -196,9 +192,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         8. Keine Webanalyse oder Besucherprofilbildung
       </h2>
       <p class="mt-6">
-        SecPal setzt auf secpal.app, changelog.secpal.app und apk.secpal.app
-        keine Webanalyse-, Marketing- oder Nutzertrackingdienste ein. Es werden
-        keine Besucherprofile erstellt und keine optionalen Analyse- oder
+        SecPal setzt auf secpal.app und apk.secpal.app keine Webanalyse-,
+        Marketing- oder Nutzertrackingdienste ein. Es werden keine
+        Besucherprofile erstellt und keine optionalen Analyse- oder
         Marketing-Cookies gesetzt.
       </p>
       <p class="mt-4">
@@ -350,9 +346,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         SecPal speichert keine individuellen Website- oder Downloadzugriffe für
-        secpal.app, changelog.secpal.app oder apk.secpal.app in regulären
-        Webserverlogs. Die Theme-Einstellung bleibt ausschließlich im Browser,
-        bis sie geändert oder der lokale Browserspeicher gelöscht wird.
+        secpal.app oder apk.secpal.app in regulären Webserverlogs. Die
+        Theme-Einstellung bleibt ausschließlich im Browser, bis sie geändert
+        oder der lokale Browserspeicher gelöscht wird.
       </p>
       <p class="mt-4">
         E-Mails werden nach abschließender Bearbeitung gelöscht, sofern keine

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -7,12 +7,12 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Privacy Notice | SecPal"
-  description="Privacy notice for secpal.app, changelog.secpal.app, apk.secpal.app, and direct contact with SecPal."
+  description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice concerns the public secpal.app and changelog.secpal.app websites, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
+  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
   updatedLabel="Last updated"
   updatedAt="July 25, 2026"
 >
@@ -24,10 +24,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         1. Scope
       </h2>
       <p class="mt-6">
-        This privacy notice applies to the public secpal.app and
-        changelog.secpal.app websites, download resources provided through
-        apk.secpal.app, authoritative DNS services provided through Cloudflare,
-        and direct contact with SecPal.
+        This privacy notice applies to the public secpal.app website, download
+        resources provided through apk.secpal.app, authoritative DNS services
+        provided through Cloudflare, and direct contact with SecPal.
       </p>
       <p class="mt-4">
         It does not describe the processing of personal data within an installed
@@ -77,9 +76,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </p>
       <p class="mt-4">
         This data is processed transiently for the duration of the connection so
-        that the requested website or file can be transmitted. secpal.app,
-        changelog.secpal.app, and apk.secpal.app are hosted through Hetzner
-        Online GmbH.
+        that the requested website or file can be transmitted. secpal.app and
+        apk.secpal.app are hosted through Hetzner Online GmbH.
       </p>
       <p class="mt-4">
         The purposes are to deliver the requested content, provide stable and
@@ -96,9 +94,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         4. No regular access logging
       </h2>
       <p class="mt-6">
-        SecPal keeps no regular web server access or error logs for secpal.app,
-        changelog.secpal.app, and apk.secpal.app. Individual page and download
-        requests are not permanently logged by SecPal.
+        SecPal keeps no regular web server access or error logs for secpal.app
+        and apk.secpal.app. Individual page and download requests are not
+        permanently logged by SecPal.
       </p>
       <p class="mt-4">
         SecPal does not store individual IP addresses, user agents, or crawler
@@ -118,11 +116,10 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         5. Domain Name System (DNS)
       </h2>
       <p class="mt-6">
-        Authoritative DNS services for secpal.app, changelog.secpal.app, and
-        apk.secpal.app are provided through Cloudflare. The web DNS records are
-        DNS-only and answer DNS queries with the actual Hetzner origin IP
-        address. Regular HTTP and HTTPS traffic for these hosts goes directly to
-        Hetzner.
+        Authoritative DNS services for secpal.app and apk.secpal.app are
+        provided through Cloudflare. The web DNS records are DNS-only and answer
+        DNS queries with the actual Hetzner origin IP address. Regular HTTP and
+        HTTPS traffic for these hosts goes directly to Hetzner.
       </p>
       <p class="mt-4">
         Cloudflare is not used for these hosts as a Reverse Proxy, CDN, WAF, or
@@ -162,10 +159,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         7. Local display preference
       </h2>
       <p class="mt-6">
-        On secpal.app and changelog.secpal.app, a person can manually select
-        light or dark mode. The respective website stores the value <code
-          class="break-all">light</code
-        > or{" "}
+        On secpal.app, a person can manually select light or dark mode. The
+        website stores the value <code class="break-all">light</code> or{" "}
         <code class="break-all">dark</code> under the key{" "}
         <code class="break-all">theme</code> in the browser's local storage. Without
         a manual selection, the display follows the operating-system preference.
@@ -190,9 +185,8 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         SecPal does not use web analytics, marketing, or user-tracking services
-        on secpal.app, changelog.secpal.app, or apk.secpal.app. No visitor
-        profiles are created, and no optional analytics or marketing cookies are
-        set.
+        on secpal.app or apk.secpal.app. No visitor profiles are created, and no
+        optional analytics or marketing cookies are set.
       </p>
       <p class="mt-4">
         Because no optional tracking technologies are used, no consent banner
@@ -339,9 +333,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </h2>
       <p class="mt-6">
         SecPal does not store individual website or download requests for
-        secpal.app, changelog.secpal.app, or apk.secpal.app in regular web
-        server logs. The theme setting remains solely in the browser until it is
-        changed or the browser's local storage is cleared.
+        secpal.app or apk.secpal.app in regular web server logs. The theme
+        setting remains solely in the browser until it is changed or the
+        browser's local storage is cleared.
       </p>
       <p class="mt-4">
         Emails are deleted after final processing unless a statutory obligation

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -22,23 +22,23 @@ const compactPages = Object.fromEntries(
 const expectedShellProps = {
   de: [
     'title="Datenschutz | SecPal"',
-    'description="Datenschutzhinweise für secpal.app, changelog.secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
+    'description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
     'canonicalPath="/de/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Rechtliches"',
     'headline="Datenschutzerklärung"',
-    'intro="Diese Datenschutzerklärung betrifft die öffentlichen Websites secpal.app und changelog.secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
+    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
     'updatedLabel="Stand"',
     'updatedAt="25. Juli 2026"',
   ],
   en: [
     'title="Privacy Notice | SecPal"',
-    'description="Privacy notice for secpal.app, changelog.secpal.app, apk.secpal.app, and direct contact with SecPal."',
+    'description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."',
     'canonicalPath="/en/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Legal"',
     'headline="Privacy Notice"',
-    'intro="This privacy notice concerns the public secpal.app and changelog.secpal.app websites, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
+    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
     'updatedLabel="Last updated"',
     'updatedAt="July 25, 2026"',
   ],
@@ -102,14 +102,14 @@ test("localized privacy pages retain their shell metadata and aligned sections",
   assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
 });
 
-test("the formal scope covers all public hosts and authoritative DNS services", () => {
+test("the formal scope covers the public website, download resources, and authoritative DNS services", () => {
   assert.match(
     compactPages.de,
-    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*changelog\.secpal\.app[^<]*apk\.secpal\.app[^<]*autoritativen DNS-Dienste[^<]*<\/p>/
+    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*apk\.secpal\.app[^<]*autoritativen DNS-Dienste[^<]*<\/p>/
   );
   assert.match(
     compactPages.en,
-    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*changelog\.secpal\.app[^<]*apk\.secpal\.app[^<]*authoritative DNS services[^<]*<\/p>/
+    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*apk\.secpal\.app[^<]*authoritative DNS services[^<]*<\/p>/
   );
 });
 
@@ -143,11 +143,11 @@ test("the controller is identified with SecPal before Holger Schmermbeck", () =>
 test("hosting, transient delivery, and disabled regular logging are precise", () => {
   assert.match(
     compactPages.de,
-    /Hosting von secpal\.app, changelog\.secpal\.app und apk\.secpal\.app erfolgt über die Hetzner Online GmbH/
+    /Hosting von secpal\.app und apk\.secpal\.app erfolgt über die Hetzner Online GmbH/
   );
   assert.match(
     compactPages.en,
-    /secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app are hosted through Hetzner Online GmbH/
+    /secpal\.app and apk\.secpal\.app are hosted through Hetzner Online GmbH/
   );
   assert.match(compactPages.de, /flüchtig|Dauer der Verbindung/);
   assert.match(compactPages.en, /transient|duration of the connection/);
@@ -168,12 +168,9 @@ test("hosting, transient delivery, and disabled regular logging are precise", ()
   assert.match(compactPages.en, /no regular web server access or error logs/);
   assert.match(
     compactPages.de,
-    /für secpal\.app, changelog\.secpal\.app und apk\.secpal\.app keine regulären/
+    /für secpal\.app und apk\.secpal\.app keine regulären/
   );
-  assert.match(
-    compactPages.en,
-    /for secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app/
-  );
+  assert.match(compactPages.en, /for secpal\.app and apk\.secpal\.app/);
   assert.match(compactPages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
   assert.match(compactPages.en, /Article 6\(1\)\(f\) GDPR/);
   assert.match(
@@ -195,7 +192,7 @@ test("Cloudflare is limited to authoritative DNS and transfer safeguards", () =>
     assert.match(source, /Cloudflare/);
     assert.match(source, /DNS-only/);
     assert.match(source, /Hetzner/);
-    assert.match(source, /changelog\.secpal\.app/);
+    assert.doesNotMatch(source, /changelog\.secpal\.app/i);
     assert.match(source, /Reverse Proxy/i);
     assert.match(source, /\bWAF\b/);
     assert.match(source, /Data Privacy Framework/);
@@ -282,8 +279,8 @@ test("the local theme preference is the only documented browser storage", () => 
   }
   assert.match(compactPages.de, /lokalen Speicher des Browsers/);
   assert.match(compactPages.en, /browser's local storage/);
-  assert.match(compactPages.de, /secpal\.app und changelog\.secpal\.app/);
-  assert.match(compactPages.en, /secpal\.app and changelog\.secpal\.app/);
+  assert.match(compactPages.de, /Auf secpal\.app kann eine Person/);
+  assert.match(compactPages.en, /On secpal\.app, a person can manually select/);
   assert.match(compactPages.de, /§ 25 Abs\. 2 Nr\. 2 TDDDG/);
   assert.match(compactPages.en, /Section 25\(2\)\(2\) TDDDG/);
   assert.match(
@@ -315,7 +312,7 @@ test("the pages exclude web analytics, tracking, and visitor profiles", () => {
   for (const source of Object.values(compactPages)) {
     assert.match(
       source,
-      /secpal\.app, changelog\.secpal\.app und apk\.secpal\.app|secpal\.app, changelog\.secpal\.app, and apk\.secpal\.app/
+      /secpal\.app und apk\.secpal\.app|secpal\.app and apk\.secpal\.app/
     );
   }
 });

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -7,10 +7,15 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = new URL("../", import.meta.url);
 const retiredDomain = ["dev", "secpal", "app"].join(".");
+const retiredChangelogDomain = ["changelog", "secpal", "app"].join(".");
+const forbiddenDomain = ["secpal", "xyz"].join(".");
+const domainCheckScript = fileURLToPath(
+  new URL("../scripts/check-domains.sh", import.meta.url)
+);
 
 function findMatchingFiles(root) {
   const repositoryFiles = execFileSync(
@@ -80,4 +85,56 @@ test("the repository scan rejects mixed-case retired domains", (t) => {
 
   const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
   assert.deepEqual(findMatchingFiles(temporaryRoot), ["mixed-case.txt"]);
+});
+
+test("the domain policy rejects a retired changelog host beside an allowed host", (t) => {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "secpal-domain-policy-")
+  );
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(temporaryDirectory, "mixed-host.md"),
+    `Current site: secpal.app; retired site: ${retiredChangelogDomain}`
+  );
+
+  assert.throws(
+    () =>
+      execFileSync("bash", [domainCheckScript], {
+        cwd: temporaryDirectory,
+        encoding: "utf8",
+      }),
+    (error) => {
+      assert.equal(error?.status, 1);
+      assert.match(error.stdout, /Found retired web hosts:/);
+      assert.ok(error.stdout.includes(retiredChangelogDomain));
+      return true;
+    }
+  );
+});
+
+test("the domain policy rejects a forbidden domain beside an allowed host", (t) => {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "secpal-domain-policy-")
+  );
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(temporaryDirectory, "mixed-domain.md"),
+    `Current site: secpal.app; forbidden site: ${forbiddenDomain}`
+  );
+
+  assert.throws(
+    () =>
+      execFileSync("bash", [domainCheckScript], {
+        cwd: temporaryDirectory,
+        encoding: "utf8",
+      }),
+    (error) => {
+      assert.equal(error?.status, 1);
+      assert.match(error.stdout, /Found forbidden domains:/);
+      assert.ok(error.stdout.includes(forbiddenDomain));
+      return true;
+    }
+  );
 });

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { en } from "../src/i18n/en.ts";
@@ -73,4 +74,16 @@ test("roadmap reflects the current shift-planning and OWKS priorities", () => {
     !germanActiveNames.includes("Android-App"),
     "expected German Android app work to be removed from the active roadmap phases"
   );
+});
+
+test("roadmap has no retired changelog call to action", () => {
+  const roadmapComponent = readFileSync(
+    new URL("../src/components/Roadmap.astro", import.meta.url),
+    "utf8"
+  );
+
+  assert.ok(!("changelog" in en.roadmap));
+  assert.ok(!("changelog" in de.roadmap));
+  assert.doesNotMatch(roadmapComponent, /changelog\.secpal\.app/i);
+  assert.doesNotMatch(roadmapComponent, /r\.changelog/);
 });


### PR DESCRIPTION
## Problem and evidence

The standalone changelog repository, host, and domain have been deliberately retired in full. No redirect, archive notice, or replacement page is planned. A repository-wide scan found active references in the roadmap component and translations, both privacy pages and their regression tests, the domain-policy allowlist, governance mirrors, and the unreleased changelog.

## Change

- Removed active roadmap copy, links, and translation entries.
- Limited the Privacy Notice to `secpal.app`, `apk.secpal.app`, authoritative DNS, and direct email contact.
- Removed the retired host from the domain-policy allowlist and active governance documentation; future use is rejected by the policy check.
- Removed the unreleased changelog entries that described the former offer and recorded its cleanup.

Roadmap priorities and the roadmap design intentionally remain unchanged.

## Validation

- `npm ci`
- `npm test`
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `./scripts/preflight.sh`
- `bash scripts/check-domains.sh`
- `node --test tests/privacy-pages.test.mjs`
- `node --test tests/roadmap-copy.test.mjs`
- `git diff --check`

`npm run preflight` is not defined in this repository; the documented equivalent, `./scripts/preflight.sh`, passed.

## Browser check

Chromium checked `/de/roadmap/`, `/en/roadmap/`, `/de/privacy/`, and `/en/privacy/` at 320×568, 360×640, 412×915, 768×1024, and 1440×900 in light and dark mode. The roadmap ends cleanly after Later, privacy pages remain readable, and no application console errors were observed.

## Retired-host scan

`rg -n -i 'changelog\.secpal\.app' .` returns no matches.

## Readiness

No in-scope dependency or unresolved validation prevents readiness. The pull request remains a draft pending final PR-view self-review and review.
