### PR TITLE
docs(privacy): simplify public privacy notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LicenseRef-TailwindPlus` is the repo's SPDX reference for Tailwind
   Plus-derived components
 - replaced the repo-local `markdownlint-cli2` pre-commit and preflight path with pinned `markdownlint-cli@0.49.0` usage and removed the stale `cli2` file references from export/licensing metadata
-- refocused the localized privacy notice on the public website, direct download
-  infrastructure, DNS services, local display preference, and email contact;
-  removed product-internal app and beta-processing descriptions; and prevented
-  GitHub links from transmitting the referring SecPal page
+- simplified the localized public privacy notice around the actual website,
+  download, local display-preference, and email processing while removing
+  disproportionate DNS, external-link, and infrastructure detail
 - refocused the public Android landing page on end users: stable and beta are now presented as simple download choices, rollout methods are explained without pretending to be separate APK channels, and the deeper machine-readable endpoints are tucked behind secondary technical details
 - corrected the provider-neutral governance baseline so `AGENTS.md` and the Copilot mirror now advertise the workflow overlay, describe the existing `npm test` suite accurately, track Astro 7 instead of Astro 6, and pin the shared reusable quality workflows plus their `governance-ref` inputs to the reviewed `.github` SHA for reproducible validation
 - refactored `mobile-safe-area` test assertions: extracted complex inline regex literals to named constants and restored the coupled `break-all`+`{line}` assertion so endpoint-line paragraph failures remain diagnosable without weakening test coverage

--- a/src/components/LegalPageShell.astro
+++ b/src/components/LegalPageShell.astro
@@ -38,6 +38,8 @@ const {
 const alternateEnPath = `/en${currentPath}/`;
 const alternateDePath = `/de${currentPath}/`;
 const resolvedXDefaultPath = xDefaultPath ?? alternateEnPath;
+const headlineHyphenationClass =
+  locale === "de" ? "hyphens-auto" : "hyphens-none";
 ---
 
 <Base
@@ -61,7 +63,10 @@ const resolvedXDefaultPath = xDefaultPath ?? alternateEnPath;
           {eyebrow}
         </p>
         <h1
-          class="mt-2 text-4xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 sm:text-5xl dark:text-white"
+          class:list={[
+            "mt-2 text-4xl font-semibold tracking-tight text-pretty break-words text-gray-900 sm:text-5xl dark:text-white",
+            headlineHyphenationClass,
+          ]}
         >
           {headline}
         </h1>

--- a/src/components/LegalPageShell.astro
+++ b/src/components/LegalPageShell.astro
@@ -61,7 +61,7 @@ const resolvedXDefaultPath = xDefaultPath ?? alternateEnPath;
           {eyebrow}
         </p>
         <h1
-          class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl dark:text-white"
+          class="mt-2 text-4xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 sm:text-5xl dark:text-white"
         >
           {headline}
         </h1>

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -7,39 +7,38 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="de"
   title="Datenschutz | SecPal"
-  description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."
+  description="Datenschutzhinweise für secpal.app, die Downloadressourcen auf apk.secpal.app und die Kontaktaufnahme mit SecPal."
   canonicalPath="/de/privacy/"
   currentPath="/privacy"
   eyebrow="Rechtliches"
   headline="Datenschutzerklärung"
-  intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."
+  intro="Diese Datenschutzhinweise erklären, wie personenbezogene Daten beim Besuch von secpal.app, beim Abruf von Downloadressourcen auf apk.secpal.app und bei der Kontaktaufnahme per E-Mail verarbeitet werden."
   updatedLabel="Stand"
-  updatedAt="25. Juli 2026"
+  updatedAt="26. Juli 2026"
 >
   <section class="space-y-8">
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
         1. Geltungsbereich
       </h2>
       <p class="mt-6">
-        Diese Datenschutzerklärung gilt für die öffentliche Website secpal.app,
-        die über apk.secpal.app bereitgestellten Downloadressourcen, die über
-        Cloudflare bereitgestellten autoritativen DNS-Dienste sowie die direkte
+        Diese Datenschutzhinweise gelten für die öffentliche Website secpal.app,
+        die Downloadressourcen auf apk.secpal.app und die direkte
         Kontaktaufnahme mit SecPal.
       </p>
       <p class="mt-4">
-        Sie beschreibt nicht die Verarbeitung personenbezogener Daten innerhalb
-        einer installierten oder betriebenen SecPal-Instanz. Für solche
-        Verarbeitungen ist die Stelle verantwortlich, die den Betrieb und die
-        Zwecke der jeweiligen Instanz bestimmt.
+        Sie gelten nicht für die Verarbeitung personenbezogener Daten innerhalb
+        einer von einem Kunden installierten oder betriebenen SecPal-Instanz.
+        Dafür ist die Stelle verantwortlich, die über die Zwecke und Mittel des
+        jeweiligen Betriebs entscheidet.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
         2. Verantwortlicher
       </h2>
@@ -65,326 +64,111 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        3. Technische Bereitstellung und Hosting
+        3. Bereitstellung von Website und Downloads
       </h2>
       <p class="mt-6">
-        Beim Aufruf der Website oder einer Downloadressource übermittelt der
-        Browser technisch notwendige Verbindungs- und Anfragedaten. Dazu gehören
-        insbesondere die IP-Adresse, der angeforderte Host und die angeforderte
-        Ressource, Verbindungs- und Protokolldaten sowie technisch übermittelte
-        HTTP-Header.
+        Beim Aufruf von secpal.app oder einer Downloadressource auf
+        apk.secpal.app werden die IP-Adresse, der angeforderte Inhalt und
+        weitere technisch erforderliche Verbindungsdaten vorübergehend
+        verarbeitet. Dies ist erforderlich, um den angeforderten Inhalt zu
+        übertragen und den sicheren und funktionsfähigen Betrieb der Angebote zu
+        ermöglichen.
       </p>
       <p class="mt-4">
-        Diese Daten werden für die Dauer der Verbindung flüchtig verarbeitet,
-        damit die angeforderte Website oder Datei übertragen werden kann. Das
-        Hosting von secpal.app und apk.secpal.app erfolgt über die Hetzner
-        Online GmbH.
+        Hosting und Auslieferung erfolgen über die Hetzner Online GmbH.
+        Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Das berechtigte
+        Interesse liegt in der sicheren und zuverlässigen Bereitstellung der
+        Website und der Downloadressourcen.
       </p>
       <p class="mt-4">
-        Zwecke der Verarbeitung sind die Auslieferung der angeforderten Inhalte,
-        ein stabiler und sicherer Transport sowie der Betrieb der
-        Hostinginfrastruktur. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO.
-        Das berechtigte Interesse liegt in der sicheren und funktionsfähigen
-        Bereitstellung dieser Inhalte.
+        SecPal führt keine regulären Webserver-Zugriffs- oder Fehlerprotokolle
+        und setzt keine Analyse-, Marketing- oder Trackingdienste ein. Einzelne
+        Seiten- und Downloadabrufe werden von SecPal nicht dauerhaft gespeichert
+        oder für Besucher- und Downloadstatistiken verwendet.
+      </p>
+      <p class="mt-4">
+        Die Verarbeitung der technisch erforderlichen Verbindungsdaten ist
+        notwendig, um den angeforderten Inhalt zu übertragen. Ohne diese
+        Verarbeitung können die Website oder die Downloadressourcen nicht
+        bereitgestellt werden.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        4. Keine reguläre Zugriffsprotokollierung
+        4. Lokale Darstellungspräferenz
       </h2>
       <p class="mt-6">
-        SecPal führt für secpal.app und apk.secpal.app keine regulären
-        Webserver-Zugriffs- oder Fehlerprotokolle. Einzelne Seiten- und
-        Downloadabrufe werden von SecPal nicht dauerhaft protokolliert.
+        Wenn eine Person den Hell- oder Dunkelmodus manuell auswählt, wird diese
+        Einstellung ausschließlich im lokalen Speicher des Browsers gespeichert.
+        Sie wird nicht an SecPal oder einen externen Anbieter übermittelt.
       </p>
       <p class="mt-4">
-        SecPal speichert dabei keine individuellen IP-Adressen, User-Agents oder
-        Crawlerinformationen und erstellt keine Besucher-, Referrer-, Länder-,
-        Geräte- oder Downloadstatistiken. Die flüchtige technische Verarbeitung
-        während der Verbindung bleibt davon unberührt. Unabhängig von der durch
-        SecPal deaktivierten regulären Protokollierung können die eingesetzten
-        Dienstleister technisch erforderliche Betriebs- und
-        Sicherheitsverarbeitungen nach den jeweils geltenden vertraglichen und
-        gesetzlichen Rahmenbedingungen durchführen.
+        Die Einstellung bleibt gespeichert, bis sie geändert oder der lokale
+        Browserspeicher gelöscht wird. Die Speicherung ist erforderlich, um den
+        ausdrücklich gewählten Darstellungsmodus bei späteren Seitenaufrufen
+        bereitzustellen. Sie erfolgt auf Grundlage von § 25 Abs. 2 Nr. 2 TDDDG
+        und erfordert keine Einwilligung.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        5. Domain Name System (DNS)
-      </h2>
-      <p class="mt-6">
-        Die autoritativen DNS-Dienste für secpal.app und apk.secpal.app werden
-        über Cloudflare bereitgestellt. Die Web-DNS-Einträge sind DNS-only und
-        beantworten DNS-Abfragen mit der tatsächlichen Hetzner-Origin-IP. Der
-        reguläre HTTP- und HTTPS-Verkehr dieser Hosts läuft direkt zu Hetzner.
-      </p>
-      <p class="mt-4">
-        Cloudflare wird für diese Hosts nicht als Reverse Proxy, CDN, WAF oder
-        HTTP-Analyseplattform eingesetzt. Cloudflare erhält daher nicht den
-        regulären Seiten- oder Downloadverkehr.
-      </p>
-      <p class="mt-4">
-        Im Rahmen der DNS-Auflösung kann Cloudflare technisch notwendige
-        DNS-Abfragedaten verarbeiten. Zweck ist die zuverlässige und sichere
-        Erreichbarkeit der Domains. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f
-        DSGVO; das berechtigte Interesse liegt in einer stabilen und sicheren
-        Domainauflösung.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        6. Öffentliche Downloadressourcen
-      </h2>
-      <p class="mt-6">
-        apk.secpal.app kann APK-Dateien, Manifeste, Veröffentlichungsmetadaten
-        und Prüfsummen bereitstellen. Der Abruf erfordert dieselbe flüchtige
-        technische Verbindungsverarbeitung wie ein normaler Websiteabruf.
-      </p>
-      <p class="mt-4">
-        SecPal führt keine Downloadprotokolle oder individuellen Downloadzähler.
-        Aus dem Abruf erhält secpal.app keine Informationen über die spätere
-        Installation oder Verwendung der heruntergeladenen Anwendung.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        7. Lokale Darstellungspräferenz
-      </h2>
-      <p class="mt-6">
-        Auf secpal.app kann eine Person den Hell- oder Dunkelmodus manuell
-        auswählen. Die Website speichert den Wert{" "}
-        <code class="break-all">light</code> oder{" "}
-        <code class="break-all">dark</code> unter dem Schlüssel{" "}
-        <code class="break-all">theme</code> im lokalen Speicher des Browsers. Ohne
-        eine manuelle Auswahl orientiert sich die Darstellung an der Systemeinstellung.
-      </p>
-      <p class="mt-4">
-        Die Einstellung verbleibt im Browser und wird weder an SecPal noch an
-        einen externen Anbieter übermittelt. Sie bleibt gespeichert, bis sie
-        geändert oder der lokale Browserspeicher gelöscht wird.
-      </p>
-      <p class="mt-4">
-        Die Speicherung ist erforderlich, um den ausdrücklich gewählten
-        Darstellungsmodus bei späteren Seitenaufrufen bereitzustellen. Sie
-        erfolgt auf Grundlage von § 25 Abs. 2 Nr. 2 TDDDG und erfordert keine
-        Einwilligung.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        8. Keine Webanalyse oder Besucherprofilbildung
-      </h2>
-      <p class="mt-6">
-        SecPal setzt auf secpal.app und apk.secpal.app keine Webanalyse-,
-        Marketing- oder Nutzertrackingdienste ein. Es werden keine
-        Besucherprofile erstellt und keine optionalen Analyse- oder
-        Marketing-Cookies gesetzt.
-      </p>
-      <p class="mt-4">
-        Da keine optionalen Trackingtechnologien verwendet werden, ist kein
-        Einwilligungsbanner für solche Zwecke eingebunden.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        9. Kontaktaufnahme per E-Mail
+        5. Kontaktaufnahme per E-Mail
       </h2>
       <p class="mt-6">
         Die E-Mail-Kommunikation wird technisch über Uberspace bereitgestellt.
         Uberspace wird von Jonas Pasche in Mainz betrieben.
       </p>
       <p class="mt-4">
-        Verarbeitet werden können die Absenderadresse, der Name, falls
-        angegeben, der Betreff, der Nachrichteninhalt, der
-        Kommunikationszeitpunkt, Anhänge sowie technisch notwendige
-        E-Mail-Metadaten. Zweck ist ausschließlich die Bearbeitung der Anfrage
-        und die dafür erforderliche Kommunikation.
+        Bei einer Kontaktaufnahme verarbeitet SecPal die angegebenen
+        Kontaktdaten, den Inhalt der Nachricht und gegebenenfalls übermittelte
+        Anhänge. Zweck ist die Bearbeitung der Anfrage und die dafür
+        erforderliche Kommunikation.
       </p>
       <p class="mt-4">
-        Art. 6 Abs. 1 lit. b DSGVO gilt, wenn eine Person durch ihre Anfrage
-        vorvertragliche Maßnahmen anfordert oder die Kommunikation einen Vertrag
-        betrifft. In sonstigen Fällen gilt Art. 6 Abs. 1 lit. f DSGVO. Das
-        berechtigte Interesse liegt in der Bearbeitung eingehender Anfragen und
-        Sicherheitsmeldungen.
+        Art. 6 Abs. 1 lit. b DSGVO gilt, wenn die Anfrage vorvertragliche
+        Maßnahmen oder ein bestehendes Vertragsverhältnis betrifft. In allen
+        anderen Fällen erfolgt die Verarbeitung auf Grundlage von Art. 6 Abs. 1
+        lit. f DSGVO. Das berechtigte Interesse liegt in der Bearbeitung
+        eingehender Anfragen und Sicherheitsmeldungen.
       </p>
       <p class="mt-4">
-        Nach abschließender Bearbeitung löscht SecPal die Nachricht. Sie wird
-        nicht für Marketing, Newsletter, Besucheranalyse oder CRM-Profile
-        weiterverwendet. Zwingende gesetzliche Aufbewahrungspflichten bleiben
-        vorbehalten. Technisch notwendige Vorgänge in Sicherungs-, Zustell- oder
-        Warteschlangensystemen des E-Mail-Anbieters können davon abweichen.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        10. Externe Links
-      </h2>
-      <p class="mt-6">
-        Die erfassten Websites enthalten Links zu externen Angeboten,
-        insbesondere zu GitHub. Inhalte dieser Anbieter werden nicht
-        eingebettet. Beim bloßen Aufruf einer erfassten Website wird daher keine
-        Verbindung zu GitHub hergestellt.
-      </p>
-      <p class="mt-4">
-        Erst beim Auswählen eines externen Links verlässt die Person die
-        jeweilige Website, und der Browser stellt eine Verbindung zum jeweiligen
-        Anbieter her. Für die Verarbeitung auf dem externen Angebot ist der
-        jeweilige Anbieter verantwortlich.
-      </p>
-      <p class="mt-4">
-        Bei Links zum SecPal-Auftritt auf GitHub unterdrückt SecPal die
-        Übermittlung der zuvor besuchten Seite als HTTP-Referrer.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        11. Empfänger und Dienstleister
-      </h2>
-      <ul
-        role="list"
-        class="mt-8 max-w-3xl space-y-6 text-gray-600 dark:text-gray-400"
-      >
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Hetzner Online GmbH:</strong
-          >
-          {" "}
-          Hosting und Auslieferung der öffentlichen Websites und der Downloadressourcen.
-        </li>
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Cloudflare, Inc.:</strong
-          >
-          {" "}
-          autoritative DNS-Dienste. Wegen der DNS-only-Konfiguration erhält Cloudflare
-          nicht den regulären HTTP- oder HTTPS-Verkehr.
-        </li>
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Uberspace, betrieben von Jonas Pasche:</strong
-          >
-          {" "}
-          technische E-Mail-Kommunikation.
-        </li>
-      </ul>
-      <p class="mt-6">
-        GitHub ist beim bloßen Seitenaufruf kein Empfänger personenbezogener
-        Daten. Eine Verbindung entsteht erst durch das Auswählen eines externen
-        GitHub-Links.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        12. Drittlandübermittlung bei Cloudflare
-      </h2>
-      <p class="mt-6">
-        Cloudflare ist ein Anbieter mit Sitz in den USA und globaler
-        Infrastruktur. Im Rahmen der DNS-Dienste kann eine Verarbeitung
-        außerhalb des Europäischen Wirtschaftsraums nicht vollständig
-        ausgeschlossen werden.
-      </p>
-      <p class="mt-4">
-        Für Übermittlungen in die USA kann das EU-US Data Privacy Framework
-        genutzt werden, solange die Zertifizierung wirksam ist. Ergänzend
-        beziehungsweise für andere relevante Drittlandübermittlungen sieht
-        Cloudflare Standardvertragsklauseln vor.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        13. Bereitstellung der Daten
-      </h2>
-      <p class="mt-6">
-        Die Verarbeitung der Verbindungsdaten ist technisch erforderlich, um die
-        Website oder Downloadressourcen auszuliefern. Ohne diese Verarbeitung
-        kann der angeforderte Inhalt nicht übertragen werden.
-      </p>
-      <p class="mt-4">
-        Die Kontaktaufnahme per E-Mail ist freiwillig. Ohne eine erreichbare
+        Die Kontaktaufnahme ist freiwillig. Ohne eine erreichbare
         Absenderadresse und ausreichende Angaben kann eine Anfrage
         möglicherweise nicht beantwortet werden.
       </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        14. Speicherdauer
-      </h2>
-      <p class="mt-6">
-        SecPal speichert keine individuellen Website- oder Downloadzugriffe für
-        secpal.app oder apk.secpal.app in regulären Webserverlogs. Die
-        Theme-Einstellung bleibt ausschließlich im Browser, bis sie geändert
-        oder der lokale Browserspeicher gelöscht wird.
-      </p>
       <p class="mt-4">
-        E-Mails werden nach abschließender Bearbeitung gelöscht, sofern keine
-        gesetzliche Pflicht oder ein konkreter rechtlicher Grund für eine
-        längere Aufbewahrung besteht. Für technisch erforderliche Verarbeitungen
-        der Dienstleister gelten deren jeweilige betriebliche und rechtliche
-        Anforderungen; SecPal nennt hierfür keine unbelegte feste Frist.
+        SecPal löscht die Nachricht nach abschließender Bearbeitung, sofern
+        keine gesetzliche Aufbewahrungspflicht oder ein anderer konkreter
+        rechtlicher Grund eine längere Speicherung erfordert.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        15. Rechte betroffener Personen
+        6. Rechte betroffener Personen
       </h2>
       <p class="mt-6">
-        Soweit die jeweiligen gesetzlichen Voraussetzungen vorliegen, bestehen
-        Rechte auf Auskunft, Berichtigung, Löschung, Einschränkung der
-        Verarbeitung und Datenübertragbarkeit. Gegen Verarbeitungen auf
+        Betroffene Personen haben nach Maßgabe der gesetzlichen Voraussetzungen
+        insbesondere Rechte auf Auskunft, Berichtigung, Löschung, Einschränkung
+        der Verarbeitung und Datenübertragbarkeit. Gegen Verarbeitungen auf
         Grundlage von Art. 6 Abs. 1 lit. f DSGVO besteht außerdem ein
         Widerspruchsrecht.
       </p>
       <p class="mt-4">
-        Betroffene Personen können sich zudem bei einer
-        Datenschutzaufsichtsbehörde beschweren. Zuständig ist insbesondere:
+        Darüber hinaus besteht das Recht, sich bei einer
+        Datenschutzaufsichtsbehörde zu beschweren. Zuständig ist insbesondere
+        der Landesbeauftragte für den Datenschutz Niedersachsen.
       </p>
-      <div
-        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
-      >
-        <p class="font-semibold text-gray-900 dark:text-white">
-          Der Landesbeauftragte für den Datenschutz Niedersachsen
-        </p>
-        <p class="mt-2">Prinzenstraße 5</p>
-        <p class="mt-2">30159 Hannover</p>
-      </div>
       <p class="mt-4">
         Anfragen zu Betroffenenrechten können an{" "}
         <a
@@ -394,19 +178,6 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         >
         {" "}
         gerichtet werden.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        16. Änderungen der Datenschutzerklärung
-      </h2>
-      <p class="mt-6">
-        SecPal aktualisiert diese Datenschutzerklärung, wenn sich die Website,
-        die Download-Infrastruktur, die eingesetzten Dienstleister oder die
-        rechtlichen Anforderungen ändern.
       </p>
     </div>
   </section>

--- a/src/pages/de/privacy.astro
+++ b/src/pages/de/privacy.astro
@@ -30,9 +30,9 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
       </p>
       <p class="mt-4">
         Sie gelten nicht für die Verarbeitung personenbezogener Daten innerhalb
-        einer von einem Kunden installierten oder betriebenen SecPal-Instanz.
-        Dafür ist die Stelle verantwortlich, die über die Zwecke und Mittel des
-        jeweiligen Betriebs entscheidet.
+        einer installierten oder betriebenen SecPal-Instanz. Dafür ist die
+        Stelle verantwortlich, die über die Zwecke und Mittel der Verarbeitung
+        innerhalb der jeweiligen Instanz entscheidet.
       </p>
     </div>
 

--- a/src/pages/de/security.astro
+++ b/src/pages/de/security.astro
@@ -44,7 +44,7 @@ const faqItems = [
   <section class="space-y-8">
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
         Sicherheitsmeldungen
       </h2>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -7,38 +7,37 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 <LegalPageShell
   locale="en"
   title="Privacy Notice | SecPal"
-  description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."
+  description="Privacy notice for secpal.app, download resources on apk.secpal.app, and direct contact with SecPal."
   canonicalPath="/en/privacy/"
   currentPath="/privacy"
   eyebrow="Legal"
   headline="Privacy Notice"
-  intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."
+  intro="This privacy notice explains how personal data is processed when secpal.app is visited, download resources on apk.secpal.app are requested, or SecPal is contacted by email."
   updatedLabel="Last updated"
-  updatedAt="July 25, 2026"
+  updatedAt="July 26, 2026"
 >
   <section class="space-y-8">
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
         1. Scope
       </h2>
       <p class="mt-6">
         This privacy notice applies to the public secpal.app website, download
-        resources provided through apk.secpal.app, authoritative DNS services
-        provided through Cloudflare, and direct contact with SecPal.
+        resources on apk.secpal.app, and direct contact with SecPal.
       </p>
       <p class="mt-4">
-        It does not describe the processing of personal data within an installed
-        or operated SecPal instance. Such processing is the responsibility of
-        the entity that determines the operation and purposes of the respective
-        instance.
+        It does not apply to the processing of personal data within a SecPal
+        instance installed or operated by a customer. The entity that determines
+        the purposes and means of the respective operation is responsible for
+        that processing.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
         2. Controller
       </h2>
@@ -64,314 +63,102 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        3. Technical delivery and hosting
+        3. Website and download delivery
       </h2>
       <p class="mt-6">
-        When the website or a download resource is requested, the browser sends
-        technically necessary connection and request data. This includes, in
-        particular, the IP address, the requested host and resource, connection
-        and protocol data, and technically transmitted HTTP headers.
+        When secpal.app or a download resource on apk.secpal.app is requested,
+        the IP address, the requested content, and other technically necessary
+        connection data are processed temporarily. This is necessary to transmit
+        the requested content and to provide the services securely and reliably.
       </p>
       <p class="mt-4">
-        This data is processed transiently for the duration of the connection so
-        that the requested website or file can be transmitted. secpal.app and
-        apk.secpal.app are hosted through Hetzner Online GmbH.
-      </p>
-      <p class="mt-4">
-        The purposes are to deliver the requested content, provide stable and
-        secure transport, and operate the hosting infrastructure. The legal
+        Hosting and delivery are provided through Hetzner Online GmbH. The legal
         basis is Article 6(1)(f) GDPR. The legitimate interest is the secure and
-        functional provision of this content.
+        reliable provision of the website and download resources.
+      </p>
+      <p class="mt-4">
+        SecPal keeps no regular web server access or error logs and does not use
+        analytics, marketing, or tracking services. Individual page and download
+        requests are not stored permanently by SecPal or used to produce visitor
+        or download statistics.
+      </p>
+      <p class="mt-4">
+        Processing the technically necessary connection data is required to
+        transmit the requested content. Without this processing, the website or
+        download resources cannot be provided.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        4. No regular access logging
+        4. Local display preference
       </h2>
       <p class="mt-6">
-        SecPal keeps no regular web server access or error logs for secpal.app
-        and apk.secpal.app. Individual page and download requests are not
-        permanently logged by SecPal.
+        When a person manually selects light or dark mode, that preference is
+        stored exclusively in the browser's local storage. It is not transmitted
+        to SecPal or an external provider.
       </p>
       <p class="mt-4">
-        SecPal does not store individual IP addresses, user agents, or crawler
-        information and does not use such requests to produce visitor, referrer,
-        country, device, or download statistics. This does not affect the
-        transient technical processing during the connection. Independently of
-        the regular logging disabled by SecPal, the service providers may carry
-        out technically necessary operational and security processing under the
-        applicable contractual and legal frameworks.
+        The preference remains stored until it is changed or the browser's local
+        storage is cleared. The storage is necessary to provide the display mode
+        expressly selected by the user during later visits. It is based on
+        Section 25(2)(2) TDDDG and does not require consent.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        5. Domain Name System (DNS)
-      </h2>
-      <p class="mt-6">
-        Authoritative DNS services for secpal.app and apk.secpal.app are
-        provided through Cloudflare. The web DNS records are DNS-only and answer
-        DNS queries with the actual Hetzner origin IP address. Regular HTTP and
-        HTTPS traffic for these hosts goes directly to Hetzner.
-      </p>
-      <p class="mt-4">
-        Cloudflare is not used for these hosts as a Reverse Proxy, CDN, WAF, or
-        HTTP analytics platform. Cloudflare therefore does not receive regular
-        page or download traffic.
-      </p>
-      <p class="mt-4">
-        Cloudflare may process technically necessary DNS query data as part of
-        DNS resolution. The purpose is reliable and secure domain availability.
-        The legal basis is Article 6(1)(f) GDPR; the legitimate interest is
-        stable and secure domain resolution.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        6. Public download resources
-      </h2>
-      <p class="mt-6">
-        apk.secpal.app may provide APK files, manifests, release metadata, and
-        checksums. A request requires the same transient technical connection
-        processing as a regular website request.
-      </p>
-      <p class="mt-4">
-        SecPal keeps no download logs or individual download counters. A request
-        does not provide secpal.app with information about the later
-        installation or use of the downloaded software.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        7. Local display preference
-      </h2>
-      <p class="mt-6">
-        On secpal.app, a person can manually select light or dark mode. The
-        website stores the value <code class="break-all">light</code> or{" "}
-        <code class="break-all">dark</code> under the key{" "}
-        <code class="break-all">theme</code> in the browser's local storage. Without
-        a manual selection, the display follows the operating-system preference.
-      </p>
-      <p class="mt-4">
-        The setting remains in the browser and is not transmitted to SecPal or
-        an external provider. It remains stored until it is changed or the
-        browser's local storage is cleared.
-      </p>
-      <p class="mt-4">
-        The storage is necessary to provide the display mode expressly selected
-        by the user. It is based on Section 25(2)(2) TDDDG and does not require
-        consent.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        8. No web analytics or visitor profiling
-      </h2>
-      <p class="mt-6">
-        SecPal does not use web analytics, marketing, or user-tracking services
-        on secpal.app or apk.secpal.app. No visitor profiles are created, and no
-        optional analytics or marketing cookies are set.
-      </p>
-      <p class="mt-4">
-        Because no optional tracking technologies are used, no consent banner
-        for these purposes is included.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        9. Contact by email
+        5. Contact by email
       </h2>
       <p class="mt-6">
         Email communication is technically provided through Uberspace. Uberspace
         is operated by Jonas Pasche in Mainz, Germany.
       </p>
       <p class="mt-4">
-        The data processed may include the sender address, name if provided,
-        subject, message content, time of communication, attachments, and
-        technically necessary email metadata. The sole purpose is to process the
-        request and conduct the communication required for it.
+        When SecPal is contacted, SecPal processes the contact details provided,
+        the content of the message, and any attachments submitted. The purpose
+        is to handle the inquiry and conduct the communication required for it.
       </p>
       <p class="mt-4">
-        Article 6(1)(b) GDPR applies when a person requests pre-contractual
-        steps through their inquiry or when the communication concerns a
-        contract. In all other cases, Article 6(1)(f) GDPR applies. The
-        legitimate interest is processing incoming inquiries and security
-        reports.
-      </p>
-      <p class="mt-4">
-        SecPal deletes the message after the request has been finally processed.
-        It is not reused for marketing, newsletters, visitor analytics, or CRM
-        profiles. Mandatory statutory retention obligations remain unaffected.
-        Technically necessary processes in the email provider's backup,
-        delivery, or queue systems may differ.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        10. External links
-      </h2>
-      <p class="mt-6">
-        The covered websites contain links to external services, especially
-        GitHub. Content from these providers is not embedded. Merely visiting a
-        covered website therefore does not establish a connection to GitHub.
-      </p>
-      <p class="mt-4">
-        Only when a person selects an external link do they leave the respective
-        website and the browser establishes a connection to the respective
-        provider. The respective provider is responsible for processing on the
-        external service.
-      </p>
-      <p class="mt-4">
-        For links to SecPal's presence on GitHub, SecPal suppresses transmission
-        of the previously visited page as the HTTP referrer.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        11. Recipients and service providers
-      </h2>
-      <ul
-        role="list"
-        class="mt-8 max-w-3xl space-y-6 text-gray-600 dark:text-gray-400"
-      >
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Hetzner Online GmbH:</strong
-          >
-          {" "}
-          hosting and delivery of the public websites and download resources.
-        </li>
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Cloudflare, Inc.:</strong
-          >
-          {" "}
-          authoritative DNS services. Because the configuration is DNS-only, Cloudflare
-          does not receive regular HTTP or HTTPS traffic.
-        </li>
-        <li>
-          <strong class="font-semibold text-gray-900 dark:text-white"
-            >Uberspace, operated by Jonas Pasche:</strong
-          >
-          {" "}
-          technical email communication.
-        </li>
-      </ul>
-      <p class="mt-6">
-        GitHub is not a recipient of personal data merely because a person
-        visits the website. A connection is only established when an external
-        GitHub link is selected.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        12. International transfers involving Cloudflare
-      </h2>
-      <p class="mt-6">
-        Cloudflare is a provider based in the United States with global
-        infrastructure. Processing outside the European Economic Area cannot be
-        completely ruled out in connection with the DNS services.
-      </p>
-      <p class="mt-4">
-        The EU-US Data Privacy Framework may be used for transfers to the United
-        States for as long as the certification remains effective. In addition,
-        or for other relevant international transfers, Cloudflare provides for
-        Standard Contractual Clauses.
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        13. Provision of data
-      </h2>
-      <p class="mt-6">
-        Processing connection data is technically necessary to deliver the
-        website or download resources. Without this processing, the requested
-        content cannot be transmitted.
+        Article 6(1)(b) GDPR applies when the inquiry concerns pre-contractual
+        measures or an existing contractual relationship. In all other cases,
+        processing is based on Article 6(1)(f) GDPR. The legitimate interest is
+        handling incoming inquiries and security reports.
       </p>
       <p class="mt-4">
         Contact by email is voluntary. Without a reachable sender address and
         sufficient information, it may not be possible to answer an inquiry.
       </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        14. Storage periods
-      </h2>
-      <p class="mt-6">
-        SecPal does not store individual website or download requests for
-        secpal.app or apk.secpal.app in regular web server logs. The theme
-        setting remains solely in the browser until it is changed or the
-        browser's local storage is cleared.
-      </p>
       <p class="mt-4">
-        Emails are deleted after final processing unless a statutory obligation
-        or a specific legal reason requires longer retention. The service
-        providers' respective operational and legal requirements apply to
-        technically necessary processing; SecPal does not state an unsupported
-        fixed period for such processing.
+        SecPal deletes the message after the inquiry has been finally processed
+        unless a statutory retention obligation or another specific legal reason
+        requires longer storage.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
       >
-        15. Data subject rights
+        6. Data subject rights
       </h2>
       <p class="mt-6">
-        Where the relevant statutory requirements are met, data subjects have
-        rights of access, rectification, erasure, restriction of processing, and
-        data portability. They also have a right to object to processing based
-        on Article 6(1)(f) GDPR.
+        Subject to the applicable statutory requirements, data subjects have
+        rights including access, rectification, erasure, restriction of
+        processing, and data portability. They also have the right to object to
+        processing based on Article 6(1)(f) GDPR.
       </p>
       <p class="mt-4">
-        Data subjects may also lodge a complaint with a data protection
-        supervisory authority. The competent authority includes:
+        Data subjects also have the right to lodge a complaint with a data
+        protection supervisory authority. The competent authority includes the
+        State Commissioner for Data Protection of Lower Saxony.
       </p>
-      <div
-        class="mt-4 rounded-2xl border border-gray-200 p-6 dark:border-white/10"
-      >
-        <p class="font-semibold text-gray-900 dark:text-white">
-          The State Commissioner for Data Protection of Lower Saxony
-        </p>
-        <p class="mt-2">Prinzenstraße 5</p>
-        <p class="mt-2">30159 Hannover</p>
-        <p class="mt-2">Germany</p>
-      </div>
       <p class="mt-4">
         Requests concerning data subject rights may be sent to{" "}
         <a
@@ -379,18 +166,6 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
           class="font-semibold text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
           >hello@secpal.app</a
         >{"."}
-      </p>
-    </div>
-
-    <div>
-      <h2
-        class="text-3xl font-semibold tracking-tight text-pretty text-gray-900 dark:text-white"
-      >
-        16. Changes to this privacy notice
-      </h2>
-      <p class="mt-6">
-        SecPal updates this privacy notice when the website, download
-        infrastructure, service providers, or legal requirements change.
       </p>
     </div>
   </section>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -19,7 +19,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
   <section class="space-y-8">
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         1. Scope
       </h2>
@@ -28,16 +28,16 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
         resources on apk.secpal.app, and direct contact with SecPal.
       </p>
       <p class="mt-4">
-        It does not apply to the processing of personal data within a SecPal
-        instance installed or operated by a customer. The entity that determines
-        the purposes and means of the respective operation is responsible for
+        It does not apply to the processing of personal data within an installed
+        or operated SecPal instance. The entity that determines the purposes and
+        means of processing within the respective instance is responsible for
         that processing.
       </p>
     </div>
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         2. Controller
       </h2>
@@ -63,7 +63,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         3. Website and download delivery
       </h2>
@@ -93,7 +93,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         4. Local display preference
       </h2>
@@ -112,7 +112,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         5. Contact by email
       </h2>
@@ -144,7 +144,7 @@ import LegalPageShell from "../../components/LegalPageShell.astro";
 
     <div>
       <h2
-        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-auto text-gray-900 dark:text-white"
+        class="text-3xl font-semibold tracking-tight text-pretty break-words hyphens-none text-gray-900 dark:text-white"
       >
         6. Data subject rights
       </h2>

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -147,6 +147,10 @@ test("German hero heading provides a readable manual compound-word break", () =>
 });
 
 test("localized legal headings wrap without English auto-hyphenation", () => {
+  const legalShell = readFileSync(
+    new URL("../src/components/LegalPageShell.astro", import.meta.url),
+    "utf8"
+  );
   const germanSecurity = readFileSync(
     new URL("../src/pages/de/security.astro", import.meta.url),
     "utf8"
@@ -162,6 +166,18 @@ test("localized legal headings wrap without English auto-hyphenation", () => {
   assert.match(
     germanSecurity,
     /<h2\b[^>]*class="[^"]*\bbreak-words\b[^"]*\bhyphens-auto\b[^"]*"[^>]*>\s*Sicherheitsmeldungen\s*<\/h2>/
+  );
+  assert.match(
+    legalShell,
+    /const headlineHyphenationClass =\s*locale === "de" \? "hyphens-auto" : "hyphens-none";/
+  );
+  assert.match(
+    legalShell,
+    /<h1\b[^>]*class:list=\{\[[\s\S]*?\bheadlineHyphenationClass\b[\s\S]*?\]\}[^>]*>/
+  );
+  assert.doesNotMatch(
+    legalShell,
+    /<h1\b[^>]*class="[^"]*\bhyphens-auto\b[^"]*"[^>]*>/
   );
   assert.equal(englishPrivacyHeadings.length, 6);
   for (const [, classNames] of englishPrivacyHeadings) {

--- a/tests/mobile-safe-area.test.mjs
+++ b/tests/mobile-safe-area.test.mjs
@@ -146,6 +146,32 @@ test("German hero heading provides a readable manual compound-word break", () =>
   assert.match(translations, /Sicherheits\\u00addienst/);
 });
 
+test("localized legal headings wrap without English auto-hyphenation", () => {
+  const germanSecurity = readFileSync(
+    new URL("../src/pages/de/security.astro", import.meta.url),
+    "utf8"
+  );
+  const englishPrivacy = readFileSync(
+    new URL("../src/pages/en/privacy.astro", import.meta.url),
+    "utf8"
+  );
+  const englishPrivacyHeadings = [
+    ...englishPrivacy.matchAll(/<h2\b[^>]*class="([^"]*)"[^>]*>/g),
+  ];
+
+  assert.match(
+    germanSecurity,
+    /<h2\b[^>]*class="[^"]*\bbreak-words\b[^"]*\bhyphens-auto\b[^"]*"[^>]*>\s*Sicherheitsmeldungen\s*<\/h2>/
+  );
+  assert.equal(englishPrivacyHeadings.length, 6);
+  for (const [, classNames] of englishPrivacyHeadings) {
+    const tokens = classTokens(classNames);
+    assert.ok(tokens.has("break-words"));
+    assert.ok(tokens.has("hyphens-none"));
+    assert.ok(!tokens.has("hyphens-auto"));
+  }
+});
+
 test("homepage hero keeps the localized status and progress target with tighter copy", () => {
   const hero = readFileSync(
     new URL("../src/components/Hero.astro", import.meta.url),

--- a/tests/navigation-structure.test.mjs
+++ b/tests/navigation-structure.test.mjs
@@ -134,6 +134,26 @@ test("contact is only the highlighted header action and GitHub stays secondary",
   assert.equal(footer.match(/https:\/\/github\.com\/SecPal/g)?.length, 1);
 });
 
+test("external GitHub links suppress referrer transmission", () => {
+  for (const [componentName, component] of Object.entries({ cta, footer })) {
+    const githubAnchors =
+      component.match(
+        /<a\b(?=[^>]*href="https:\/\/github\.com\/SecPal")[^>]*>/g
+      ) ?? [];
+
+    assert.equal(
+      githubAnchors.length,
+      1,
+      `${componentName} must contain one SecPal GitHub link`
+    );
+    assert.match(
+      githubAnchors[0],
+      /\breferrerpolicy="no-referrer"/,
+      `${componentName} must suppress referrer transmission`
+    );
+  }
+});
+
 test("navigation translations are aligned and obsolete fields are removed", () => {
   assert.equal(de.nav.workflow, "Ablauf");
   assert.equal(en.nav.workflow, "Workflow");

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const readSource = (path) =>
@@ -22,25 +22,25 @@ const compactPages = Object.fromEntries(
 const expectedShellProps = {
   de: [
     'title="Datenschutz | SecPal"',
-    'description="Datenschutzhinweise für secpal.app, apk.secpal.app und die direkte Kontaktaufnahme mit SecPal."',
+    'description="Datenschutzhinweise für secpal.app, die Downloadressourcen auf apk.secpal.app und die Kontaktaufnahme mit SecPal."',
     'canonicalPath="/de/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Rechtliches"',
     'headline="Datenschutzerklärung"',
-    'intro="Diese Datenschutzerklärung betrifft die öffentliche Website secpal.app, die über apk.secpal.app bereitgestellten Downloadressourcen, das Domain Name System (DNS) sowie die direkte Kontaktaufnahme per E-Mail."',
+    'intro="Diese Datenschutzhinweise erklären, wie personenbezogene Daten beim Besuch von secpal.app, beim Abruf von Downloadressourcen auf apk.secpal.app und bei der Kontaktaufnahme per E-Mail verarbeitet werden."',
     'updatedLabel="Stand"',
-    'updatedAt="25. Juli 2026"',
+    'updatedAt="26. Juli 2026"',
   ],
   en: [
     'title="Privacy Notice | SecPal"',
-    'description="Privacy notice for secpal.app, apk.secpal.app, and direct contact with SecPal."',
+    'description="Privacy notice for secpal.app, download resources on apk.secpal.app, and direct contact with SecPal."',
     'canonicalPath="/en/privacy/"',
     'currentPath="/privacy"',
     'eyebrow="Legal"',
     'headline="Privacy Notice"',
-    'intro="This privacy notice concerns the public secpal.app website, download resources provided through apk.secpal.app, the Domain Name System (DNS), and direct contact by email."',
+    'intro="This privacy notice explains how personal data is processed when secpal.app is visited, download resources on apk.secpal.app are requested, or SecPal is contacted by email."',
     'updatedLabel="Last updated"',
-    'updatedAt="July 25, 2026"',
+    'updatedAt="July 26, 2026"',
   ],
 };
 
@@ -48,332 +48,287 @@ const expectedSections = {
   de: [
     "Geltungsbereich",
     "Verantwortlicher",
-    "Technische Bereitstellung und Hosting",
-    "Keine reguläre Zugriffsprotokollierung",
-    "Domain Name System (DNS)",
-    "Öffentliche Downloadressourcen",
+    "Bereitstellung von Website und Downloads",
     "Lokale Darstellungspräferenz",
-    "Keine Webanalyse oder Besucherprofilbildung",
     "Kontaktaufnahme per E-Mail",
-    "Externe Links",
-    "Empfänger und Dienstleister",
-    "Drittlandübermittlung bei Cloudflare",
-    "Bereitstellung der Daten",
-    "Speicherdauer",
     "Rechte betroffener Personen",
-    "Änderungen der Datenschutzerklärung",
   ],
   en: [
     "Scope",
     "Controller",
-    "Technical delivery and hosting",
-    "No regular access logging",
-    "Domain Name System (DNS)",
-    "Public download resources",
+    "Website and download delivery",
     "Local display preference",
-    "No web analytics or visitor profiling",
     "Contact by email",
-    "External links",
-    "Recipients and service providers",
-    "International transfers involving Cloudflare",
-    "Provision of data",
-    "Storage periods",
     "Data subject rights",
-    "Changes to this privacy notice",
   ],
 };
 
-const extractSectionNames = (source) =>
-  [...source.matchAll(/<h2\b[^>]*>\s*(?:\d+\.\s*)?([^<]+?)\s*<\/h2>/g)].map(
-    ([, heading]) => heading.replace(/\s+/g, " ").trim()
+const extractHeadings = (source) =>
+  [...source.matchAll(/<h2\b[^>]*>\s*(\d+)\.\s*([^<]+?)\s*<\/h2>/g)].map(
+    ([, number, name]) => ({
+      number: Number(number),
+      name: name.replace(/\s+/g, " ").trim(),
+    })
   );
 
-test("localized privacy pages retain their shell metadata and aligned sections", () => {
+test("localized privacy pages use the exact shell metadata", () => {
   for (const [locale, source] of Object.entries(pages)) {
     assert.match(source, /import LegalPageShell from/);
     for (const property of expectedShellProps[locale]) {
       assert.ok(
         source.includes(property),
-        `${locale} privacy page must retain ${property}`
+        `${locale} privacy page must contain ${property}`
       );
     }
   }
-  assert.deepEqual(extractSectionNames(pages.de), expectedSections.de);
-  assert.deepEqual(extractSectionNames(pages.en), expectedSections.en);
 });
 
-test("the formal scope covers the public website, download resources, and authoritative DNS services", () => {
+test("localized privacy pages have exactly six aligned numbered sections", () => {
+  for (const [locale, source] of Object.entries(pages)) {
+    const headings = extractHeadings(source);
+
+    assert.equal(headings.length, 6);
+    assert.deepEqual(
+      headings.map(({ number }) => number),
+      [1, 2, 3, 4, 5, 6]
+    );
+    assert.deepEqual(
+      headings.map(({ name }) => name),
+      expectedSections[locale]
+    );
+  }
+
+  assert.equal(
+    extractHeadings(pages.de).length,
+    extractHeadings(pages.en).length
+  );
+});
+
+test("the controller and contact details remain complete and ordered", () => {
   assert.match(
     compactPages.de,
-    /<h2[^>]*> 1\. Geltungsbereich <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*apk\.secpal\.app[^<]*autoritativen DNS-Dienste[^<]*<\/p>/
+    /Verantwortlicher im Sinne der DSGVO ist:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
   );
   assert.match(
     compactPages.en,
-    /<h2[^>]*> 1\. Scope <\/h2> <p class="mt-6"> [^<]*secpal\.app[^<]*apk\.secpal\.app[^<]*authoritative DNS services[^<]*<\/p>/
-  );
-});
-
-test("section extraction rejects headings that contain markup", () => {
-  const headingWithMarkup = "<h2>1. Scope <em>note</em></h2>";
-
-  assert.deepEqual(extractSectionNames(headingWithMarkup), []);
-});
-
-test("the controller is identified with SecPal before Holger Schmermbeck", () => {
-  assert.match(
-    compactPages.de,
-    /<p class="mt-6">Verantwortlicher im Sinne der DSGVO ist:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
-  );
-  assert.match(
-    compactPages.en,
-    /<p class="mt-6">The controller within the meaning of the GDPR is:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
+    /The controller within the meaning of the GDPR is:<\/p> <div[^>]*> <p[^>]*>SecPal<\/p> <p[^>]*>Holger Schmermbeck<\/p>/
   );
 
   for (const source of Object.values(pages)) {
     assert.match(source, /Enno-Arends-Str\. 4/);
     assert.match(source, /26571 Juist/);
-    assert.match(source, /hello@secpal\.app/);
+    assert.match(source, /href="mailto:hello@secpal\.app"/);
     assert.doesNotMatch(
       source,
       /Datenschutzbeauftragter|Data Protection Officer/i
     );
   }
+  assert.match(pages.de, /Deutschland/);
+  assert.match(pages.en, /Germany/);
 });
 
-test("hosting, transient delivery, and disabled regular logging are precise", () => {
+test("scope distinguishes public services from customer-operated instances", () => {
+  assert.match(compactPages.de, /öffentliche Website secpal\.app/);
+  assert.match(compactPages.de, /Downloadressourcen auf apk\.secpal\.app/);
+  assert.match(compactPages.de, /direkte Kontaktaufnahme mit SecPal/);
   assert.match(
     compactPages.de,
-    /Hosting von secpal\.app und apk\.secpal\.app erfolgt über die Hetzner Online GmbH/
+    /nicht für die Verarbeitung personenbezogener Daten innerhalb einer von einem Kunden installierten oder betriebenen SecPal-Instanz/
   );
+  assert.match(compactPages.de, /über die Zwecke und Mittel[^.]*entscheidet/);
+
+  assert.match(compactPages.en, /public secpal\.app website/);
+  assert.match(compactPages.en, /download resources on apk\.secpal\.app/);
+  assert.match(compactPages.en, /direct contact with SecPal/);
   assert.match(
     compactPages.en,
-    /secpal\.app and apk\.secpal\.app are hosted through Hetzner Online GmbH/
+    /does not apply to the processing of personal data within a SecPal instance installed or operated by a customer/
   );
-  assert.match(compactPages.de, /flüchtig|Dauer der Verbindung/);
-  assert.match(compactPages.en, /transient|duration of the connection/);
-  assert.match(compactPages.de, /IP-Adresse/);
-  assert.match(compactPages.en, /IP address/);
-  assert.match(
-    compactPages.de,
-    /keine individuellen IP-Adressen, User-Agents oder Crawlerinformationen/
-  );
-  assert.match(
-    compactPages.en,
-    /does not store individual IP addresses, user agents, or crawler information/
-  );
-  assert.match(
-    compactPages.de,
-    /keine regulären Webserver-Zugriffs- oder Fehlerprotokolle/
-  );
-  assert.match(compactPages.en, /no regular web server access or error logs/);
-  assert.match(
-    compactPages.de,
-    /für secpal\.app und apk\.secpal\.app keine regulären/
-  );
-  assert.match(compactPages.en, /for secpal\.app and apk\.secpal\.app/);
-  assert.match(compactPages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
-  assert.match(compactPages.en, /Article 6\(1\)\(f\) GDPR/);
-  assert.match(
-    compactPages.de,
-    /Unabhängig von der durch SecPal deaktivierten regulären Protokollierung/
-  );
-  assert.match(
-    compactPages.en,
-    /Independently of the regular logging disabled by SecPal/
-  );
-  assert.doesNotMatch(compactPages.de, /in eigener Verantwortung/);
-  assert.doesNotMatch(compactPages.en, /under their own responsibility/);
-  assert.doesNotMatch(compactPages.de, /keinerlei Daten verarbeitet/i);
-  assert.doesNotMatch(compactPages.en, /no data (?:is|are) processed/i);
+  assert.match(compactPages.en, /determines the purposes and means/);
 });
 
-test("Cloudflare is limited to authoritative DNS and transfer safeguards", () => {
-  for (const source of Object.values(compactPages)) {
-    assert.match(source, /Cloudflare/);
-    assert.match(source, /DNS-only/);
-    assert.match(source, /Hetzner/);
-    assert.doesNotMatch(source, /changelog\.secpal\.app/i);
-    assert.match(source, /Reverse Proxy/i);
-    assert.match(source, /\bWAF\b/);
-    assert.match(source, /Data Privacy Framework/);
-    assert.match(
-      source,
-      /Standardvertragsklauseln|Standard Contractual Clauses/
-    );
-  }
-  assert.match(compactPages.de, /autoritative DNS-Dienste/);
-  assert.match(compactPages.en, /authoritative DNS services/);
-  assert.doesNotMatch(compactPages.de, /Domainverwaltung/);
-  assert.doesNotMatch(compactPages.en, /domain management/i);
-  assert.match(
-    compactPages.de,
-    /HTTP- und HTTPS-Verkehr[^.]*direkt[^.]*Hetzner/
-  );
-  assert.match(
-    compactPages.en,
-    /HTTP and HTTPS traffic[^.]*directly[^.]*Hetzner/
-  );
-});
-
-test("recipient labels preserve a visible space after the colon", () => {
-  const recipientLabels = {
+test("website and download delivery contains the required processing information", () => {
+  const expectedPatterns = {
     de: [
-      "Hetzner Online GmbH:",
-      "Cloudflare, Inc.:",
-      "Uberspace, betrieben von Jonas Pasche:",
+      /IP-Adresse/,
+      /angeforderte Inhalt/,
+      /vorübergehend verarbeitet/,
+      /Hetzner Online GmbH/,
+      /Art\. 6 Abs\. 1 lit\. f DSGVO/,
+      /berechtigte Interesse/,
+      /keine regulären Webserver-Zugriffs- oder Fehlerprotokolle/,
+      /keine Analyse-, Marketing- oder Trackingdienste/,
+      /nicht dauerhaft gespeichert/,
+      /technisch erforderlichen Verbindungsdaten ist notwendig/,
     ],
     en: [
-      "Hetzner Online GmbH:",
-      "Cloudflare, Inc.:",
-      "Uberspace, operated by Jonas Pasche:",
+      /IP address/,
+      /requested content/,
+      /processed temporarily/,
+      /Hetzner Online GmbH/,
+      /Article 6\(1\)\(f\) GDPR/,
+      /legitimate interest/,
+      /no regular web server access or error logs/,
+      /does not use analytics, marketing, or tracking services/,
+      /not stored permanently/,
+      /technically necessary connection data is required/,
     ],
   };
 
-  for (const [locale, labels] of Object.entries(recipientLabels)) {
-    for (const label of labels) {
-      assert.ok(
-        compactPages[locale].includes(`${label}</strong > {" "}`),
-        `${locale} recipient label "${label}" must retain explicit spacing`
-      );
+  for (const [locale, patterns] of Object.entries(expectedPatterns)) {
+    for (const pattern of patterns) {
+      assert.match(compactPages[locale], pattern);
     }
   }
+  assert.doesNotMatch(compactPages.de, /keine Daten werden verarbeitet/i);
+  assert.doesNotMatch(compactPages.en, /no data is processed/i);
 });
 
-test("inline email links preserve surrounding spaces and punctuation", () => {
-  assert.match(
-    compactPages.de,
-    /Anfragen zu Betroffenenrechten können an\{" "\} <a[^>]*href="mailto:hello@secpal\.app"[^>]*>hello@secpal\.app<\/a\s*> \{" "\} gerichtet werden\./
-  );
-  assert.match(
-    compactPages.en,
-    /Requests concerning data subject rights may be sent to\{" "\} <a[^>]*href="mailto:hello@secpal\.app"[^>]*>hello@secpal\.app<\/a\s*>\{"\."\}/
-  );
-});
+test("local display preference is explained without implementation details", () => {
+  const expectedPatterns = {
+    de: [
+      /Hell- oder Dunkelmodus manuell auswählt/,
+      /lokalen Speicher des Browsers/,
+      /nicht an SecPal oder einen externen Anbieter übermittelt/,
+      /bis sie geändert oder der lokale Browserspeicher gelöscht wird/,
+      /§ 25 Abs\. 2 Nr\. 2 TDDDG/,
+      /erfordert keine Einwilligung/,
+    ],
+    en: [
+      /manually selects light or dark mode/,
+      /browser's local storage/,
+      /not transmitted to SecPal or an external provider/,
+      /until it is changed or the browser's local storage is cleared/,
+      /Section 25\(2\)\(2\) TDDDG/,
+      /does not require consent/,
+    ],
+  };
 
-test("email processing and deletion are documented for Uberspace", () => {
+  for (const [locale, patterns] of Object.entries(expectedPatterns)) {
+    for (const pattern of patterns) {
+      assert.match(compactPages[locale], pattern);
+    }
+  }
   for (const source of Object.values(pages)) {
-    assert.match(source, /Uberspace/);
-    assert.match(source, /Jonas Pasche/);
-    assert.match(source, /hello@secpal\.app/);
-  }
-  assert.match(pages.de, /Nachrichteninhalt/);
-  assert.match(pages.en, /message content/);
-  assert.match(pages.de, /Anhänge/);
-  assert.match(pages.en, /attachments/);
-  assert.match(pages.de, /Art\. 6 Abs\. 1 lit\. b DSGVO/);
-  assert.match(pages.de, /Art\. 6 Abs\. 1 lit\. f DSGVO/);
-  assert.match(pages.en, /Article 6\(1\)\(b\) GDPR/);
-  assert.match(pages.en, /Article 6\(1\)\(f\) GDPR/);
-  assert.match(pages.de, /nach abschließender Bearbeitung/);
-  assert.match(
-    pages.en,
-    /after (?:the request has been finally processed|final processing)/
-  );
-});
-
-test("the local theme preference is the only documented browser storage", () => {
-  for (const source of Object.values(compactPages)) {
-    assert.match(source, /<code[^>]*>theme<\/code\s*>/);
-    assert.match(source, /<code[^>]*>light<\/code\s*>/);
-    assert.match(source, /<code[^>]*>dark<\/code\s*>/);
-  }
-  assert.match(compactPages.de, /lokalen Speicher des Browsers/);
-  assert.match(compactPages.en, /browser's local storage/);
-  assert.match(compactPages.de, /Auf secpal\.app kann eine Person/);
-  assert.match(compactPages.en, /On secpal\.app, a person can manually select/);
-  assert.match(compactPages.de, /§ 25 Abs\. 2 Nr\. 2 TDDDG/);
-  assert.match(compactPages.en, /Section 25\(2\)\(2\) TDDDG/);
-  assert.match(
-    compactPages.de,
-    /weder an SecPal noch an einen externen Anbieter übermittelt/
-  );
-  assert.match(
-    compactPages.en,
-    /not transmitted to SecPal or an external provider/
-  );
-});
-
-test("the pages exclude web analytics, tracking, and visitor profiles", () => {
-  assert.match(
-    compactPages.de,
-    /keine Webanalyse-, Marketing- oder Nutzertrackingdienste/
-  );
-  assert.match(
-    compactPages.en,
-    /does not use web analytics, marketing, or user-tracking services/
-  );
-  assert.match(compactPages.de, /keine Besucherprofile/);
-  assert.match(compactPages.en, /No visitor profiles/);
-  assert.match(
-    compactPages.de,
-    /keine optionalen Analyse- oder Marketing-Cookies/
-  );
-  assert.match(compactPages.en, /no optional analytics or marketing cookies/);
-  for (const source of Object.values(compactPages)) {
-    assert.match(
-      source,
-      /secpal\.app und apk\.secpal\.app|secpal\.app and apk\.secpal\.app/
-    );
+    assert.doesNotMatch(source, /<code\b/i);
+    assert.doesNotMatch(source, /\btheme\b/i);
   }
 });
 
-test("external GitHub navigation is click-only and suppresses the referrer", () => {
-  assert.match(compactPages.de, /externen Angeboten/);
-  assert.match(compactPages.en, /external services/);
-  assert.match(
-    compactPages.de,
-    /Inhalte dieser Anbieter werden nicht eingebettet/
-  );
-  assert.match(compactPages.en, /Content from these providers is not embedded/);
-  assert.match(compactPages.de, /Erst beim Auswählen eines externen Links/);
-  assert.match(compactPages.en, /Only when a person selects an external link/);
-  assert.match(compactPages.de, /jeweilige Anbieter verantwortlich/);
-  assert.match(compactPages.en, /respective provider is responsible/);
-  assert.match(compactPages.de, /HTTP-Referrer/);
-  assert.match(compactPages.en, /HTTP referrer/);
-});
+test("email processing, legal bases, necessity, and deletion remain visible", () => {
+  const expectedPatterns = {
+    de: [
+      /Uberspace/,
+      /Jonas Pasche/,
+      /Mainz/,
+      /Kontaktdaten/,
+      /Inhalt der Nachricht/,
+      /Anhänge/,
+      /Bearbeitung der Anfrage/,
+      /Art\. 6 Abs\. 1 lit\. b DSGVO/,
+      /Art\. 6 Abs\. 1 lit\. f DSGVO/,
+      /Kontaktaufnahme ist freiwillig/,
+      /erreichbare Absenderadresse/,
+      /nach abschließender Bearbeitung/,
+      /gesetzliche Aufbewahrungspflicht/,
+    ],
+    en: [
+      /Uberspace/,
+      /Jonas Pasche/,
+      /Mainz, Germany/,
+      /contact details/,
+      /content of the message/,
+      /attachments/,
+      /handle the inquiry/,
+      /Article 6\(1\)\(b\) GDPR/,
+      /Article 6\(1\)\(f\) GDPR/,
+      /Contact by email is voluntary/,
+      /reachable sender address/,
+      /after the inquiry has been finally processed/,
+      /statutory retention obligation/,
+    ],
+  };
 
-test("every visible SecPal GitHub link suppresses the referrer", () => {
-  const sourceFiles = readdirSync(new URL("../src", import.meta.url), {
-    recursive: true,
-    withFileTypes: true,
-  })
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".astro"))
-    .map(
-      (entry) => new URL(entry.name, new URL(`${entry.parentPath}/`, "file:"))
-    );
-  let linkCount = 0;
-
-  for (const path of sourceFiles) {
-    const source = readFileSync(path, "utf8");
-    const githubAnchors =
-      source.match(
-        /<a\b(?=[^>]*href="https:\/\/github\.com\/SecPal")[^>]*>/g
-      ) ?? [];
-
-    linkCount += githubAnchors.length;
-    for (const anchor of githubAnchors) {
-      assert.match(
-        anchor,
-        /\breferrerpolicy="no-referrer"/,
-        `${path.pathname} contains an unhardened GitHub link`
-      );
-      assert.doesNotMatch(anchor, /\btarget="_blank"/);
+  for (const [locale, patterns] of Object.entries(expectedPatterns)) {
+    for (const pattern of patterns) {
+      assert.match(compactPages[locale], pattern);
     }
   }
-
-  assert.equal(linkCount, 2);
 });
 
-test("superseded app and beta topics are absent from both privacy pages", () => {
-  const forbidden =
-    /\b(?:Beta|beta distribution|Google Play|Play Store|Device Owner|Managed Device|Provisioning|Bootstrap|Push|Benutzerkonto|user account|Beschäftigtendaten|employee data|SaaS|GoAccess|App-Daten löschen|delete app data)\b/i;
+test("data subject rights and supervisory authority remain complete", () => {
+  const expectedPatterns = {
+    de: [
+      /Auskunft/,
+      /Berichtigung/,
+      /Löschung/,
+      /Einschränkung/,
+      /Datenübertragbarkeit/,
+      /Widerspruchsrecht/,
+      /beschweren/,
+      /Landesbeauftragte für den Datenschutz Niedersachsen/,
+      /hello@secpal\.app/,
+    ],
+    en: [
+      /access/,
+      /rectification/,
+      /erasure/,
+      /restriction/,
+      /data portability/,
+      /right to object/,
+      /lodge a complaint/,
+      /State Commissioner for Data Protection of Lower Saxony/,
+      /hello@secpal\.app/,
+    ],
+  };
+
+  for (const [locale, patterns] of Object.entries(expectedPatterns)) {
+    for (const pattern of patterns) {
+      assert.match(compactPages[locale], pattern);
+    }
+    assert.match(pages[locale], /href="mailto:hello@secpal\.app"/);
+    assert.doesNotMatch(pages[locale], /Prinzenstraße 5|30159 Hannover/);
+  }
+});
+
+test("public privacy pages exclude disproportionate infrastructure detail", () => {
+  const forbiddenTerms = [
+    /Cloudflare/i,
+    /Domain Name System/i,
+    /\bDNS\b/i,
+    /DNS-only/i,
+    /Reverse Proxy/i,
+    /\bCDN\b/i,
+    /\bWAF\b/i,
+    /Data Privacy Framework/i,
+    /Standardvertragsklauseln/i,
+    /Standard Contractual Clauses/i,
+    /Drittlandübermittlung/i,
+    /international transfers/i,
+    /GitHub/i,
+    /HTTP-Referrer/i,
+    /HTTP referrer/i,
+    /CRM-Profile/i,
+    /CRM profiles/i,
+    /Warteschlangensystem/i,
+    /queue systems/i,
+    /User-Agent/i,
+    /user agent/i,
+    /Crawlerinformation/i,
+    /crawler information/i,
+    /Besucherprofil/i,
+    /visitor profiling/i,
+    /Einwilligungsbanner/i,
+    /consent banner/i,
+  ];
 
   for (const [locale, source] of Object.entries(pages)) {
-    assert.doesNotMatch(
-      source,
-      forbidden,
-      `${locale} privacy page contains superseded product-internal content`
-    );
+    for (const term of forbiddenTerms) {
+      assert.doesNotMatch(
+        source,
+        term,
+        `${locale} privacy page contains forbidden term ${term}`
+      );
+    }
   }
 });

--- a/tests/privacy-pages.test.mjs
+++ b/tests/privacy-pages.test.mjs
@@ -127,24 +127,42 @@ test("the controller and contact details remain complete and ordered", () => {
   assert.match(pages.en, /Germany/);
 });
 
-test("scope distinguishes public services from customer-operated instances", () => {
+test("scope distinguishes public services from processing inside SecPal instances", () => {
   assert.match(compactPages.de, /öffentliche Website secpal\.app/);
   assert.match(compactPages.de, /Downloadressourcen auf apk\.secpal\.app/);
   assert.match(compactPages.de, /direkte Kontaktaufnahme mit SecPal/);
   assert.match(
     compactPages.de,
-    /nicht für die Verarbeitung personenbezogener Daten innerhalb einer von einem Kunden installierten oder betriebenen SecPal-Instanz/
+    /nicht für die Verarbeitung personenbezogener Daten innerhalb einer installierten oder betriebenen SecPal-Instanz/
   );
-  assert.match(compactPages.de, /über die Zwecke und Mittel[^.]*entscheidet/);
+  assert.match(
+    compactPages.de,
+    /über die Zwecke und Mittel der Verarbeitung innerhalb der jeweiligen Instanz entscheidet/
+  );
 
   assert.match(compactPages.en, /public secpal\.app website/);
   assert.match(compactPages.en, /download resources on apk\.secpal\.app/);
   assert.match(compactPages.en, /direct contact with SecPal/);
   assert.match(
     compactPages.en,
-    /does not apply to the processing of personal data within a SecPal instance installed or operated by a customer/
+    /does not apply to the processing of personal data within an installed or operated SecPal instance/
   );
-  assert.match(compactPages.en, /determines the purposes and means/);
+  assert.match(
+    compactPages.en,
+    /determines the purposes and means of processing within the respective instance/
+  );
+
+  for (const source of Object.values(pages)) {
+    assert.doesNotMatch(
+      source,
+      /von einem Kunden installierten oder betriebenen/i
+    );
+    assert.doesNotMatch(source, /installed or operated by a customer/i);
+    assert.doesNotMatch(
+      source,
+      /customer-operated|customer-hosted|SecPal-operated|self-hosted/i
+    );
+  }
 });
 
 test("website and download delivery contains the required processing information", () => {


### PR DESCRIPTION
## Problem

- The previous public privacy notice was technically overloaded.
- DNS, Cloudflare, referrer, and negative-information details dominated the processing activities relevant to visitors.
- Recipient, necessity, and retention information was spread redundantly across multiple sections.
- The source pages contained 16 numbered sections, including standalone DNS, external-link, recipient, international-transfer, provision, retention, and future-change sections.
- The former regression suite explicitly required Cloudflare, DNS-only, transfer-safeguard, storage-key, crawler, and referrer implementation details instead of protecting a concise visitor-facing disclosure.

## Change

- Reduced both localized notices from 16 to 6 numbered sections.
- Focused the notice on website and download delivery, the local display preference, and contact by email.
- Integrated recipients, retention periods, and necessity directly into the relevant processing activities.
- Removed disproportionate infrastructure detail without weakening visitor-relevant disclosures.
- Fully aligned the German and English versions.
- Reworked the regression tests around required disclosures, exact structure, and forbidden over-technical content.
- Added language-aware heading wrapping to the shared legal-page shell and privacy headings after the 320 px browser check exposed horizontal overflow in long German headings.
- Clarified that the public privacy notice does not cover processing inside any installed or operated SecPal instance, independent of who technically operates it.
- Extended heading-wrap regression coverage after reviewing every localized page that uses the shared legal-page shell.

## Boundaries

- No technical DNS or Cloudflare configuration changed.
- The actual hosting and email providers remain unchanged.
- No hosting, processing-role, or operator model was added for installed SecPal instances.
- No roadmap, marketing, homepage, Android, imprint, security, navigation, footer, theme implementation, server configuration, or domain-policy copy changed.
- Infrastructure documentation and checks outside the public privacy pages remain untouched.

## Validation

- `node --test tests/privacy-pages.test.mjs` — expected pre-implementation failure against the old 16-section notice; final result: 9/9 passed.
- `npm ci` — passed; 429 packages audited, 0 vulnerabilities.
- `npm test` — passed; 71/71 tests.
- `npm run format:check` — passed.
- `npm run check` — passed with zero errors, warnings, or hints.
- `npm run lint` — passed with zero warnings.
- `npm run build` — passed; 16 static pages built.
- `./scripts/preflight.sh` — passed after formatting the `.mjs` test; includes Prettier, REUSE (121/121 files), domain policy, Astro checks, ESLint, build, and commit-signature verification.
- `bash scripts/check-domains.sh` — passed.
- `git diff --check` — passed.
- The forbidden-term search across both privacy pages returned no matches.
- The required-content search confirmed the controller, address, contact address, Hetzner, Uberspace, Jonas Pasche, GDPR legal bases, and TDDDG disclosure.
- The repository-wide `Cloudflare|DNS-only` control search now finds only the forbidden-term expressions in the privacy regression test; no infrastructure or policy file was removed or edited.

## Browser review

Reviewed all localized routes that use the shared legal-page shell:

- `/de/privacy/`
- `/en/privacy/`
- `/de/imprint/`
- `/en/imprint/`
- `/de/security/`
- `/en/security/`

Each route was reviewed at:

- 320 × 568
- 360 × 640
- 412 × 915
- 768 × 1024
- 1440 × 900

Each route and viewport was checked in light and dark mode (60 combinations total). All combinations passed:

- no horizontal overflow, clipped headings, unnatural English hyphenation, empty lists, empty cards, or disproportionate gaps;
- headings, introductions, update dates, and content widths remain visible and correctly positioned;
- email links and keyboard focus states remain visible;
- the language switch opens the corresponding localized legal page;
- the footer remains correctly positioned; and
- no page exceptions, log errors, or browser-console errors were reported.

## Readiness

- The review findings concerning neutral instance scope and shared LegalPageShell browser coverage were addressed.
- No in-scope dependency or unresolved validation currently prevents readiness.
- The pull request remains a draft as requested. It should be marked ready only after the final review in the pull-request view still reports zero findings.
