### PR TITLE
Make PR size reporting advisory

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -9,11 +9,10 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   pr-size:
     name: Check PR Size
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@7f5d24a599c03cdc59998c22578c345c518b755d
     with:
       max-lines: 600

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # Preflight overrides (local only)
-.preflight-allow-large-pr
 
 # Temporary files
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- changed local and hosted pull-request size reporting to treat 600 changed
+  lines as an advisory reviewability threshold, removed the obsolete override
+  file, and preserved all non-size validation failures
 - removed retired standalone changelog links, privacy scope, domain-policy
   allowance, and active documentation before release, and hardened the domain
   check against mixed allowed, forbidden, and retired host references

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,6 +337,7 @@ If you experience issues with the pre-push hook (e.g., it runs on commands other
    This will check your hook installation, git configuration, and shell environment.
 
 2. **Common causes:**
+
    - **Shell prompts** (starship, oh-my-zsh) may execute git commands on every prompt render
    - **Directory hooks** (direnv, `.envrc` files) may trigger on `cd` commands
    - **Git aliases** or wrapper functions may intercept git commands
@@ -369,7 +370,6 @@ If you experience issues with the pre-push hook (e.g., it runs on commands other
 - **Skip tests locally:** Tests are skipped by default in pre-push hooks (run in CI instead)
 - **Force enable tests:** `PREFLIGHT_RUN_TESTS=1 git push` (useful before major PRs)
 - **Force dependency reinstall:** `PREFLIGHT_FORCE_INSTALL=1 git push`
-- **Skip hook temporarily:** `git push --no-verify` (use sparingly)
 
 ## Getting Help
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -145,26 +145,25 @@ if [ "$UNSIGNED" -gt 0 ]; then
 fi
 echo "✅ All commits are signed"
 
-# 3) PR Size Check
-DIFF_STAT=$(git diff --shortstat origin/"$BASE"...HEAD 2>/dev/null || echo "")
-if [ -n "$DIFF_STAT" ]; then
-  LINES_CHANGED=$(git diff --stat origin/"$BASE"...HEAD 2>/dev/null | tail -1 | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
-  DELETIONS=$(git diff --stat origin/"$BASE"...HEAD 2>/dev/null | tail -1 | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
-  TOTAL_CHANGES=$((LINES_CHANGED + DELETIONS))
-  MAX_LINES=600
+# 3) PR size advisory
+MERGE_BASE=$(git merge-base "origin/$BASE" HEAD 2>/dev/null || echo "")
+DIFF_OUTPUT=""
+if [ -n "$MERGE_BASE" ]; then
+  DIFF_OUTPUT=$(git diff --numstat "$MERGE_BASE"..HEAD 2>/dev/null || echo "")
+fi
 
-  # Allow override via local file
-  if [ -f ".preflight-allow-large-pr" ]; then
-    echo "⚠️  Large PR override active (.preflight-allow-large-pr). Document the reason in your PR."
-  elif [ "$TOTAL_CHANGES" -gt "$MAX_LINES" ]; then
-    echo ""
-    echo "⚠️  WARNING: PR is large (${TOTAL_CHANGES} lines changed, limit is ${MAX_LINES})"
-    echo "Consider splitting this into smaller PRs."
-    echo "To override: touch .preflight-allow-large-pr (do NOT commit)"
-    echo ""
-  else
-    echo "✅ PR size OK (${TOTAL_CHANGES}/${MAX_LINES} lines)"
-  fi
+PR_SIZE_ADVISORY_THRESHOLD=600
+INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
+DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
+TOTAL_CHANGES=$((INSERTIONS + DELETIONS))
+SIZE_REPORT="PR size: $TOTAL_CHANGES changed lines ($INSERTIONS insertions, $DELETIONS deletions; advisory threshold: $PR_SIZE_ADVISORY_THRESHOLD)"
+
+if [ "$TOTAL_CHANGES" -gt "$PR_SIZE_ADVISORY_THRESHOLD" ]; then
+  echo "$SIZE_REPORT" >&2
+  echo "WARNING: PR size advisory threshold exceeded." >&2
+  echo "Keep this pull request focused on one logical topic and make the review plan explicit." >&2
+else
+  echo "Preflight OK · $SIZE_REPORT"
 fi
 
 echo ""

--- a/tests/pr-size-advisory.sh
+++ b/tests/pr-size-advisory.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/secpal-app-pr-size-advisory.XXXXXX")"
+trap 'rm -rf -- "$fixture"' EXIT
+
+mkdir -p "$fixture/scripts" "$fixture/bin"
+cp "$repo_root/scripts/preflight.sh" "$fixture/scripts/preflight.sh"
+real_git="$(command -v git)"
+sed "s|@REAL_GIT@|$real_git|" >"$fixture/bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "log" ] && [[ " $* " == *' --format=%G? '* ]]; then
+  echo G
+  exit 0
+fi
+exec @REAL_GIT@ "$@"
+EOF
+chmod +x "$fixture/bin/git"
+for command in npx npm reuse; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$fixture/bin/$command"
+  chmod +x "$fixture/bin/$command"
+done
+
+(
+  cd "$fixture"
+  git init --quiet --initial-branch=main
+  git config user.name "SecPal Test"
+  git config user.email "test@secpal.dev"
+  git config commit.gpgSign false
+  : >seed.txt
+  git add .
+  git commit --quiet -m "test: seed fixture"
+  git remote add origin "$fixture"
+  git update-ref refs/remotes/origin/main HEAD
+  git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+  git checkout --quiet -b test-branch
+  awk 'BEGIN { for (line = 1; line <= 601; line++) print "line " line }' >large.txt
+  git add large.txt
+  git commit --quiet -m "test: exceed advisory threshold"
+)
+
+set +e
+(cd "$fixture" && PATH="$fixture/bin:/usr/bin:/bin" bash scripts/preflight.sh) \
+  >"$fixture/stdout" 2>"$fixture/stderr"
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  cat "$fixture/stdout" "$fixture/stderr" >&2
+fi
+test "$status" -eq 0
+if ! grep -Fq "PR size: 601 changed lines (601 insertions, 0 deletions; advisory threshold: 600)" \
+  "$fixture/stderr"; then
+  cat "$fixture/stdout" "$fixture/stderr" >&2
+  exit 1
+fi
+grep -Fq "WARNING: PR size advisory threshold exceeded." "$fixture/stderr"
+if grep -Fq ".preflight-allow-large-pr" "$repo_root/scripts/preflight.sh" ||
+  grep -Fq "limit is" "$repo_root/scripts/preflight.sh"; then
+  echo "Obsolete size-override policy remains active" >&2
+  exit 1
+fi
+
+echo "tests/pr-size-advisory.sh: advisory PR-size reporting verified."


### PR DESCRIPTION
## Problem

Pull-request size policy had drifted across managed repositories: copied local
preflight implementations could still treat 600 changed lines as a hard
boundary, while hosted callers and documentation retained obsolete permissions
or override concepts.

## Root cause

Repository-local preflight copies evolve independently from the central reusable
workflow, and mutable or stale caller configuration allowed the local and hosted
policy surfaces to diverge.

## Changes

- make the repository's PR-size behavior advisory-only
- report insertions, deletions, total changed lines, and the 600-line advisory
  threshold where local calculation exists
- remove obsolete size override behavior and unused hosted permissions where
  applicable
- pin the hosted caller to the reviewed advisory governance revision
- add or update focused regression coverage when the repository has executable
  local size policy

## TDD / Validate-First Evidence

Focused regression coverage was added or updated before the executable policy
change and recorded a failing result against the previous behavior. After the
implementation, the focused repository regression and the deterministic
organization-wide validator both passed. Repositories without a local size gate
are covered by the central validator so no local gate was introduced merely for
consistency.

## Validation

- focused PR-size regression: passed
- changed-file formatting, Markdown, ShellCheck, YAML, and actionlint checks:
  passed where applicable
- repository-required final local preflight: passed
- commit signature verification: passed

## Boundaries

600 is an advisory reviewability threshold, not a correctness boundary.
The one-PR-one-topic rule remains strict.
No size override file or approval label is required.
No non-size quality gate was weakened.
GitHub-hosted CI was not inspected.
