### PR TITLE
Remove retired changelog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- removed the remaining retired standalone changelog host exceptions and
+  dedicated regression cases from website domain policy
 - removed retired standalone changelog links, privacy scope, domain-policy
   allowance, and active documentation before release, and hardened the domain
   check against mixed allowed, forbidden, and retired host references

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -58,11 +58,7 @@ domains=$(printf '%s\n' "$matches" | \
 # (including api/app subdomains), apk.secpal.app, the app.secpal Android
 # identifier, and deprecated-but-allowed api.secpal.app.
 violations=$(printf '%s\n' "$domains" | \
-    grep -Evi '^(secpal\.app(\.git)?|www\.secpal\.app|apk\.secpal\.app|(\*\.)?([A-Za-z0-9-]+\.)*secpal\.dev|api\.secpal\.app|app\.secpal)\.?$' |
-    grep -Evi '^changelog\.secpal\.app\.?$' || true)
-
-retired_web_hosts=$(printf '%s\n' "$domains" | \
-    grep -Ei '^changelog\.secpal\.app\.?$' || true)
+    grep -Evi '^(secpal\.app(\.git)?|www\.secpal\.app|apk\.secpal\.app|(\*\.)?([A-Za-z0-9-]+\.)*secpal\.dev|api\.secpal\.app|app\.secpal)\.?$' || true)
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -Ei 'api\.secpal\.app' | \
@@ -92,7 +88,7 @@ deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -v -- 'must not appear as active web hosts' | \
     grep -v -- 'not treated as a deployable web domain' || true)
 
-if [[ -z "$violations" && -z "$retired_web_hosts" && -z "$deprecated_web_hosts" ]]; then
+if [[ -z "$violations" && -z "$deprecated_web_hosts" ]]; then
     echo -e "${GREEN}✅ Domain Policy Check PASSED${NC}"
     echo "All domain usage matches the approved SecPal split"
     exit 0
@@ -102,11 +98,6 @@ else
     if [[ -n "$violations" ]]; then
         echo "Found forbidden domains:"
         echo "$violations"
-        echo ""
-    fi
-    if [[ -n "$retired_web_hosts" ]]; then
-        echo "Found retired web hosts:"
-        echo "$retired_web_hosts"
         echo ""
     fi
     if [[ -n "$deprecated_web_hosts" ]]; then

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = new URL("../", import.meta.url);
 const retiredDomain = ["dev", "secpal", "app"].join(".");
+const retiredChangelogDomain = ["changelog", "secpal", "app"].join(".");
 const forbiddenDomain = ["secpal", "xyz"].join(".");
 const domainCheckScript = fileURLToPath(
   new URL("../scripts/check-domains.sh", import.meta.url)
@@ -84,6 +85,32 @@ test("the repository scan rejects mixed-case retired domains", (t) => {
 
   const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
   assert.deepEqual(findMatchingFiles(temporaryRoot), ["mixed-case.txt"]);
+});
+
+test("the domain policy rejects the former changelog host beside an allowed host", (t) => {
+  const temporaryDirectory = mkdtempSync(
+    join(tmpdir(), "secpal-domain-policy-")
+  );
+  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+  writeFileSync(
+    join(temporaryDirectory, "mixed-host.md"),
+    `Current site: secpal.app; former site: ${retiredChangelogDomain}`
+  );
+
+  assert.throws(
+    () =>
+      execFileSync("bash", [domainCheckScript], {
+        cwd: temporaryDirectory,
+        encoding: "utf8",
+      }),
+    (error) => {
+      assert.equal(error?.status, 1);
+      assert.match(error.stdout, /Found forbidden domains:/);
+      assert.ok(error.stdout.includes(retiredChangelogDomain));
+      return true;
+    }
+  );
 });
 
 test("the domain policy rejects a forbidden domain beside an allowed host", (t) => {

--- a/tests/retired-domain.test.mjs
+++ b/tests/retired-domain.test.mjs
@@ -11,7 +11,6 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = new URL("../", import.meta.url);
 const retiredDomain = ["dev", "secpal", "app"].join(".");
-const retiredChangelogDomain = ["changelog", "secpal", "app"].join(".");
 const forbiddenDomain = ["secpal", "xyz"].join(".");
 const domainCheckScript = fileURLToPath(
   new URL("../scripts/check-domains.sh", import.meta.url)
@@ -85,32 +84,6 @@ test("the repository scan rejects mixed-case retired domains", (t) => {
 
   const temporaryRoot = pathToFileURL(`${temporaryRepository}/`);
   assert.deepEqual(findMatchingFiles(temporaryRoot), ["mixed-case.txt"]);
-});
-
-test("the domain policy rejects a retired changelog host beside an allowed host", (t) => {
-  const temporaryDirectory = mkdtempSync(
-    join(tmpdir(), "secpal-domain-policy-")
-  );
-  t.after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
-
-  writeFileSync(
-    join(temporaryDirectory, "mixed-host.md"),
-    `Current site: secpal.app; retired site: ${retiredChangelogDomain}`
-  );
-
-  assert.throws(
-    () =>
-      execFileSync("bash", [domainCheckScript], {
-        cwd: temporaryDirectory,
-        encoding: "utf8",
-      }),
-    (error) => {
-      assert.equal(error?.status, 1);
-      assert.match(error.stdout, /Found retired web hosts:/);
-      assert.ok(error.stdout.includes(retiredChangelogDomain));
-      return true;
-    }
-  );
 });
 
 test("the domain policy rejects a forbidden domain beside an allowed host", (t) => {

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { en } from "../src/i18n/en.ts";

--- a/tests/roadmap-copy.test.mjs
+++ b/tests/roadmap-copy.test.mjs
@@ -75,15 +75,3 @@ test("roadmap reflects the current shift-planning and OWKS priorities", () => {
     "expected German Android app work to be removed from the active roadmap phases"
   );
 });
-
-test("roadmap has no retired changelog call to action", () => {
-  const roadmapComponent = readFileSync(
-    new URL("../src/components/Roadmap.astro", import.meta.url),
-    "utf8"
-  );
-
-  assert.ok(!("changelog" in en.roadmap));
-  assert.ok(!("changelog" in de.roadmap));
-  assert.doesNotMatch(roadmapComponent, /changelog\.secpal\.app/i);
-  assert.doesNotMatch(roadmapComponent, /r\.changelog/);
-});


### PR DESCRIPTION
## Summary

- remove the retired standalone changelog host exception from website domain policy
- remove dedicated retired-changelog regression cases that now encode obsolete behavior
- document the cleanup in the unreleased changelog

## Why

The standalone changelog site has been permanently retired, so the website repository should not preserve dedicated exceptions or compatibility tests for it.

## Validation

- `bash scripts/check-domains.sh`
- `node --test tests/retired-domain.test.mjs tests/roadmap-copy.test.mjs` (5 tests)
- `reuse lint`
- Prettier check for changed Markdown and JavaScript files
