### PR TITLE
Pin external workflow references to commit SHAs

### DIFF
--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   check-conflicts:
-    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@8afe1087d89952eacefd829ee1a226af111b9d8a # v1
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e # v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@8afe1087d89952eacefd829ee1a226af111b9d8a # v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   pr-size:
     name: Check PR Size
-    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-pr-size.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       max-lines: 600

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -30,6 +30,7 @@ jobs:
   check-project-automation-secrets:
     name: Check project automation secrets
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       available: ${{ steps.check.outputs.available }}
     steps:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -50,14 +50,14 @@ jobs:
     name: Project automation
     needs: check-project-automation-secrets
     if: needs.check-project-automation-secrets.outputs.available == 'true'
-    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   draft-reminder:
     name: Draft PR Reminder
-    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,51 +18,51 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       node-version: "22"
 
   astro-check:
     name: Astro TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       node-version: "22"
       build-command: "npm run check"
 
   build:
     name: Astro Build
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       node-version: "22"
       build-command: "npm run build"
 
   test:
     name: Node Tests
-    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       node-version: "22"
       test-command: "npm test"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,51 +18,51 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
 
   prettier:
     name: Formatting Check
-    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-prettier.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   eslint:
     name: ESLint
-    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       node-version: "22"
 
   astro-check:
     name: Astro TypeScript Check
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       node-version: "22"
       build-command: "npm run check"
 
   build:
     name: Astro Build
-    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-node-build.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       node-version: "22"
       build-command: "npm run build"
 
   test:
     name: Node Tests
-    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee
+    uses: SecPal/.github/.github/workflows/reusable-node-test.yml@177beb19b9f20978480bf96f1ada74e8bbbaccee # main
     with:
       node-version: "22"
       test-command: "npm test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- bounded the project-automation secret check and made workflow-pin regression
+  failures identify the offending missing revision or source annotation
 - pinned every external GitHub Actions workflow reference to a full commit SHA
   with its source tag or branch recorded inline, preventing mutable action
   revisions from changing workflow behavior unexpectedly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- pinned every external GitHub Actions workflow reference to a full commit SHA
+  with its source tag or branch recorded inline, preventing mutable action
+  revisions from changing workflow behavior unexpectedly
 - made retired-domain validation tolerate tracked files deleted from the
   working tree and reject mixed-case hostnames, so local validation remains
   usable during removals without allowing case-based policy bypasses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- parsed GitHub Actions workflows as YAML when checking immutable action pins,
+  covering valid multiline scalar syntax
 - bounded the project-automation secret check and made workflow-pin regression
   failures identify the offending missing revision or source annotation
 - pinned every external GitHub Actions workflow reference to a full commit SHA

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "prettier-plugin-astro": "^0.14.1",
         "sharp": "^0.35.3",
         "tailwindcss": "^4.3.0",
-        "typescript": "6.0.x"
+        "typescript": "6.0.x",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@astrojs/check": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "prettier-plugin-astro": "^0.14.1",
     "sharp": "^0.35.3",
     "tailwindcss": "^4.3.0",
-    "typescript": "6.0.x"
+    "typescript": "6.0.x",
+    "yaml": "^2.8.3"
   },
   "overrides": {
     "anymatch": {

--- a/tests/workflow-action-pins.test.mjs
+++ b/tests/workflow-action-pins.test.mjs
@@ -36,6 +36,31 @@ function workflowPath(directory, entryName) {
   return join(fileURLToPath(directory), entryName);
 }
 
+function assertImmutableWorkflowReference({ reference, source, location }) {
+  const revisionStart = reference.lastIndexOf("@");
+  const revision =
+    revisionStart === -1 ? "" : reference.slice(revisionStart + 1);
+  const annotation = source ?? "";
+
+  assert.notEqual(
+    revisionStart,
+    -1,
+    `${location} must include an @ followed by a full commit SHA`
+  );
+  assert.ok(revision, `${location} must include a full commit SHA`);
+  assert.ok(annotation, `${location} must identify the source tag or branch`);
+  assert.match(
+    revision,
+    immutableRevision,
+    `${location} must use a full commit SHA`
+  );
+  assert.match(
+    annotation,
+    sourceReference,
+    `${location} must identify the source tag or branch`
+  );
+}
+
 function externalWorkflowReferences() {
   return readdirSync(workflowsDirectory, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
@@ -111,6 +136,48 @@ test("workflow paths decode file URL path segments", () => {
   );
 });
 
+test("missing workflow pin details report actionable assertion failures", () => {
+  assert.throws(
+    () =>
+      assertImmutableWorkflowReference({
+        reference: "actions/checkout",
+        source: "v7",
+        location: "fixture.yml:1",
+      }),
+    /fixture\.yml:1 must include an @ followed by a full commit SHA/
+  );
+  assert.throws(
+    () =>
+      assertImmutableWorkflowReference({
+        reference: "actions/checkout@",
+        source: "v7",
+        location: "fixture.yml:2",
+      }),
+    /fixture\.yml:2 must include a full commit SHA/
+  );
+  assert.throws(
+    () =>
+      assertImmutableWorkflowReference({
+        reference: "actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        source: undefined,
+        location: "fixture.yml:3",
+      }),
+    /fixture\.yml:3 must identify the source tag or branch/
+  );
+});
+
+test("project automation secret checks have a bounded timeout", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/project-automation.yml", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(
+    workflow,
+    /  check-project-automation-secrets:\n(?:    [^\n]*\n)*?    timeout-minutes:/
+  );
+});
+
 test("external workflow references use immutable revisions with source annotations", () => {
   const references = externalWorkflowReferences();
 
@@ -120,18 +187,10 @@ test("external workflow references use immutable revisions with source annotatio
   );
 
   for (const { file, line, reference, source } of references) {
-    const [, revision] = reference.split("@");
-    const location = `${file}:${line}`;
-
-    assert.match(
-      revision,
-      immutableRevision,
-      `${location} must use a full commit SHA`
-    );
-    assert.match(
+    assertImmutableWorkflowReference({
+      reference,
       source,
-      sourceReference,
-      `${location} must identify the source tag or branch`
-    );
+      location: `${file}:${line}`,
+    });
   }
 });

--- a/tests/workflow-action-pins.test.mjs
+++ b/tests/workflow-action-pins.test.mjs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const workflowsDirectory = new URL("../.github/workflows/", import.meta.url);
+const immutableRevision = /^[0-9a-f]{40}$/;
+const sourceReference = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+function externalWorkflowReferences() {
+  return readdirSync(workflowsDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+    .flatMap((entry) => {
+      const workflowPath = join(workflowsDirectory.pathname, entry.name);
+
+      return readFileSync(workflowPath, "utf8")
+        .split("\n")
+        .flatMap((line, index) => {
+          const match = line.match(
+            /^\s*uses:\s*([^\s#]+)(?:\s+#\s*(\S+))?\s*$/
+          );
+
+          if (!match || match[1].startsWith("./")) {
+            return [];
+          }
+
+          return [
+            {
+              file: entry.name,
+              line: index + 1,
+              reference: match[1],
+              source: match[2],
+            },
+          ];
+        });
+    });
+}
+
+test("external workflow references use immutable revisions with source annotations", () => {
+  const references = externalWorkflowReferences();
+
+  assert.ok(
+    references.length > 0,
+    "expected at least one external workflow reference"
+  );
+
+  for (const { file, line, reference, source } of references) {
+    const [, revision] = reference.split("@");
+    const location = `${file}:${line}`;
+
+    assert.match(
+      revision,
+      immutableRevision,
+      `${location} must use a full commit SHA`
+    );
+    assert.match(
+      source,
+      sourceReference,
+      `${location} must identify the source tag or branch`
+    );
+  }
+});

--- a/tests/workflow-action-pins.test.mjs
+++ b/tests/workflow-action-pins.test.mjs
@@ -6,34 +6,70 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { LineCounter, isMap, isScalar, isSeq, parseDocument } from "yaml";
 
 const workflowsDirectory = new URL("../.github/workflows/", import.meta.url);
 const immutableRevision = /^[0-9a-f]{40}$/;
 const sourceReference = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
-function parseExternalWorkflowReference(line) {
-  const blockMatch = line.match(
-    /^\s*(?:-\s+)?(?:"uses"|'uses'|uses)\s*:\s*("[^"]+"|'[^']+'|[^\s#]+)(?:\s+#\s*(.*?))?\s*$/
-  );
-  const flowMatch = line.match(
-    /^\s*-\s*\{.*?(?:"uses"|'uses'|uses)\s*:\s*("[^"]+"|'[^']+'|[^,\s#}]+).*?\}\s*(?:#\s*(.*?))?\s*$/
-  );
-  const match = blockMatch ?? flowMatch;
-  const rawReference = match?.[1];
-  const reference = rawReference?.replace(/^(?:"(.*)"|'(.*)')$/, "$1$2");
-
-  if (!reference || reference.startsWith("./")) {
-    return null;
-  }
-
-  return {
-    reference,
-    source: match[2],
-  };
-}
-
 function workflowPath(directory, entryName) {
   return join(fileURLToPath(directory), entryName);
+}
+
+function externalWorkflowReferencesFromSource(file, source) {
+  const lineCounter = new LineCounter();
+  const document = parseDocument(source, {
+    lineCounter,
+    prettyErrors: false,
+    strict: true,
+  });
+  const parseErrors = document.errors.map((error) => error.message).join("; ");
+
+  assert.equal(
+    document.errors.length,
+    0,
+    `${file} must contain valid YAML${parseErrors ? `: ${parseErrors}` : ""}`
+  );
+
+  const lines = source.split("\n");
+  const references = [];
+
+  function visit(node) {
+    if (isMap(node)) {
+      for (const pair of node.items) {
+        if (isScalar(pair.key) && pair.key.value === "uses") {
+          const offset = pair.value?.range?.[0] ?? pair.key.range?.[0] ?? 0;
+          const line = lineCounter.linePos(offset).line;
+
+          assert.ok(
+            isScalar(pair.value) && typeof pair.value.value === "string",
+            `${file}:${line} uses must be a string scalar`
+          );
+
+          const reference = pair.value.value;
+
+          if (!reference.startsWith("./")) {
+            references.push({
+              file,
+              line,
+              reference,
+              source: lines[line - 1]?.match(/#\s*(.*?)\s*$/)?.[1],
+            });
+          }
+        }
+
+        visit(pair.value);
+      }
+    } else if (isSeq(node)) {
+      for (const item of node.items) {
+        visit(item);
+      }
+    }
+  }
+
+  visit(document.contents);
+
+  return references;
 }
 
 function assertImmutableWorkflowReference({ reference, source, location }) {
@@ -67,23 +103,10 @@ function externalWorkflowReferences() {
     .flatMap((entry) => {
       const path = workflowPath(workflowsDirectory, entry.name);
 
-      return readFileSync(path, "utf8")
-        .split("\n")
-        .flatMap((line, index) => {
-          const parsedReference = parseExternalWorkflowReference(line);
-
-          if (!parsedReference) {
-            return [];
-          }
-
-          return [
-            {
-              file: entry.name,
-              line: index + 1,
-              ...parsedReference,
-            },
-          ];
-        });
+      return externalWorkflowReferencesFromSource(
+        entry.name,
+        readFileSync(path, "utf8")
+      );
     });
 }
 
@@ -91,38 +114,40 @@ test("external workflow references are discovered in valid YAML forms", () => {
   const revision = "a".repeat(40);
 
   assert.deepEqual(
-    parseExternalWorkflowReference("- uses: actions/checkout@v7 # v7"),
-    {
-      reference: "actions/checkout@v7",
-      source: "v7",
-    }
+    externalWorkflowReferencesFromSource(
+      "fixture.yml",
+      `steps:
+  - uses: actions/checkout@v7 # v7
+  - "uses": "actions/checkout@${revision}" # v7
+  - 'uses': 'actions/checkout@v7' # v7
+  - { name: Checkout, uses: "actions/checkout@${revision}" } # v7
+  - uses: ./local-action
+`
+    ).map(({ reference, source }) => ({ reference, source })),
+    [
+      { reference: "actions/checkout@v7", source: "v7" },
+      { reference: `actions/checkout@${revision}`, source: "v7" },
+      { reference: "actions/checkout@v7", source: "v7" },
+      { reference: `actions/checkout@${revision}`, source: "v7" },
+    ]
   );
+});
+
+test("external workflow references are discovered in multiline YAML scalars", () => {
   assert.deepEqual(
-    parseExternalWorkflowReference(
-      `"uses": "actions/checkout@${revision}" # v7`
+    externalWorkflowReferencesFromSource(
+      "fixture.yml",
+      'steps:\n  - uses:\n      "actions/checkout@v7" # v7\n'
     ),
-    {
-      reference: `actions/checkout@${revision}`,
-      source: "v7",
-    }
+    [
+      {
+        file: "fixture.yml",
+        line: 3,
+        reference: "actions/checkout@v7",
+        source: "v7",
+      },
+    ]
   );
-  assert.deepEqual(
-    parseExternalWorkflowReference("uses: 'actions/checkout@v7' # v7 release"),
-    {
-      reference: "actions/checkout@v7",
-      source: "v7 release",
-    }
-  );
-  assert.deepEqual(
-    parseExternalWorkflowReference(
-      `- { name: Checkout, uses: "actions/checkout@${revision}" } # v7`
-    ),
-    {
-      reference: `actions/checkout@${revision}`,
-      source: "v7",
-    }
-  );
-  assert.equal(parseExternalWorkflowReference("- uses: ./local-action"), null);
 });
 
 test("workflow paths decode file URL path segments", () => {

--- a/tests/workflow-action-pins.test.mjs
+++ b/tests/workflow-action-pins.test.mjs
@@ -5,25 +5,49 @@ import assert from "node:assert/strict";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const workflowsDirectory = new URL("../.github/workflows/", import.meta.url);
 const immutableRevision = /^[0-9a-f]{40}$/;
 const sourceReference = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
+function parseExternalWorkflowReference(line) {
+  const blockMatch = line.match(
+    /^\s*(?:-\s+)?(?:"uses"|'uses'|uses)\s*:\s*("[^"]+"|'[^']+'|[^\s#]+)(?:\s+#\s*(.*?))?\s*$/
+  );
+  const flowMatch = line.match(
+    /^\s*-\s*\{.*?(?:"uses"|'uses'|uses)\s*:\s*("[^"]+"|'[^']+'|[^,\s#}]+).*?\}\s*(?:#\s*(.*?))?\s*$/
+  );
+  const match = blockMatch ?? flowMatch;
+  const rawReference = match?.[1];
+  const reference = rawReference?.replace(/^(?:"(.*)"|'(.*)')$/, "$1$2");
+
+  if (!reference || reference.startsWith("./")) {
+    return null;
+  }
+
+  return {
+    reference,
+    source: match[2],
+  };
+}
+
+function workflowPath(directory, entryName) {
+  return join(fileURLToPath(directory), entryName);
+}
+
 function externalWorkflowReferences() {
   return readdirSync(workflowsDirectory, { withFileTypes: true })
     .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
     .flatMap((entry) => {
-      const workflowPath = join(workflowsDirectory.pathname, entry.name);
+      const path = workflowPath(workflowsDirectory, entry.name);
 
-      return readFileSync(workflowPath, "utf8")
+      return readFileSync(path, "utf8")
         .split("\n")
         .flatMap((line, index) => {
-          const match = line.match(
-            /^\s*uses:\s*([^\s#]+)(?:\s+#\s*(\S+))?\s*$/
-          );
+          const parsedReference = parseExternalWorkflowReference(line);
 
-          if (!match || match[1].startsWith("./")) {
+          if (!parsedReference) {
             return [];
           }
 
@@ -31,13 +55,61 @@ function externalWorkflowReferences() {
             {
               file: entry.name,
               line: index + 1,
-              reference: match[1],
-              source: match[2],
+              ...parsedReference,
             },
           ];
         });
     });
 }
+
+test("external workflow references are discovered in valid YAML forms", () => {
+  const revision = "a".repeat(40);
+
+  assert.deepEqual(
+    parseExternalWorkflowReference("- uses: actions/checkout@v7 # v7"),
+    {
+      reference: "actions/checkout@v7",
+      source: "v7",
+    }
+  );
+  assert.deepEqual(
+    parseExternalWorkflowReference(
+      `"uses": "actions/checkout@${revision}" # v7`
+    ),
+    {
+      reference: `actions/checkout@${revision}`,
+      source: "v7",
+    }
+  );
+  assert.deepEqual(
+    parseExternalWorkflowReference("uses: 'actions/checkout@v7' # v7 release"),
+    {
+      reference: "actions/checkout@v7",
+      source: "v7 release",
+    }
+  );
+  assert.deepEqual(
+    parseExternalWorkflowReference(
+      `- { name: Checkout, uses: "actions/checkout@${revision}" } # v7`
+    ),
+    {
+      reference: `actions/checkout@${revision}`,
+      source: "v7",
+    }
+  );
+  assert.equal(parseExternalWorkflowReference("- uses: ./local-action"), null);
+});
+
+test("workflow paths decode file URL path segments", () => {
+  const directory = new URL(
+    "file:///tmp/SecPal%20workspace/.github/workflows/"
+  );
+
+  assert.equal(
+    workflowPath(directory, "quality.yml"),
+    join(fileURLToPath(directory), "quality.yml")
+  );
+});
 
 test("external workflow references use immutable revisions with source annotations", () => {
   const references = externalWorkflowReferences();


### PR DESCRIPTION
## Summary

Six external workflow references used mutable branch or tag revisions. That
allowed a later branch or tag change to alter workflow behavior without a
repository change.

- Pin every external `uses:` reference in `.github/workflows` to a verified
  40-character commit SHA and record its source tag or branch inline.
- Add regression coverage that enforces immutable revisions and annotations
  without depending on production SHA values.
- Align the quality and Dependabot reusable-workflow callers with the verified
  shared-workflow revision that resolves their startup failures.
- Record the workflow hardening in the changelog.

## Evidence

The local inventory now contains no mutable external `uses:` reference. The
shared-workflow `main` and `v1` refs, `actions/checkout` `v7`, and CodeQL
`v4.37.5` were verified against their upstream Git references.

The earlier Quality Checks and Dependabot Auto-Merge runs failed during
workflow startup and produced no jobs. Their callers now use the shared
workflow revision already used successfully by the other reusable workflows.

## Validation

- `npm test` (74 passing tests)
- `npm run lint`
- `npx --no-install prettier --check CHANGELOG.md .github/workflows tests/workflow-action-pins.test.mjs`
- `reuse lint`
- Repository pre-commit checks, including YAML and GitHub Actions validation

## Unresolved check

Direct `yamllint .github/workflows` emits existing policy warnings where the
required SHA-and-source form conflicts with the repository's Prettier and
line-length rules. This is tracked in #265; the repository pre-commit YAML
check passes.

Closes #262 and #267.

Related to SecPal/.github#626.
