### PR TITLE
fix: resolve npm audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- updated transitive `brace-expansion` and `nanoid` dependencies to patched
+  releases, resolving their high-severity denial-of-service advisories
 - parsed GitHub Actions workflows as YAML when checking immutable action pins,
   covering valid multiline scalar syntax
 - bounded the project-automation secret check and made workflow-pin regression

--- a/package-lock.json
+++ b/package-lock.json
@@ -3312,9 +3312,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5849,9 +5849,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,12 @@
     "anymatch": {
       "picomatch": "^2.3.2"
     },
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.9",
     "defu": "^6.1.7",
     "micromatch": {
       "picomatch": "^2.3.2"
     },
+    "nanoid": "^3.3.17",
     "picomatch": "^4.0.4",
     "yaml": "^2.8.3"
   },


### PR DESCRIPTION
## Summary

- resolves two high-severity transitive dependency advisories reported by `npm audit`
- updates the `brace-expansion` and `nanoid` overrides and their lockfile resolutions
- records the security fix in `CHANGELOG.md`

## Problem and evidence

Before this change, `npm audit --json` reported two high-severity denial-of-service advisories:

- `brace-expansion` 5.0.8, introduced through `eslint` and `minimatch`, was below the patched 5.0.9 release
- `nanoid` 3.3.16, introduced through `eslint-plugin-astro` and `postcss`, was below the patched 3.3.17 release

Both packages are transitive development dependencies. The overrides in `package.json` now resolve `brace-expansion` to 5.0.9 and `nanoid` to 3.3.18.

## Validation

- `npm audit --json` — 0 vulnerabilities
- `npm test` — 77 passing tests
- `npm run lint`
- `npm run check` — 0 errors, warnings, and hints
- `npm run build`
- `npm run format:check`
- `reuse lint`
- `git diff --check`

## Readiness

No in-scope dependencies or unresolved checks prevent review readiness.
