### PR TITLE
Fix workflow YAML linting compatibility

### DIFF
--- a/.github/workflows/check-conflict-markers.yml
+++ b/.github/workflows/check-conflict-markers.yml
@@ -14,4 +14,5 @@ permissions:
 
 jobs:
   check-conflicts:
+    # yamllint disable-line rule:line-length
     uses: SecPal/.github/.github/workflows/reusable-check-conflict-markers.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   auto-merge:
+    # yamllint disable-line rule:line-length
     uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -22,6 +22,7 @@ jobs:
 
   license-compatibility:
     name: Check License Compatibility
+    # yamllint disable-line rule:line-length
     uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@eefac02583d4c50c77323c0200745ab4fb988fa1 # main
 
   prettier:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,10 +4,18 @@
 extends: default
 
 rules:
-  # Allow longer lines (default is 80)
+  # Allow longer lines (default is 80). Immutable action references that
+  # include a same-line source annotation use a targeted disable-line.
   line-length:
     max: 120
     level: warning
+
+  # Match Prettier's one-space inline comment convention.
+  comments:
+    min-spaces-from-content: 1
+
+  # Workflows do not require a document-start marker, and Prettier does not add one.
+  document-start: disable
 
   # GitHub Actions workflows often have long keys
   key-ordering: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - updated transitive `brace-expansion` and `nanoid` dependencies to patched
   releases, resolving their high-severity denial-of-service advisories
+- reconciled workflow YAML linting with Prettier's inline-comment convention,
+  made document-start markers optional, and scoped line-length exemptions to
+  immutable action references that retain their same-line source annotations
 - parsed GitHub Actions workflows as YAML when checking immutable action pins,
   covering valid multiline scalar syntax
 - bounded the project-automation secret check and made workflow-pin regression


### PR DESCRIPTION
Fixes #265

## Problem and evidence

The default YAML lint rules conflict with the repository's Prettier output and immutable workflow references:

- `.github/workflows/codeql.yml:37`, `:40`, `:46`, and `:49` use Prettier-preserved one-space source annotations.
- Several workflows omit optional document-start markers.
- `.github/workflows/check-conflict-markers.yml:18`, `.github/workflows/dependabot-auto-merge.yml:33`, and `.github/workflows/quality.yml:26` exceed 120 characters only because immutable SHA references retain required same-line source annotations.

## Changes

- Configure YAML linting to accept one-space inline comments and optional document-start markers.
- Retain the 120-character limit and exempt only the three immutable `uses:` lines that cannot be wrapped safely.
- Document the correction in `CHANGELOG.md`.

Workflow behavior, immutable revisions, and source annotations are unchanged.

## Validation

- `yamllint .yamllint.yml .github/workflows`
- `npx prettier --check CHANGELOG.md .yamllint.yml .github/workflows`
- `npm test` (77 passing tests, including immutable workflow-reference coverage)
- `reuse lint`
- Repository commit hooks, including YAML linting and workflow-file linting

## Draft status

`actionlint` is not installed in this workspace, so it could not be run locally. This is the only unresolved in-scope local check before the draft can be considered ready.
