### PR TITLE
Remove obsolete large-PR override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Preflight overrides (local only)
-.preflight-allow-large-pr
-
 # Temporary files
 *.tmp
 *.temp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- removed the obsolete local large-PR override mechanism, keeping the 600-line
+  threshold advisory in preflight to match the shared pull-request size check
 - updated transitive `brace-expansion` and `nanoid` dependencies to patched
   releases, resolving their high-severity denial-of-service advisories
 - reconciled workflow YAML linting with Prettier's inline-comment convention,

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -153,14 +153,10 @@ if [ -n "$DIFF_STAT" ]; then
   TOTAL_CHANGES=$((LINES_CHANGED + DELETIONS))
   MAX_LINES=600
 
-  # Allow override via local file
-  if [ -f ".preflight-allow-large-pr" ]; then
-    echo "⚠️  Large PR override active (.preflight-allow-large-pr). Document the reason in your PR."
-  elif [ "$TOTAL_CHANGES" -gt "$MAX_LINES" ]; then
+  if [ "$TOTAL_CHANGES" -gt "$MAX_LINES" ]; then
     echo ""
     echo "⚠️  WARNING: PR is large (${TOTAL_CHANGES} lines changed, limit is ${MAX_LINES})"
-    echo "Consider splitting this into smaller PRs."
-    echo "To override: touch .preflight-allow-large-pr (do NOT commit)"
+    echo "Keep this pull request focused on one logical topic and make the review plan explicit."
     echo ""
   else
     echo "✅ PR size OK (${TOTAL_CHANGES}/${MAX_LINES} lines)"

--- a/tests/preflight-large-pr.test.mjs
+++ b/tests/preflight-large-pr.test.mjs
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const preflightPath = new URL("../scripts/preflight.sh", import.meta.url);
+const preflight = await readFile(preflightPath, "utf8");
+const gitignore = await readFile(
+  new URL("../.gitignore", import.meta.url),
+  "utf8",
+);
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}
+
+async function runPreflight(changedLines) {
+  const fixture = await mkdtemp(join(tmpdir(), "secpal-preflight-"));
+
+  try {
+    const binDir = join(fixture, "bin");
+    const scriptsDir = join(fixture, "scripts");
+    await mkdir(binDir);
+    await mkdir(scriptsDir);
+    await writeExecutable(join(scriptsDir, "preflight.sh"), preflight);
+    await writeFile(join(fixture, ".preflight-allow-large-pr"), "");
+
+    await writeExecutable(
+      join(binDir, "git"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == "rev-parse --show-toplevel" ]]; then
+  printf '%s\\n' "$TEST_ROOT"
+elif [[ "$*" == "symbolic-ref --short HEAD" ]]; then
+  printf '%s\\n' "test-branch"
+elif [[ "$*" == "symbolic-ref refs/remotes/origin/HEAD" ]]; then
+  printf '%s\\n' "refs/remotes/origin/main"
+elif [[ "\${1:-}" == "diff" && "\${2:-}" == "--shortstat" ]]; then
+  printf ' 1 file changed, %s insertions(+)\\n' "$TEST_CHANGED_LINES"
+elif [[ "\${1:-}" == "diff" && "\${2:-}" == "--stat" ]]; then
+  printf ' 1 file changed, %s insertions(+)\\n' "$TEST_CHANGED_LINES"
+fi
+`,
+    );
+    await writeExecutable(join(binDir, "npx"), "#!/usr/bin/env bash\nexit 0\n");
+    await writeExecutable(
+      join(binDir, "reuse"),
+      "#!/usr/bin/env bash\nexit 0\n",
+    );
+
+    const result = spawnSync("bash", ["scripts/preflight.sh"], {
+      cwd: fixture,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        TEST_CHANGED_LINES: String(changedLines),
+        TEST_ROOT: fixture,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    return `${result.stdout}${result.stderr}`;
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+}
+
+test("reports ordinary changes normally even with a stale local override file", async () => {
+  const output = await runPreflight(119);
+
+  assert.match(output, /PR size OK \(119\/600 lines\)/);
+  assert.doesNotMatch(output, /override/i);
+});
+
+test("reports oversized changes as advisory without an override", async () => {
+  const output = await runPreflight(601);
+
+  assert.match(output, /WARNING: PR is large \(601 lines changed, limit is 600\)/);
+  assert.doesNotMatch(output, /override/i);
+});
+
+test("does not retain the obsolete local override mechanism", () => {
+  assert.doesNotMatch(preflight, /preflight-allow-large-pr|override/i);
+  assert.doesNotMatch(gitignore, /preflight-allow-large-pr/);
+});

--- a/tests/preflight-large-pr.test.mjs
+++ b/tests/preflight-large-pr.test.mjs
@@ -14,6 +14,8 @@ const gitignore = await readFile(
   new URL("../.gitignore", import.meta.url),
   "utf8",
 );
+const removedLargePrOverridePattern =
+  /\.preflight-allow-large-pr|Large PR override/i;
 
 async function writeExecutable(path, contents) {
   await writeFile(path, contents);
@@ -77,17 +79,24 @@ test("reports ordinary changes normally even with a stale local override file", 
   const output = await runPreflight(119);
 
   assert.match(output, /PR size OK \(119\/600 lines\)/);
-  assert.doesNotMatch(output, /override/i);
+  assert.doesNotMatch(output, removedLargePrOverridePattern);
 });
 
 test("reports oversized changes as advisory without an override", async () => {
   const output = await runPreflight(601);
 
   assert.match(output, /WARNING: PR is large \(601 lines changed, limit is 600\)/);
-  assert.doesNotMatch(output, /override/i);
+  assert.doesNotMatch(output, removedLargePrOverridePattern);
 });
 
 test("does not retain the obsolete local override mechanism", () => {
-  assert.doesNotMatch(preflight, /preflight-allow-large-pr|override/i);
+  assert.doesNotMatch(preflight, removedLargePrOverridePattern);
   assert.doesNotMatch(gitignore, /preflight-allow-large-pr/);
+});
+
+test("does not confuse unrelated override wording with the removed mechanism", () => {
+  assert.doesNotMatch(
+    "An unrelated configuration override remains supported.",
+    removedLargePrOverridePattern,
+  );
 });


### PR DESCRIPTION
## Problem and evidence

The local preflight supported `.preflight-allow-large-pr` as a worktree-wide override. When that file was present, every branch reported the override before considering whether the change exceeded the 600-line threshold. Issue #241 records this on `remove-dev-site-host`, which changed only 119 lines.

The shared pull-request size workflow now treats 600 changed lines as an advisory review threshold rather than a blocking limit, so a separate local override is unnecessary and can obscure the normal size report.

## Change

- remove the local large-PR override branch from `scripts/preflight.sh`
- remove the obsolete override entry from `.gitignore`
- retain the 600-line advisory and ask oversized pull requests to document a focused review plan
- add executable regression coverage for ordinary and oversized changes, including a stale local override file
- document the fix in `CHANGELOG.md`

## Validation

- `npm run format:check`
- `npm test` — 80 tests passed
- `npm run lint`
- `npm run check` — 0 errors, warnings, or hints
- `npm run build`
- `bash -n scripts/preflight.sh`
- `reuse lint`
- `git diff --check`
- commit hooks, including Prettier, markdownlint, ShellCheck, REUSE, conflict checks, and whitespace checks

## Readiness

No in-scope dependency or unresolved local check prevents readiness. The pull request starts as a draft pending the required final review in the pull-request view.

The separate pre-existing mismatch between local `.preflight-exclude` handling and the shared size workflow is tracked in #272 and is not part of this change.

Closes #241
