### PR TITLE
Use branch changes for conditional preflight checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- based conditional Markdown and REUSE preflight checks on the branch diff
+  against the selected base, so clean pre-push indexes no longer skip checks
+  for committed changes and license metadata
 - removed the obsolete local large-PR override mechanism, keeping the 600-line
   threshold advisory in preflight to match the shared pull-request size check
 - updated transitive `brace-expansion` and `nanoid` dependencies to patched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - based conditional Markdown and REUSE preflight checks on the branch diff
   against the selected base, so clean pre-push indexes no longer skip checks
-  for committed changes and license metadata
+  for committed changes, license metadata, or non-ASCII Markdown paths, while
+  unavailable base refs now produce an actionable error
 - removed the obsolete local large-PR override mechanism, keeping the 600-line
   threshold advisory in preflight to match the shared pull-request size check
 - updated transitive `brace-expansion` and `nanoid` dependencies to patched

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -44,8 +44,26 @@ git fetch origin "$BASE" 2>/dev/null || true
 # Get branch changes against the selected base for conditional checks. The index
 # is normally clean during pre-push, so staged changes do not represent the
 # commits that are about to be pushed.
-BRANCH_DIFF="origin/$BASE...HEAD"
+BASE_REF="origin/$BASE"
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "Error: Base ref '$BASE_REF' is unavailable. Run 'git fetch origin $BASE' and retry." >&2
+  exit 1
+fi
+
+BRANCH_DIFF="$BASE_REF...HEAD"
 CHANGED_FILES=$(git diff --name-only "$BRANCH_DIFF")
+MARKDOWN_CHANGED=$(
+  git diff --name-only -z "$BRANCH_DIFF" |
+    {
+      found=""
+      while IFS= read -r -d '' path; do
+        if [[ "$path" == *.md ]]; then
+          found=1
+        fi
+      done
+      printf '%s' "$found"
+    }
+)
 
 is_license_related_path() {
   local path="$1"
@@ -71,7 +89,7 @@ if command -v npx >/dev/null 2>&1; then
   npx --no-install prettier --check --cache '**/*.{md,yml,yaml,json,ts,tsx,js,mjs,astro}' || FORMAT_EXIT=1
 
   # Only run markdownlint if .md files changed
-  if echo "$CHANGED_FILES" | grep -q '\.md$'; then
+  if [ -n "$MARKDOWN_CHANGED" ]; then
     npx --no-install markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore dist --ignore .astro --ignore .git || FORMAT_EXIT=1
   else
     echo "ℹ️  No markdown files changed, skipping markdownlint"
@@ -119,7 +137,7 @@ if command -v reuse >/dev/null 2>&1; then
       echo "ℹ️  No new files or license changes, skipping REUSE lint"
     fi
   else
-    reuse lint || FORMAT_EXIT=1
+    echo "ℹ️  No branch changes, skipping REUSE lint"
   fi
 fi
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -46,7 +46,6 @@ git fetch origin "$BASE" 2>/dev/null || true
 # commits that are about to be pushed.
 BRANCH_DIFF="origin/$BASE...HEAD"
 CHANGED_FILES=$(git diff --name-only "$BRANCH_DIFF")
-CHANGED_FILE_STATUS=$(git diff --name-status "$BRANCH_DIFF")
 
 is_license_related_path() {
   local path="$1"
@@ -88,18 +87,31 @@ if [ -d .github/workflows ]; then
   fi
 fi
 
-# Only run REUSE lint if new files were added or license-related files changed
+# Only run REUSE lint if files were added or renamed, or license-related files changed
 if command -v reuse >/dev/null 2>&1; then
   if [ -n "$CHANGED_FILES" ]; then
-    NEW_OR_LICENSE=""
-    while IFS=$'\t' read -r status old_path new_path; do
-      if [[ "$status" == A* || "$status" == C* ]] ||
-        is_license_related_path "$old_path" ||
-        { [ -n "${new_path:-}" ] && is_license_related_path "$new_path"; }; then
-        NEW_OR_LICENSE=1
-        break
-      fi
-    done <<<"$CHANGED_FILE_STATUS"
+    NEW_OR_LICENSE=$(
+      git diff --name-status -z "$BRANCH_DIFF" |
+        {
+          found=""
+          while IFS= read -r -d '' status && IFS= read -r -d '' old_path; do
+            new_path=""
+            if [[ "$status" == R* || "$status" == C* ]]; then
+              IFS= read -r -d '' new_path || {
+                echo "Invalid name-status output for $status" >&2
+                exit 1
+              }
+            fi
+
+            if [[ "$status" == A* || "$status" == C* || "$status" == R* ]] ||
+              is_license_related_path "$old_path" ||
+              { [ -n "$new_path" ] && is_license_related_path "$new_path"; }; then
+              found=1
+            fi
+          done
+          printf '%s' "$found"
+        }
+    )
 
     if [ -n "$NEW_OR_LICENSE" ]; then
       reuse lint || FORMAT_EXIT=1

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -38,11 +38,28 @@ BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/rem
 
 echo "Using base branch: $BASE"
 
-# Fetch base branch for PR size check (failure is handled later)
+# Fetch the selected base for branch comparisons (a missing ref fails below)
 git fetch origin "$BASE" 2>/dev/null || true
 
-# Get list of changed files for conditional checks
-CHANGED_FILES=$(git diff --name-only --cached 2>/dev/null || git diff --name-only HEAD 2>/dev/null || echo "")
+# Get branch changes against the selected base for conditional checks. The index
+# is normally clean during pre-push, so staged changes do not represent the
+# commits that are about to be pushed.
+BRANCH_DIFF="origin/$BASE...HEAD"
+CHANGED_FILES=$(git diff --name-only "$BRANCH_DIFF")
+CHANGED_FILE_STATUS=$(git diff --name-status "$BRANCH_DIFF")
+
+is_license_related_path() {
+  local path="$1"
+
+  case "/$path" in
+    */REUSE.toml | */LICENSE | */LICENSE.* | */LICENSE-* | */LICENSES/* | */COPYING | */COPYING.* | */COPYING-* | *.license)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 if [ "$HAS_NODE_PROJECT" -eq 1 ]; then
   echo "Installing dependencies..."
@@ -74,7 +91,16 @@ fi
 # Only run REUSE lint if new files were added or license-related files changed
 if command -v reuse >/dev/null 2>&1; then
   if [ -n "$CHANGED_FILES" ]; then
-    NEW_OR_LICENSE=$(git diff --name-status --cached 2>/dev/null | grep -E '^(A|M.*LICENSE)' || echo "")
+    NEW_OR_LICENSE=""
+    while IFS=$'\t' read -r status old_path new_path; do
+      if [[ "$status" == A* || "$status" == C* ]] ||
+        is_license_related_path "$old_path" ||
+        { [ -n "${new_path:-}" ] && is_license_related_path "$new_path"; }; then
+        NEW_OR_LICENSE=1
+        break
+      fi
+    done <<<"$CHANGED_FILE_STATUS"
+
     if [ -n "$NEW_OR_LICENSE" ]; then
       reuse lint || FORMAT_EXIT=1
     else

--- a/tests/preflight-changed-files.test.mjs
+++ b/tests/preflight-changed-files.test.mjs
@@ -25,22 +25,22 @@ async function writeExecutable(path, contents) {
   await chmod(path, 0o755);
 }
 
-function encodeNulDelimitedStatus(changedFileStatus) {
-  if (!changedFileStatus) {
+function encodeNulDelimitedFields(value) {
+  if (!value) {
     return "";
   }
 
-  return `${changedFileStatus
+  return `${value
     .split("\n")
     .flatMap((line) => line.split("\t"))
     .map((field) => field.replaceAll("\\", "\\\\"))
     .join("\\0")}\\0`;
 }
 
-async function runPreflight(
+async function executePreflight(
   changedFiles,
   changedFileStatus,
-  quotedChangedFileStatus = changedFileStatus
+  { baseRefAvailable = true, nulChangedFiles = changedFiles } = {}
 ) {
   const fixture = await mkdtemp(join(tmpdir(), "secpal-preflight-changes-"));
 
@@ -63,10 +63,16 @@ elif [[ "$*" == "symbolic-ref --short HEAD" ]]; then
   printf '%s\\n' "test-branch"
 elif [[ "$*" == "symbolic-ref refs/remotes/origin/HEAD" ]]; then
   printf '%s\\n' "refs/remotes/origin/main"
+elif [[ "$*" == "rev-parse --verify --quiet origin/main" ]]; then
+  [[ "$TEST_BASE_REF_AVAILABLE" == "1" ]]
 elif [[ "$*" == "diff --name-only origin/main...HEAD" ]]; then
+  if [[ "$TEST_BASE_REF_AVAILABLE" != "1" ]]; then
+    printf '%s\\n' "fatal: ambiguous argument 'origin/main...HEAD': unknown revision" >&2
+    exit 128
+  fi
   printf '%s\\n' "$TEST_CHANGED_FILES"
-elif [[ "$*" == "diff --name-status origin/main...HEAD" ]]; then
-  printf '%s\\n' "$TEST_QUOTED_CHANGED_FILE_STATUS"
+elif [[ "$*" == "diff --name-only -z origin/main...HEAD" ]]; then
+  printf '%b' "$TEST_NUL_CHANGED_FILES"
 elif [[ "$*" == "diff --name-status -z origin/main...HEAD" ]]; then
   printf '%b' "$TEST_NUL_CHANGED_FILE_STATUS"
 fi
@@ -91,20 +97,37 @@ printf 'reuse %s\\n' "$*" >> "$TEST_COMMAND_LOG"
       env: {
         ...process.env,
         PATH: `${binDir}:${process.env.PATH}`,
+        TEST_BASE_REF_AVAILABLE: baseRefAvailable ? "1" : "0",
         TEST_CHANGED_FILES: changedFiles,
         TEST_COMMAND_LOG: commandLog,
+        TEST_NUL_CHANGED_FILES: encodeNulDelimitedFields(nulChangedFiles),
         TEST_NUL_CHANGED_FILE_STATUS:
-          encodeNulDelimitedStatus(changedFileStatus),
-        TEST_QUOTED_CHANGED_FILE_STATUS: quotedChangedFileStatus,
+          encodeNulDelimitedFields(changedFileStatus),
         TEST_ROOT: fixture,
       },
     });
 
-    assert.equal(result.status, 0, result.stderr);
-    return await readFile(commandLog, "utf8");
+    const commands = await readFile(commandLog, "utf8").catch((error) => {
+      if (error.code === "ENOENT") {
+        return "";
+      }
+      throw error;
+    });
+    return { commands, result };
   } finally {
     await rm(fixture, { recursive: true, force: true });
   }
+}
+
+async function runPreflight(changedFiles, changedFileStatus, options) {
+  const execution = await executePreflight(
+    changedFiles,
+    changedFileStatus,
+    options
+  );
+
+  assert.equal(execution.result.status, 0, execution.result.stderr);
+  return execution.commands;
 }
 
 test("runs markdownlint for a Markdown file changed on the branch", async () => {
@@ -154,9 +177,33 @@ test("runs REUSE lint for a file renamed on the branch", async () => {
 test("runs REUSE lint for a non-ASCII license path", async () => {
   const commands = await runPreflight(
     '"docs/\\303\\274ber/LICENSE"',
-    "M\tdocs/über/LICENSE",
-    'M\t"docs/\\303\\274ber/LICENSE"'
+    "M\tdocs/über/LICENSE"
   );
 
   assert.match(commands, /^reuse lint$/m);
+});
+
+test("runs markdownlint for a non-ASCII Markdown path", async () => {
+  const commands = await runPreflight(
+    '"docs/\\303\\274ber.md"',
+    "M\tdocs/über.md",
+    { nulChangedFiles: "docs/über.md" }
+  );
+
+  assert.match(commands, /^npx .*markdownlint/m);
+});
+
+test("skips REUSE lint when the branch has no changes", async () => {
+  const commands = await runPreflight("", "");
+
+  assert.doesNotMatch(commands, /^reuse lint$/m);
+});
+
+test("reports an actionable error when the selected base ref is unavailable", async () => {
+  const { result } = await executePreflight("", "", {
+    baseRefAvailable: false,
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Base ref 'origin\/main' is unavailable/);
 });

--- a/tests/preflight-changed-files.test.mjs
+++ b/tests/preflight-changed-files.test.mjs
@@ -25,7 +25,23 @@ async function writeExecutable(path, contents) {
   await chmod(path, 0o755);
 }
 
-async function runPreflight(changedFiles, changedFileStatus) {
+function encodeNulDelimitedStatus(changedFileStatus) {
+  if (!changedFileStatus) {
+    return "";
+  }
+
+  return `${changedFileStatus
+    .split("\n")
+    .flatMap((line) => line.split("\t"))
+    .map((field) => field.replaceAll("\\", "\\\\"))
+    .join("\\0")}\\0`;
+}
+
+async function runPreflight(
+  changedFiles,
+  changedFileStatus,
+  quotedChangedFileStatus = changedFileStatus
+) {
   const fixture = await mkdtemp(join(tmpdir(), "secpal-preflight-changes-"));
 
   try {
@@ -50,7 +66,9 @@ elif [[ "$*" == "symbolic-ref refs/remotes/origin/HEAD" ]]; then
 elif [[ "$*" == "diff --name-only origin/main...HEAD" ]]; then
   printf '%s\\n' "$TEST_CHANGED_FILES"
 elif [[ "$*" == "diff --name-status origin/main...HEAD" ]]; then
-  printf '%s\\n' "$TEST_CHANGED_FILE_STATUS"
+  printf '%s\\n' "$TEST_QUOTED_CHANGED_FILE_STATUS"
+elif [[ "$*" == "diff --name-status -z origin/main...HEAD" ]]; then
+  printf '%b' "$TEST_NUL_CHANGED_FILE_STATUS"
 fi
 `
     );
@@ -74,8 +92,10 @@ printf 'reuse %s\\n' "$*" >> "$TEST_COMMAND_LOG"
         ...process.env,
         PATH: `${binDir}:${process.env.PATH}`,
         TEST_CHANGED_FILES: changedFiles,
-        TEST_CHANGED_FILE_STATUS: changedFileStatus,
         TEST_COMMAND_LOG: commandLog,
+        TEST_NUL_CHANGED_FILE_STATUS:
+          encodeNulDelimitedStatus(changedFileStatus),
+        TEST_QUOTED_CHANGED_FILE_STATUS: quotedChangedFileStatus,
         TEST_ROOT: fixture,
       },
     });
@@ -118,6 +138,25 @@ for (const [
 
 test("runs REUSE lint for a file added on the branch", async () => {
   const commands = await runPreflight("src/new-file.ts", "A\tsrc/new-file.ts");
+
+  assert.match(commands, /^reuse lint$/m);
+});
+
+test("runs REUSE lint for a file renamed on the branch", async () => {
+  const commands = await runPreflight(
+    ".node-version",
+    "R100\t.nvmrc\t.node-version"
+  );
+
+  assert.match(commands, /^reuse lint$/m);
+});
+
+test("runs REUSE lint for a non-ASCII license path", async () => {
+  const commands = await runPreflight(
+    '"docs/\\303\\274ber/LICENSE"',
+    "M\tdocs/über/LICENSE",
+    'M\t"docs/\\303\\274ber/LICENSE"'
+  );
 
   assert.match(commands, /^reuse lint$/m);
 });

--- a/tests/preflight-changed-files.test.mjs
+++ b/tests/preflight-changed-files.test.mjs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import assert from "node:assert/strict";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const preflight = await readFile(
+  new URL("../scripts/preflight.sh", import.meta.url),
+  "utf8"
+);
+
+async function writeExecutable(path, contents) {
+  await writeFile(path, contents);
+  await chmod(path, 0o755);
+}
+
+async function runPreflight(changedFiles, changedFileStatus) {
+  const fixture = await mkdtemp(join(tmpdir(), "secpal-preflight-changes-"));
+
+  try {
+    const binDir = join(fixture, "bin");
+    const scriptsDir = join(fixture, "scripts");
+    const commandLog = join(fixture, "commands.log");
+    await mkdir(binDir);
+    await mkdir(scriptsDir);
+    await writeExecutable(join(scriptsDir, "preflight.sh"), preflight);
+
+    await writeExecutable(
+      join(binDir, "git"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == "rev-parse --show-toplevel" ]]; then
+  printf '%s\\n' "$TEST_ROOT"
+elif [[ "$*" == "symbolic-ref --short HEAD" ]]; then
+  printf '%s\\n' "test-branch"
+elif [[ "$*" == "symbolic-ref refs/remotes/origin/HEAD" ]]; then
+  printf '%s\\n' "refs/remotes/origin/main"
+elif [[ "$*" == "diff --name-only origin/main...HEAD" ]]; then
+  printf '%s\\n' "$TEST_CHANGED_FILES"
+elif [[ "$*" == "diff --name-status origin/main...HEAD" ]]; then
+  printf '%s\\n' "$TEST_CHANGED_FILE_STATUS"
+fi
+`
+    );
+    await writeExecutable(
+      join(binDir, "npx"),
+      `#!/usr/bin/env bash
+printf 'npx %s\\n' "$*" >> "$TEST_COMMAND_LOG"
+`
+    );
+    await writeExecutable(
+      join(binDir, "reuse"),
+      `#!/usr/bin/env bash
+printf 'reuse %s\\n' "$*" >> "$TEST_COMMAND_LOG"
+`
+    );
+
+    const result = spawnSync("bash", ["scripts/preflight.sh"], {
+      cwd: fixture,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        TEST_CHANGED_FILES: changedFiles,
+        TEST_CHANGED_FILE_STATUS: changedFileStatus,
+        TEST_COMMAND_LOG: commandLog,
+        TEST_ROOT: fixture,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    return await readFile(commandLog, "utf8");
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+}
+
+test("runs markdownlint for a Markdown file changed on the branch", async () => {
+  const commands = await runPreflight(
+    "docs/existing-page.md",
+    "M\tdocs/existing-page.md"
+  );
+
+  assert.match(commands, /^npx .*markdownlint/m);
+  assert.doesNotMatch(commands, /^reuse lint$/m);
+});
+
+const licenseChangeCases = [
+  ["REUSE metadata", "REUSE.toml", "M\tREUSE.toml"],
+  ["license sidecars", "src/example.ts.license", "M\tsrc/example.ts.license"],
+  ["deleted license texts", "LICENSES/MIT.txt", "D\tLICENSES/MIT.txt"],
+  ["renamed license texts", "NOTICE", "R100\tLICENSE\tNOTICE"],
+];
+
+for (const [
+  description,
+  changedFiles,
+  changedFileStatus,
+] of licenseChangeCases) {
+  test(`runs REUSE lint for ${description} changed on the branch`, async () => {
+    const commands = await runPreflight(changedFiles, changedFileStatus);
+
+    assert.match(commands, /^reuse lint$/m);
+  });
+}
+
+test("runs REUSE lint for a file added on the branch", async () => {
+  const commands = await runPreflight("src/new-file.ts", "A\tsrc/new-file.ts");
+
+  assert.match(commands, /^reuse lint$/m);
+});


### PR DESCRIPTION
## Problem and evidence

The preflight script derived conditional checks from `git diff --name-only --cached`. A clean index is the normal state during a pre-push hook, and that command succeeds with empty output. Because the fallback depended on command failure rather than empty output, committed branch changes could be absent from `CHANGED_FILES`, allowing Markdown linting to be skipped for branches that changed Markdown files.

## Change

- derive changed paths and statuses from `origin/$BASE...HEAD`, matching the selected branch base instead of the index
- use the same branch status data for conditional REUSE checks
- recognize added files, REUSE metadata, license sidecars, license texts, deletions, copies, and both paths of a rename
- add regression coverage for clean-index Markdown changes and the supported REUSE-triggering cases
- document the fix in the changelog

## Validation

- `npm test` — 87 tests passed
- `npm run lint`
- `npm run check` — 69 files, no errors, warnings, or hints
- `npm run build` — 16 static pages built
- Prettier
- Bash syntax validation
- ShellCheck
- REUSE compliance
- `git diff --check`
- commit hooks, including Markdownlint and conflict-marker checks

## Draft readiness

No known in-scope dependency or unresolved check prevents readiness. The final self-review in the pull request view found no issues; the pull request remains draft as requested.

Closes #274
